### PR TITLE
Persistent dw directives

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -160,38 +160,41 @@ def setup_cb(fh, t, msg, k8s_api):
         {"data": compute_nodes},
     )
     for breakdown in workflow.breakdowns:
-        allocation_sets = []
-        for alloc_set in breakdown["status"]["storage"]["allocationSets"]:
-            storage_field = []
-            server_alloc_set = {
-                "allocationSize": alloc_set["minimumCapacity"],
-                "label": alloc_set["label"],
-                "storage": storage_field,
-            }
-            if (
-                alloc_set["allocationStrategy"]
-                == directivebreakdown.AllocationStrategy.PER_COMPUTE.value
-            ):
-                # make an allocation on every rabbit attached to compute nodes
-                # in the job
-                for nnf_name in nodes_per_nnf.keys():
+        # if a breakdown doesn't have a storage field (e.g. persistentdw) directives
+        # ignore it and proceed
+        if "storage" in breakdown["status"]:
+            allocation_sets = []
+            for alloc_set in breakdown["status"]["storage"]["allocationSets"]:
+                storage_field = []
+                server_alloc_set = {
+                    "allocationSize": alloc_set["minimumCapacity"],
+                    "label": alloc_set["label"],
+                    "storage": storage_field,
+                }
+                if (
+                    alloc_set["allocationStrategy"]
+                    == directivebreakdown.AllocationStrategy.PER_COMPUTE.value
+                ):
+                    # make an allocation on every rabbit attached to compute nodes
+                    # in the job
+                    for nnf_name in nodes_per_nnf.keys():
+                        storage_field.append(
+                            {"allocationCount": nodes_per_nnf[nnf_name], "name": nnf_name}
+                        )
+                else:
+                    # make a single allocation on a random rabbit
                     storage_field.append(
-                        {"allocationCount": nodes_per_nnf[nnf_name], "name": nnf_name}
+                        {"allocationCount": 1, "name": next(iter(nodes_per_nnf.keys()))}
                     )
-            else:
-                # make a single allocation on a random rabbit
-                storage_field.append(
-                    {"allocationCount": 1, "name": next(iter(nodes_per_nnf.keys()))}
-                )
-            allocation_sets.append(server_alloc_set)
-        k8s_api.patch_namespaced_custom_object(
-            SERVER_CRD.group,
-            SERVER_CRD.version,
-            breakdown["status"]["storage"]["reference"]["namespace"],
-            SERVER_CRD.plural,
-            breakdown["status"]["storage"]["reference"]["name"],
-            {"spec": {"allocationSets": allocation_sets}},
-        )
+                allocation_sets.append(server_alloc_set)
+            k8s_api.patch_namespaced_custom_object(
+                SERVER_CRD.group,
+                SERVER_CRD.version,
+                breakdown["status"]["storage"]["reference"]["namespace"],
+                SERVER_CRD.plural,
+                breakdown["status"]["storage"]["reference"]["name"],
+                {"spec": {"allocationSets": allocation_sets}},
+            )
     workflow.setup_rpc = msg
     move_workflow_desiredstate(workflow.name, "Setup", k8s_api)
 

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -69,8 +69,9 @@ def message_callback_wrapper(func):
         except Exception as exc:
             try:
                 jobid = msg.payload["jobid"]
+                topic = msg.topic
             except Exception:
-                jobid = None
+                topic = jobid = None
             try:
                 # only k8s APIExceptions will have a JSON message body,
                 # but try to extract it out of every exception for simplicity
@@ -79,7 +80,7 @@ def message_callback_wrapper(func):
                 errstr = str(exc)
             fh.log(syslog.LOG_ERR, f"{os.path.basename(__file__)}: {errstr}")
             fh.respond(msg, {"success": False, "errstr": errstr})
-            LOGGER.error("Error in responding to RPC for %s: %s", jobid, errstr)
+            LOGGER.error("Error in responding to %s RPC for %s: %s", topic, jobid, errstr)
 
     return wrapper
 

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -76,7 +76,7 @@ def apply_breakdowns(k8s_api, workflow, resources):
 def _fetch_breakdowns(k8s_api, workflow):
     """Fetch all of the directive breakdowns associated with a workflow."""
     if not workflow["status"].get("directiveBreakdowns"):
-        raise ValueError(f"workflow {workflow} has no directive breakdowns")
+        return []  # destroy_persistent DW directives have no breakdowns
     for breakdown in workflow["status"]["directiveBreakdowns"]:
         yield k8s_api.get_namespaced_custom_object(
             DIRECTIVEBREAKDOWN_CRD.group,

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -57,7 +57,7 @@ test_expect_success 'job submission without DW string works' '
 '
 
 test_expect_success 'job submission with valid DW string works' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1" \
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
 		-N1 -n1 hostname) &&
 	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&
