### PR TITLE
load port distributor in all Flux instances, and support -o pmi=cray-pals

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,3 +44,7 @@ check-prep: all
 	cd src && $(MAKE) check
 	cd doc && $(MAKE) check
 	cd t && $(MAKE) check-prep
+
+
+dist_fluxrc1_SCRIPTS = \
+	etc/01-coral2-rc

--- a/configure.ac
+++ b/configure.ac
@@ -113,12 +113,6 @@ AC_SUBST(fluxrc1dir)
 AS_VAR_SET(fluxrc3dir, $sysconfdir/flux/rc3.d)
 AC_SUBST(fluxrc3dir)
 
-AS_VAR_SET(fluxrc1dir, $sysconfdir/flux/rc1.d)
-AC_SUBST(fluxrc1dir)
-
-AS_VAR_SET(fluxrc3dir, $sysconfdir/flux/rc3.d)
-AC_SUBST(fluxrc3dir)
-
 AS_VAR_SET(fluxk8spydir, $pyexecdir/flux_k8s)
 AC_SUBST(fluxk8spydir)
 

--- a/etc/01-coral2-rc
+++ b/etc/01-coral2-rc
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Load jobtap plugin, unless it's already loaded (e.g. by config)
+jobtap_load() {
+    if flux jobtap query $1 >/dev/null 2>&1; then
+        echo $1 is already loaded 2>&1
+    else
+        flux jobtap load $1
+    fi
+}
+
+if test $(flux getattr rank) -eq 0; then
+    jobtap_load cray_pals_port_distributor.so
+fi

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -7,10 +7,13 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 shell_plugindir = \
-    $(fluxlibdir)/shell/plugins/coral2/
+    $(fluxlibdir)/shell/plugins
+shell_plugin_subdir = \
+    $(shell_plugindir)/coral2
 
 shell_plugin_LTLIBRARIES = \
-	cray_pals.la \
+	cray_pals.la
+shell_plugin_sub_LTLIBRARIES = \
 	dws_environment.la
 
 cray_pals_la_SOURCES = cray_pals.c \

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
-#define FLUX_SHELL_PLUGIN_NAME "libpals"
+#define FLUX_SHELL_PLUGIN_NAME "pmi-cray-pals"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -9,6 +9,9 @@
 \************************************************************/
 #define FLUX_SHELL_PLUGIN_NAME "pmi-cray-pals"
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <argz.h>
 
 #include <jansson.h>
 
@@ -734,12 +735,49 @@ static int libpals_task_init (flux_plugin_t *p,
     return 0;
 }
 
+static bool member_of_csv (const char *list, const char *name)
+{
+    char *argz = NULL;
+    size_t argz_len;
+
+    if (argz_create_sep (list, ',', &argz, &argz_len) == 0) {
+        const char *entry = NULL;
+
+        while ((entry = argz_next (argz, argz_len, entry))) {
+            if (!strcmp (entry, name)) {
+                free (argz);
+                return true;
+            }
+        }
+        free (argz);
+    }
+    return false;
+}
+
 int flux_plugin_init (flux_plugin_t *p)
 {
-    if (flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME) < 0
-        || flux_plugin_add_handler (p, "shell.init", libpals_init, NULL) < 0
-        || flux_plugin_add_handler (p, "task.init", libpals_task_init, NULL) < 0) {
+    const char *pmi_opt = NULL;
+    flux_shell_t *shell;
+
+    if (!(shell = flux_plugin_get_shell (p))
+        || flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME) < 0)
+        return -1;
+
+    if (flux_shell_getopt_unpack (shell, "pmi", "s", &pmi_opt) < 0) {
+        shell_log_error ("pmi shell option must be a string");
         return -1;
     }
