### PR TITLE
Split DW directives across lines

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -101,7 +101,9 @@ def create_cb(fh, t, msg, api_instance):
     jobid = msg.payload["jobid"]
     userid = msg.payload["userid"]
     if isinstance(dw_directives, str):
-        dw_directives = dw_directives.splitlines()
+        # assume different directives are on different lines and remove
+        # any blank lines
+        dw_directives = [dw for dw in dw_directives.splitlines() if dw]
     if not isinstance(dw_directives, list):
         raise TypeError(
             f"Malformed dw_directives, not list or string: {dw_directives!r}"

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -101,7 +101,7 @@ def create_cb(fh, t, msg, api_instance):
     jobid = msg.payload["jobid"]
     userid = msg.payload["userid"]
     if isinstance(dw_directives, str):
-        dw_directives = [dw_directives]
+        dw_directives = dw_directives.splitlines()
     if not isinstance(dw_directives, list):
         raise TypeError(
             f"Malformed dw_directives, not list or string: {dw_directives!r}"

--- a/t/data/workflow-obj/two_directives.json
+++ b/t/data/workflow-obj/two_directives.json
@@ -1,0 +1,2 @@
+["#DW jobdw capacity=10GiB type=xfs name=project1",
+ "#DW jobdw capacity=10GiB type=lustre name=project2"]

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -77,7 +77,9 @@ test_expect_success 'job submission with valid DW string works' '
 '
 
 test_expect_success 'job submission with multiple valid DW strings on different lines works' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1
+	jobid=$(flux submit --setattr=system.dw="
+											 #DW jobdw capacity=10KiB type=xfs name=project1
+
 											 #DW jobdw capacity=20KiB type=gfs2 name=project2" \
 		    -N1 -n1 hostname) &&
 	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \


### PR DESCRIPTION
The first two commits are minor tweaks to improve error messages.

Requests for rabbit storage are strings that look like `#DW jobdw capacity=10GiB type=xfs name=project1`. The strings go either as a string or a list of strings into jobspec `attributes.system.dw`. Users might therefore do something like `flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1" -n1 sleep 15`. If they want multiple directives (which will be common) they currently need to do something like `flux submit --setattr=^system.dw="xfs_copy_in.json"` where `xfs_copy_in.json` is a JSON file containing a list of DW directives. 

By splitting DW directives across lines, we can allow users to write things like `flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1 \n #DW jobdw capacity=10KiB type=xfs name=project1" -n1 sleep 15`, thereby stuffing two directives into the command line. Doesn't look like a huge improvement, but it makes the following legal in a batch script, which is more important:

```
#!/bin/bash

#flux: -N1
#flux: --setattr=system.dw="""
#flux: #DW jobdw capacity=10GiB type=xfs name=project1
#flux: #DW copy_in source=/p/lslide/corbett8/ destination=$DW_JOB_project1/
#flux: """
```

