### PR TITLE
cray-libpals: allow shell plugin to detect missing port-distributor jobtap plugin

### DIFF
--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -70,4 +70,12 @@ test_expect_success 'shell: pals shell plugin creates apinfo file' '
 	&& test ! -z \$PALS_APINFO && test -f \$PALS_APINFO"
 '
 
+test_expect_success 'shell: pals shell plugin ignores missing jobtap plugin' '
+	flux jobtap remove cray_pals_port_distributor.so &&
+	flux mini run -o verbose -o userrc=$(pwd)/$USERRC_NAME \
+		-N2 -n2 hostname > no-jobtap.log 2>&1 &&
+	test_debug "cat no-jobtap.log" &&
+	grep "jobtap plugin not loaded" no-jobtap.log
+'
+
 test_done


### PR DESCRIPTION
This PR adds better synchronization between the cray-pals shell plugin and the port-distributor jobtap plugin as discussed in #16. The jobtap plugin now emits the `cray_port_distribution` event under a `prolog` action, allowing the shell plugin to definitively detect a missing jobtap plugin if this event does not appear before the `start` event.

This means the shell plugin can be loaded without the jobtap plugin and jobs will still run successfully (e.g. if running the flux-sched testsuite)

One minor issue: This change doesn't prevent the shell plugin from setting most of the libpals environment variables (besides `PMI_CONTROL_PORT`) and writing out the apinfo file, since these actions happen before the plugin fetches the `cray_port_distribution` event. I figure this isn't a critical problem for now, since running with this package installed but without the jobtap plugin loaded will likely be an uncommon case.
