### PR TITLE
build: remove pylintrc dist requirement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,7 @@ EXTRA_DIST = \
 	config/tap-driver.py \
 	NOTICE.LLNS \
 	README.md \
-	NEWS.md \
-	scripts/.pylintrc
+	NEWS.md
 
 ACLOCAL_AMFLAGS = -I config
 


### PR DESCRIPTION
Problem: running 'make dist' requires a pylintrc file which
cannot be built and does not exist.
Solution: remove the file from the requirements.