### PR TITLE
dws: add jobid to RPC error message

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -62,9 +62,13 @@ def message_callback_wrapper(func):
         try:
             func(fh, t, msg, k8s_api)
         except Exception as exc:
+            try:
+                jobid = msg.payload["jobid"]
+            except Exception:
+                jobid = None
             fh.log(syslog.LOG_ERR, f"{os.path.basename(__file__)}: {exc}")
             fh.respond(msg, {"success": False, "errstr": str(exc)})
-            LOGGER.exception("Error in responding to RPC: ")
+            LOGGER.exception(f"Error in responding to RPC for {jobid}:")
 
     return wrapper
 


### PR DESCRIPTION
Problem: some error messages are logged which do not include the jobid, making it difficult or impossible to figure out which job is associated with the error.