### PR TITLE
dws: split directives by DW token

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -103,9 +103,10 @@ def create_cb(fh, t, msg, api_instance):
     jobid = msg.payload["jobid"]
     userid = msg.payload["userid"]
     if isinstance(dw_directives, str):
-        # assume different directives are on different lines and remove
-        # any blank lines
-        dw_directives = [dw for dw in dw_directives.splitlines() if dw]
+        # the string may contain multiple #DW directives
+        dw_directives = dw_directives.split("#DW ")
+        # remove any blank entries that resulted and add back "#DW "
+        dw_directives = ["#DW " + dw.strip() for dw in dw_directives if dw.strip()]
     if not isinstance(dw_directives, list):
         raise TypeError(
             f"Malformed dw_directives, not list or string: {dw_directives!r}"

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -99,6 +99,27 @@ test_expect_success 'job submission with multiple valid DW strings on different 
 	flux job wait-event -vt 5 ${jobid} clean
 '
 
+test_expect_success 'job submission with multiple valid DW strings on the same line works' '
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1 \
+			#DW jobdw capacity=20KiB type=gfs2 name=project2" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-remove &&
+	flux job wait-event -vt 5 ${jobid} depend &&
+	flux job wait-event -vt 5 ${jobid} priority &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
+	flux job wait-event -vt 5 ${jobid} clean
+'
+
 test_expect_success 'job submission with multiple valid DW strings in a JSON file works' '
 	jobid=$(flux submit --setattr=^system.dw="${DATADIR}/two_directives.json" \
 		    -N1 -n1 hostname) &&


### PR DESCRIPTION
Problem: coral2_dws.py splits DW strings by
newlines. This generally works, but is restrictive.

Split DW strings by the '#DW ' token. This should
prove both more robust and more flexible.