### PR TITLE
build: require flux-core >= 0.49.0

### DIFF
--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -63,7 +63,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH}
   export PKG_CONFIG_PATH
 
-  PKG_CHECK_MODULES([FLUX_CORE], [flux-core],
+  PKG_CHECK_MODULES([FLUX_CORE], [flux-core >= 0.49.0],
     [
       FLUX_PREFIX=`pkg-config --variable=prefix flux-core`
       LIBFLUX_VERSION=`pkg-config --modversion flux-core`


### PR DESCRIPTION
Problem: the cray-pals shell plugin parses the pmi shell option as a list of PMI implementations and if it doesn't find itself in the list, it is disabled. However, in flux-core versions prior to 0.49.0, the pmi shell plugin throws an error if the pmi shell option does not contain options it recognizes.

Require flux-core >= 0.49.0 at configure time.

Fixes #65