### PR TITLE
dws: install shell plugin to main dir

### DIFF
--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -8,12 +8,9 @@ AM_LDFLAGS = \
 
 shell_plugindir = \
     $(fluxlibdir)/shell/plugins
-shell_plugin_subdir = \
-    $(shell_plugindir)/coral2
 
 shell_plugin_LTLIBRARIES = \
-	cray_pals.la
-shell_plugin_sub_LTLIBRARIES = \
+	cray_pals.la \
 	dws_environment.la
 
 cray_pals_la_SOURCES = cray_pals.c \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -26,6 +26,7 @@ TESTSCRIPTS = \
 	t1001-cray-pals.t \
 	t1002-dws-workflow-obj.t \
 	t1003-dws-nnf-watch.t \
+	t1004-dws-environment.t \
 	t2000-dws2jgf.t \
 	python/t0001-directive-breakdown.py
 


### PR DESCRIPTION
Problem: the dws_environment shell plugin is not
loaded by default. The plugin has no effect when
a job has no DW string, so there is no drawback
to always loading it.

Install the plugin to the shell plugin dir, not
a subdirectory.