### PR TITLE
Dws prolog exceptions

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -138,7 +138,7 @@ static int depend_cb (flux_plugin_t *p,
     json_t *resources;
     json_t *jobspec;
     int userid;
-    int *prolog_active;
+    int *prolog_active = NULL;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -165,6 +165,7 @@ static int depend_cb (flux_plugin_t *p,
                                      "dws_prolog_active",
                                      prolog_active,
                                      free) < 0){
+            free (prolog_active);
             flux_log_error (h, "dws-jobtap: error initializing exception-monitoring");
             return -1;
         }

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -453,7 +453,7 @@ static int exception_cb (flux_plugin_t *p,
         return -1;
     }
     if ((prolog_active = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "dws_prolog_active")) && (*prolog_active)){
-        if (flux_jobtap_prolog_finish (p, id, SETUP_PROLOG_NAME, -1) < 0) {
+        if (flux_jobtap_prolog_finish (p, id, SETUP_PROLOG_NAME, 1) < 0) {
             flux_log_error (h,
                             "Failed to finish prolog %s for job %" PRIu64 " after exception",
                             SETUP_PROLOG_NAME,
@@ -463,7 +463,7 @@ static int exception_cb (flux_plugin_t *p,
         *prolog_active = 0;
     }
     if ((epilog_active = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "dws_epilog_active")) && (*epilog_active)){
-        if (flux_jobtap_epilog_finish (p, id, DWS_EPILOG_NAME, -1) < 0) {
+        if (flux_jobtap_epilog_finish (p, id, DWS_EPILOG_NAME, 1) < 0) {
             flux_log_error (h,
                             "Failed to finish epilog %s for job %" PRIu64 " after exception",
                             DWS_EPILOG_NAME,

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -71,17 +71,14 @@ static int dws_prolog_finish (flux_t *h, flux_plugin_t *p, flux_jobid_t id, int 
     return 0;
 }
 
-static int dws_epilog_finish (flux_t *h, flux_plugin_t *p, flux_jobid_t id, int success, const char *errstr, int *epilog_active){
-    if (*epilog_active){
-        if (flux_jobtap_epilog_finish (p, id, DWS_EPILOG_NAME, !success) < 0) {
-            flux_log_error (h,
-                            "Failed to finish epilog %s for job %" PRIu64,
-                            DWS_EPILOG_NAME,
-                            id);
-            return -1;
-        }
+static int dws_epilog_finish (flux_t *h, flux_plugin_t *p, flux_jobid_t id, int success, const char *errstr){
+    if (flux_jobtap_epilog_finish (p, id, DWS_EPILOG_NAME, !success) < 0) {
+        flux_log_error (h,
+                        "Failed to finish epilog %s for job %" PRIu64,
+                        DWS_EPILOG_NAME,
+                        id);
+        return -1;
     }
-    *epilog_active = 0;
     if (!success) {
         flux_log_error (h, "Failed to clean up DWS workflow object for job %" PRIu64, id);
         return raise_job_exception (h, id, DWS_EPILOG_NAME, errstr);
@@ -141,7 +138,7 @@ static int depend_cb (flux_plugin_t *p,
     json_t *resources;
     json_t *jobspec;
     int userid;
-    int *prolog_active, *epilog_active;
+    int *prolog_active;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -163,21 +160,15 @@ static int depend_cb (flux_plugin_t *p,
         // subscribe to exception events
         if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0
             || !(prolog_active = malloc(sizeof (int)))
-            || !(epilog_active = malloc(sizeof (int)))
             || flux_jobtap_job_aux_set (p,
                                      FLUX_JOBTAP_CURRENT_JOB,
                                      "dws_prolog_active",
                                      prolog_active,
-                                     free) < 0
-            || flux_jobtap_job_aux_set (p,
-                                     FLUX_JOBTAP_CURRENT_JOB,
-                                     "dws_epilog_active",
-                                     epilog_active,
                                      free) < 0){
             flux_log_error (h, "dws-jobtap: error initializing exception-monitoring");
             return -1;
         }
-        *prolog_active = *epilog_active = 0;
+        *prolog_active = 0;
         flux_future_t *create_fut = flux_rpc_pack (
             h, "dws.create", FLUX_NODEID_ANY, 0, "{s:O, s:I, s:O, s:i}", "dw_directives", dw, "jobid", id, "resources", resources, "userid", userid
         );
@@ -347,10 +338,9 @@ static void post_run_rpc_callback (flux_future_t *f, void *arg)
     flux_t *h = flux_future_get_flux(f);
     struct create_arg_t *args;
     int success = false;
-    int *epilog_active = NULL;
     const char *errstr = NULL;
 
-    if (!(args = flux_future_aux_get (f, "flux::create_args")) || !(epilog_active = flux_future_aux_get (f, "flux::epilog_active"))) {
+    if (!(args = flux_future_aux_get (f, "flux::create_args"))) {
         flux_log_error (h, "create args missing in future aux");
         goto done;
     }
@@ -360,14 +350,14 @@ static void post_run_rpc_callback (flux_future_t *f, void *arg)
                              "success", &success,
                              "errstr", &errstr) < 0)
     {
-        dws_epilog_finish (h, args->p, args->id, 0, "Failed to send dws.post_run RPC", epilog_active);
+        dws_epilog_finish (h, args->p, args->id, 0, "Failed to send dws.post_run RPC");
         goto done;
     }
     if (success) {
-        dws_epilog_finish (h, args->p, args->id, 1, "success!", epilog_active);
+        dws_epilog_finish (h, args->p, args->id, 1, "success!");
     }
     else {
-        dws_epilog_finish (h, args->p, args->id, 0, errstr, epilog_active);
+        dws_epilog_finish (h, args->p, args->id, 0, errstr);
     }
 
 done:
@@ -384,7 +374,6 @@ static int cleanup_cb (flux_plugin_t *p,
     flux_future_t *post_run_fut;
     flux_t *h = flux_jobtap_get_flux (p);
     int dws_run_started = 0;
-    int *epilog_active;
     struct create_arg_t *create_args;
 
     if (flux_plugin_arg_unpack (args,
@@ -409,12 +398,10 @@ static int cleanup_cb (flux_plugin_t *p,
         if (flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::dws_run_started")) {
             dws_run_started = 1;
         }
-        if (flux_jobtap_epilog_start (p, DWS_EPILOG_NAME) < 0
-            || !(epilog_active = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "dws_epilog_active"))) {
+        if (flux_jobtap_epilog_start (p, DWS_EPILOG_NAME) < 0) {
             flux_log_error (h, "Failed to start jobtap epilog");
             return -1;
         }
-        *epilog_active = 1;
         if (!(post_run_fut = flux_rpc_pack (
             h,
             "dws.post_run",
@@ -424,11 +411,10 @@ static int cleanup_cb (flux_plugin_t *p,
             "jobid", id,
             "run_started", dws_run_started))
             || flux_future_aux_set (post_run_fut, "flux::create_args", create_args, free) < 0
-            || flux_future_aux_set (post_run_fut, "flux::epilog_active", epilog_active, NULL)
             || flux_future_then (post_run_fut, -1., post_run_rpc_callback, NULL) < 0) {
 
             flux_future_destroy (post_run_fut);
-            dws_epilog_finish (h, p, id, 0, "Failed to send dws.post_run RPC", epilog_active);
+            dws_epilog_finish (h, p, id, 0, "Failed to send dws.post_run RPC");
             flux_log_error (h, "Failed to send dws.post_run RPC");
             return -1;
         }
@@ -443,7 +429,7 @@ static int exception_cb (flux_plugin_t *p,
 {
     flux_jobid_t id;
     flux_t *h = flux_jobtap_get_flux (p);
-    int *prolog_active, *epilog_active;
+    int *prolog_active;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -457,16 +443,6 @@ static int exception_cb (flux_plugin_t *p,
             flux_log_error (h,
                             "Failed to finish prolog %s for job %" PRIu64 " after exception",
                             SETUP_PROLOG_NAME,
-                            id);
-            return -1;
-        }
-        *prolog_active = 0;
-    }
-    if ((epilog_active = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "dws_epilog_active")) && (*epilog_active)){
-        if (flux_jobtap_epilog_finish (p, id, DWS_EPILOG_NAME, 1) < 0) {
-            flux_log_error (h,
-                            "Failed to finish epilog %s for job %" PRIu64 " after exception",
-                            DWS_EPILOG_NAME,
                             id);
             return -1;
         }

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -9,7 +9,9 @@ from flux.future import Future
 parser = argparse.ArgumentParser()
 parser.add_argument('--create-fail', action='store_true')
 parser.add_argument('--setup-fail', action='store_true')
+parser.add_argument('--setup-hang', action='store_true')
 parser.add_argument('--post-run-fail', action='store_true')
+
 args = parser.parse_args()
 
 def create_cb(fh, t, msg, arg):
@@ -22,6 +24,8 @@ def create_cb(fh, t, msg, arg):
         fh.reactor_stop()
 
 def setup_cb(fh, t, msg, arg):
+    if args.setup_hang:
+        return
     payload = {"success": not args.setup_fail, "variables": {}}
     if args.setup_fail:
         payload['errstr'] = "Failed for test purposes"

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -79,4 +79,21 @@ test_expect_success 'job-manager: dws jobtap plugin works when post_run RPC fail
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
+test_expect_success 'job-manager: dws jobtap plugin works when job hits exception during prolog' '
+	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --setup-hang) &&
+	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
+	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job cancel $jobid
+	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
+	flux job wait-event -vt 5 ${create_jobid} clean
+'
+
 test_done


### PR DESCRIPTION
dws-jobtap.c adds jobtap prologs and epilogs to hold jobs in a state while data is moved to rabbits (the prolog) and from them (the epilog). If a severity-0 exception occurs during the prolog, the prolog should be removed immediately rather than waiting for the data movement to complete. However, there are no tests for that functionality. Also, epilogs are currently removed from jobs when exceptions occur, but there is no reason for that to be done, since the epilog runs once the job has already finished.