+    if (!pmi_opt || !member_of_csv (pmi_opt, "cray-pals"))
+        return 0; // plugin disabled
+
+    shell_debug ("enabled");
+
+    if (flux_plugin_add_handler (p, "shell.init", libpals_init, NULL) < 0
+        || flux_plugin_add_handler (p,
+                                    "task.init",
+                                    libpals_task_init,
+                                     NULL) < 0)
+        return -1;
+
     return 0;
 }

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -589,7 +589,8 @@ static int read_future (flux_future_t *fut, char *buf, size_t bufsize)
             /*  'start' event with no cray_port_distribution event.
              *  assume cray-pals jobtap plugin is not loaded.
              */
-            shell_debug ("jobtap plugin not loaded: disabling operation");
+            shell_debug ("cray_pals_port_distributor jobtap plugin is not "
+                         "loaded: proceeding without PMI_CONTROL_PORT set");
             return 0;
         }
         if (!strcmp (name, "cray_port_distribution")) {

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -49,10 +49,16 @@ test_expect_success 'job-manager: pals port distributor reclaims ports' '
 	flux job wait-event -vt 5 ${jobid} clean
 '
 
-test_expect_success 'shell: pals shell plugin sets environment' '
-	echo "
+test_expect_success 'shell: create shell initrc for testing' "
+	cat >$USERRC_NAME <<-EOT
+	if shell.options['pmi'] == nil then
+	    shell.options['pmi'] = 'cray-pals'
+	end
 	plugin.load { file = \"$SHELL_PLUGINPATH/cray_pals.so\", conf = { } }
-	" > $USERRC_NAME &&
+	EOT
+"
+
+test_expect_success 'shell: pals shell plugin sets environment' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 env) &&
 	echo "$environment" | grep PALS_NODEID=0 &&
 	echo "$environment" | grep PALS_RANKID=0 &&

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -58,6 +58,25 @@ test_expect_success 'shell: create shell initrc for testing' "
 	EOT
 "
 
+test_expect_success 'shell: cray-pals is active when userrc is loaded' '
+	flux run -o userrc=$(pwd)/$USERRC_NAME \
+	    printenv PALS_RANKID
+'
+test_expect_success 'shell: cray-pals is inactive with -opmi=off' '
+	test_must_fail flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=off \
+	    printenv PALS_RANKID
+'
+test_expect_success 'shell: cray-pals is active with -opmi=cray-pals' '
+	flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=cray-pals \
+	    printenv PALS_RANKID
+'
+test_expect_success 'shell: cray-pals is active with -opmi includes cray-pals' '
+	flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=simple,cray-pals \
+	    printenv PALS_RANKID &&
+	flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=cray-pals,simple \
+	    printenv PALS_RANKID
+'
+
 test_expect_success 'shell: pals shell plugin sets environment' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 env) &&
 	echo "$environment" | grep PALS_NODEID=0 &&

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -133,7 +133,7 @@ test_expect_success 'shell: pals shell plugin ignores missing jobtap plugin' '
 	flux run -o verbose -o userrc=$(pwd)/$USERRC_NAME \
 		-N2 -n2 hostname > no-jobtap.log 2>&1 &&
 	test_debug "cat no-jobtap.log" &&
-	grep "jobtap plugin not loaded" no-jobtap.log
+	grep "jobtap plugin is not loaded" no-jobtap.log
 '
 
 test_done


### PR DESCRIPTION
This resolves #52 by adding an rc script that loads the port distributor jobtap plugin in all instances.

In addition it makes a slight tweak to the cray_pals plugin so that it conforms to the way the `pmi` shell option is being changed in flux-core, as described in flux-framework/flux-core#5063.

These changes assume that `flux-coral2` is built with the same prefix as `flux-core`.

Also, we'll want to ask the sys admins to
1) drop the job manager config in the system instance that loads the port distributor plugin
2) drop the change to the shell initrc.lua that loads the cray_pals plugin from its side-installed location
3) add a change to the shell initrc.lua to add `cray-pals` to the default set of PMIs offered to jobs

The last one looks like this
```lua
-- Add cray-pals to the default PMIs offered on this system
if shell.options['pmi'] == nil then
    shell.options['pmi'] = 'cray-pals,simple'
end
```
(It needs to be before the line that loads all hte `*.so` plugins)

I've been testing this on my home system and it all seems to go together well.