### PR TITLE
Dws jobtap epilog

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,7 +46,7 @@ dist_check_SCRIPTS = \
 	rc/rc1-job \
 	rc/rc3-job \
 	python/pycotap \
-	dws-dependencies/dws.py \
+	dws-dependencies/coral2_dws.py \
 	$(TESTSCRIPTS)
 
 check_PROGRAMS = \

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -7,28 +7,32 @@ from flux.constants import FLUX_MSGTYPE_REQUEST
 from flux.future import Future
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--fail', action='store_true')
+parser.add_argument('--create-fail', action='store_true')
 parser.add_argument('--setup-fail', action='store_true')
+parser.add_argument('--post-run-fail', action='store_true')
 args = parser.parse_args()
 
 def create_cb(fh, t, msg, arg):
-    payload = {"success": not args.fail, "resources": msg.payload["resources"]}
-    if args.fail:
+    payload = {"success": not args.create_fail, "resources": msg.payload["resources"]}
+    if args.create_fail:
         payload['errstr'] = "Failed for test purposes"
     fh.respond(msg, payload)
     print(f"Responded to create request with {payload}")
-    if args.fail:
+    if args.create_fail:
         fh.reactor_stop()
 
 def setup_cb(fh, t, msg, arg):
-    payload = {"success": not args.fail, "variables": {}}
-    if args.fail:
+    payload = {"success": not args.setup_fail, "variables": {}}
+    if args.setup_fail:
+        payload['errstr'] = "Failed for test purposes"
+    fh.respond(msg, payload)
+
+def post_run_cb(fh, t, msg, arg):
+    payload = {"success": not args.post_run_fail}
+    if args.post_run_fail:
         payload['errstr'] = "Failed for test purposes"
     fh.respond(msg, payload)
     fh.reactor_stop()
-
-def post_run_cb(fh, t, msg, arg):
-    pass
 
 fh = flux.Flux()
 service_reg_fut = Future(fh.service_register("dws"))
@@ -43,9 +47,6 @@ print("DWS service registered")
 
 fh.reactor_run()
 
-create_watcher.stop()
-create_watcher.destroy()
-setup_watcher.stop()
-setup_watcher.destroy()
-post_run_watcher.stop()
-post_run_watcher.destroy()
+for watcher in (create_watcher, setup_watcher, post_run_watcher):
+    watcher.stop()
+    watcher.destroy()

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test job dependencies'
+test_description='Test dws-jobtap plugin with fake coral2_dws.py'
 
 . $(dirname $0)/sharness.sh
 
@@ -9,13 +9,23 @@ test_under_flux 2 job
 flux setattr log-stderr-level 1
 
 PLUGINPATH=${FLUX_BUILD_DIR}/src/job-manager/plugins/.libs
-DWS_SCRIPT=${SHARNESS_TEST_SRCDIR}/dws-dependencies/dws.py
+DWS_SCRIPT=${SHARNESS_TEST_SRCDIR}/dws-dependencies/coral2_dws.py
 DEPENDENCY_NAME="dws-create"
+PROLOG_NAME="dws-setup"
+EPILOG_NAME="dws-epilog"
 
 test_expect_success 'job-manager: load dws-jobtap plugin' '
 	flux jobtap load ${PLUGINPATH}/dws-jobtap.so
 '
-test_expect_success 'job-manager: dependency plugin works when creation succeeds' '
+
+test_expect_success 'job-manager: dws jobtap plugin works when coral2_dws is absent' '
+	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -vt 1 ${jobid} exception
+'
+
+test_expect_success 'job-manager: dws jobtap plugin works when RPCs succeed' '
 	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT}) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
@@ -23,16 +33,48 @@ test_expect_success 'job-manager: dependency plugin works when creation succeeds
 		${jobid} dependency-add &&
 	flux job wait-event -t 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-remove &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
 	flux job wait-event -vt 15 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
-test_expect_success 'job-manager: dependency plugin works when creation fails' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --fail) &&
+test_expect_success 'job-manager: dws jobtap plugin works when creation RPC fails' '
+	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --create-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
+	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 ${create_jobid} clean
+'
+
+test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' '
+	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --setup-fail) &&
+	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
+	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 ${create_jobid} clean
+'
+
+test_expect_success 'job-manager: dws jobtap plugin works when post_run RPC fails' '
+	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --post-run-fail) &&
+	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
+	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} -m status=1 \
+		${jobid} epilog-finish &&
 	flux job wait-event -vt 1 ${jobid} exception &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '


### PR DESCRIPTION
Flux jobs with rabbit file systems should be held in jobtap epilog while data movement is completed. Add an epilog to the dws-jobtap plugin and associated tests.