### PR TITLE
Pals incorrect task counts

### DIFF
--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -79,6 +79,13 @@ test_expect_success 'shell: pals shell plugin creates apinfo file' '
 	&& test ! -z \$PALS_APINFO && test -f \$PALS_APINFO"
 '
 
+test_expect_success 'shell: pals shell plugin handles resource oversubscription' '
+	flux mini run -o userrc=$(pwd)/$USERRC_NAME -N1 -n2 -oper-resource.type=core -oper-resource.count=2 \
+	env | grep PALS_RANKID=3 &&
+	flux mini run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 -oper-resource.type=node -oper-resource.count=6 \
+	env | grep PALS_RANKID=5
+'
+
 test_expect_success 'shell: pals shell plugin ignores missing jobtap plugin' '
 	flux jobtap remove cray_pals_port_distributor.so &&
 	flux mini run -o verbose -o userrc=$(pwd)/$USERRC_NAME \


### PR DESCRIPTION
Problem: the libpals shell plugin does not account for task counts
not specified in the usual task-count jobspec position. For instance,
it does not count tasks specified with the per-resource.* shell options.

Solution: properly count tasks by checking the counts given by the shell
rather than the counts given in the jobspec.

Fixes https://github.com/flux-framework/flux-coral2/issues/27.