### PR TITLE
test: replace 'flux mini' usage

### DIFF
--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -19,16 +19,16 @@ test_expect_success 'job-manager: load dws-jobtap plugin' '
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when coral2_dws is absent' '
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -vt 1 ${jobid} exception
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when RPCs succeed' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT}) &&
+	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT}) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -t 5 -m description=${DEPENDENCY_NAME} \
@@ -46,9 +46,9 @@ test_expect_success 'job-manager: dws jobtap plugin works when RPCs succeed' '
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when creation RPC fails' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --create-fail) &&
+	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --create-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -vt 1 ${jobid} exception &&
@@ -56,9 +56,9 @@ test_expect_success 'job-manager: dws jobtap plugin works when creation RPC fail
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --setup-fail) &&
+	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --setup-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
@@ -68,9 +68,9 @@ test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' 
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when post_run RPC fails' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --post-run-fail) &&
+	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --post-run-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} -m status=1 \

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -31,7 +31,7 @@ test_expect_success 'job-manager: load dws-jobtap plugin' '
 
 test_expect_success 'exec dws service-providing script' '
 	R=$(flux R encode -r 0) &&
-	jobid=$(flux mini submit \
+	jobid=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws.out --error=dws.err \
 	        flux python ${DWS_MODULE_PATH}) &&
@@ -47,14 +47,14 @@ test_expect_success 'wait for service to register and send test RPC' '
 '
 
 test_expect_success 'job submission without DW string works' '
-	jobid=$(flux mini submit -n1 /bin/true) &&
+	jobid=$(flux submit -n1 /bin/true) &&
 	flux job wait-event -vt 25 ${jobid} finish &&
 	test_must_fail flux job wait-event -vt 5 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add
 '
 
 test_expect_success 'job submission with valid DW string works' '
-	jobid=$(flux mini submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1" \
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1" \
 		-N1 -n1 hostname) &&
 	flux job wait-event -vt 25 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&
@@ -66,7 +66,7 @@ test_expect_success 'job submission with valid DW string works' '
 '
 
 test_expect_success 'job-manager: dependency plugin works when validation fails' '
-	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -vt 10 ${jobid} exception

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -30,7 +30,7 @@ test_expect_success 'job-manager: load alloc-bypass plugin' '
 test_expect_success 'exec nnf watching script' '
 	echo $PYTHONPATH >&2 &&
 	R=$(flux R encode -r 0) &&
-	jobid=$(flux mini submit \
+	jobid=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node flux python ${DWS_MODULE_PATH}) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start


### PR DESCRIPTION
Problem: 'flux mini CMD' is deprecated in favor of 'flux CMD'.

Replace usage in the test suite.