### PR TITLE
Fix workflow error handling

### DIFF
--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -75,7 +75,7 @@ def apply_breakdowns(k8s_api, workflow, resources):
 
 def _fetch_breakdowns(k8s_api, workflow):
     """Fetch all of the directive breakdowns associated with a workflow."""
-    if not workflow["status"]["directiveBreakdowns"]:
+    if not workflow["status"].get("directiveBreakdowns"):
         raise ValueError(f"workflow {workflow} has no directive breakdowns")
     for breakdown in workflow["status"]["directiveBreakdowns"]:
         yield k8s_api.get_namespaced_custom_object(


### PR DESCRIPTION
Workflows that are stuck in "State: Error" should be killed off after a configurable number of seconds. But the logic for doing so is broken. Fix the logic and add a test.