@@ -65,25 +65,25 @@ test_expect_success 'job submission with valid DW string works' '
 		${jobid} dependency-remove &&
 	flux job wait-event -t 10 -m rabbit_workflow=fluxjob-$(flux job id ${jobid}) \
 		${jobid} memo &&
-	flux job wait-event -vt 5 ${jobid} depend &&
-	flux job wait-event -vt 5 ${jobid} priority &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
-	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 5 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean
 '
 
 test_expect_success 'job submission with multiple valid DW strings on different lines works' '
 	jobid=$(flux submit --setattr=system.dw="
-											 #DW jobdw capacity=10KiB type=xfs name=project1
+											 #DW jobdw capacity=10GiB type=xfs name=project1
 
-											 #DW jobdw capacity=20KiB type=gfs2 name=project2" \
+											 #DW jobdw capacity=20GiB type=gfs2 name=project2" \
 		    -N1 -n1 hostname) &&
 	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&
@@ -91,40 +91,40 @@ test_expect_success 'job submission with multiple valid DW strings on different 
 		${jobid} dependency-remove &&
 	flux job wait-event -t 10 -m rabbit_workflow=fluxjob-$(flux job id ${jobid}) \
 		${jobid} memo &&
-	flux job wait-event -vt 5 ${jobid} depend &&
-	flux job wait-event -vt 5 ${jobid} priority &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
-	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 5 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean
 '
 
 test_expect_success 'job submission with multiple valid DW strings on the same line works' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1 \
-			#DW jobdw capacity=20KiB type=gfs2 name=project2" \
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1 \
+			#DW jobdw capacity=20GiB type=gfs2 name=project2" \
 		-N1 -n1 hostname) &&
 	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-remove &&
-	flux job wait-event -vt 5 ${jobid} depend &&
-	flux job wait-event -vt 5 ${jobid} priority &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
-	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 5 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean
 '
 
 test_expect_success 'job submission with multiple valid DW strings in a JSON file works' '
@@ -134,20 +134,20 @@ test_expect_success 'job submission with multiple valid DW strings in a JSON fil
 		${jobid} dependency-add &&
 	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-remove &&
-	flux job wait-event -vt 5 ${jobid} depend &&
-	flux job wait-event -vt 5 ${jobid} priority &&
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
 	flux job wait-event -t 10 -m rabbit_workflow=fluxjob-$(flux job id ${jobid}) \
 		${jobid} memo &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
-	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 5 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean
 '
 
 test_expect_success 'job-manager: dependency plugin works when validation fails' '
@@ -158,7 +158,7 @@ test_expect_success 'job-manager: dependency plugin works when validation fails'
 '
 
 test_expect_success 'dws service kills workflows in Error properly' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1
 		#DW copy_in source=/some/fake/dir destination=$DW_JOB_project1/" \
 		-N1 -n1 hostname) &&
 	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
@@ -179,7 +179,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 '
 
 test_expect_success 'job submission with valid DW string works after config change' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10KiB type=xfs name=project1" \
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
 		-N1 -n1 hostname) &&
 	flux job wait-event -vt 15 -m description=${CREATE_DEP_NAME} \
 		${jobid} dependency-add &&

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -188,8 +188,33 @@ test_expect_success 'job submission with valid DW string works after config chan
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 15 ${jobid} clean &&
-	flux job cancel ${DWS_JOBID}
+	flux job wait-event -vt 15 ${jobid} clean
+'
+
+test_expect_success 'job submission with persistent DW string works' '
+	flux run --setattr=system.dw="#DW create_persistent capacity=10GiB type=lustre name=project1" \
+		-N1 -n1 -c1 hostname &&
+	jobid=$(flux submit --setattr=system.dw="#DW persistentdw name=project1" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 30 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 30 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 30 ${jobid} clean &&
+	jobid=$(flux submit --setattr=system.dw="#DW persistentdw name=project1" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 30 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 30 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 30 ${jobid} clean &&
+	jobid=$(flux submit --setattr=system.dw="#DW destroy_persistent name=project1" \
+		-N1 -n1 -c1 hostname) &&
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 30 ${jobid} clean
 '
 
 test_done


### PR DESCRIPTION
Add support and tests for persistent rabbit allocations---i.e., rabbit allocations that are independent of jobs.