### PR TITLE
systemd: change Requires to BindTo

### DIFF
--- a/etc/flux-coral2-dws.service.in
+++ b/etc/flux-coral2-dws.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Flux-DWS communication service
-Requires=flux.service
+BindsTo=flux.service
 After=flux.service
 
 [Service]


### PR DESCRIPTION
Problem: the coral2-dws systemd service 'requires' flux which means (in combination with 'Restart=always') that the flux service cannot be shut down without first shutting down the coral2-dws service. That is obnoxious.

Solution: change 'requires' to 'bindsto' which is
a looser requirement.

Fixes #59.