### PR TITLE
build: change shell plugin install directory

### DIFF
--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -7,7 +7,7 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 shell_plugindir = \
-    $(fluxlibdir)/shell/plugins/
+    $(fluxlibdir)/shell/plugins/coral2/
 
 shell_plugin_LTLIBRARIES = cray_pals.la
 


### PR DESCRIPTION
Problem: flux-coral2 is being added to mainline TOSS. The cray-pals plugin is built into the main shell pluginpath, so it is loaded by default. This introduces some performance overhead.

Solution: move the shell plugin install directory into a subdirectory of the shell pluginpath so it is not
loaded by default.