### PR TITLE
shell/plugins: add FLUX_SHELL_PLUGIN_NAME to cray_pals plugin

### DIFF
--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "libpals"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -833,7 +834,7 @@ static int libpals_task_init (flux_plugin_t *p,
 
 int flux_plugin_init (flux_plugin_t *p)
 {
-    if (flux_plugin_set_name (p, "libpals") < 0
+    if (flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME) < 0
         || flux_plugin_add_handler (p, "shell.init", libpals_init, NULL) < 0
         || flux_plugin_add_handler (p, "task.init", libpals_task_init, NULL) < 0) {
         return -1;


### PR DESCRIPTION
Problem: Future versions of flux-core will require FLUX_SHELL_PLUGIN_NAME
to be defined when including `flux/shell.h` or compilation will fail.

Set FLUX_SHELL_PLUGIN_NAME to "libpals" for the cray_pals shell plugin
and use this definition to set the plugin name.