### PR TITLE
dws: change workflow names

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -93,7 +93,7 @@ def create_cb(fh, t, msg, api_instance):
         raise TypeError(
             f"Malformed dw_directives, not list or string: {dw_directives!r}"
         )
-    workflow_name = f"dws-workflow-test-{jobid}"
+    workflow_name = f"fluxjob-{jobid}"
     spec = {
         "desiredState": "Proposal",
         "dwDirectives": dw_directives,


### PR DESCRIPTION
Problem: dws-workflow-test-JOBID names
are long and it isn't clear that the jobid is
in fact a flux job ID.

Rename workflows created by flux for clarity.