### PR TITLE
DWS service crashes

### DIFF
--- a/src/job-manager/plugins/cray_pals_port_distributor.c
+++ b/src/job-manager/plugins/cray_pals_port_distributor.c
@@ -293,8 +293,7 @@ int flux_plugin_init (flux_plugin_t *p)
     for (int i = 0; i < size; ++i) {
         range->available_ports[i] = port_min + i;
     }
-    if (flux_plugin_set_name (p, "cray-pals") < 0
-        || flux_plugin_add_handler (p, "job.state.run", run_cb, range) < 0
+    if (flux_plugin_add_handler (p, "job.state.run", run_cb, range) < 0
         || flux_plugin_add_handler (p, "job.state.cleanup", cleanup_cb, range) < 0
         || flux_plugin_aux_set (p, NULL, range, (flux_free_f)port_range_destroy) < 0) {
         port_range_destroy (range);

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -160,19 +160,17 @@ static int depend_cb (flux_plugin_t *p,
     json_t *dw = NULL;
     flux_t *h = flux_jobtap_get_flux (p);
     json_t *resources;
-    json_t *jobspec;
     int userid;
     int *prolog_active = NULL;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:I s:{s:{s:{s?o}}} s:o s:{s:o} s:i}",
+                                "{s:I s:{s:{s:{s?o}}} s:{s:o} s:i}",
                                 "id", &id,
                                 "jobspec",
                                 "attributes",
                                 "system",
                                 "dw", &dw,
-                                "jobspec", &jobspec,
                                 "jobspec", "resources", &resources,
                                 "userid", &userid) < 0)
         return -1;

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -302,7 +302,7 @@ def _workflow_state_change_cb_inner(workflow, jobid, winfo, fh, k8s_api):
         winfo.computes = workflow["status"]["computes"]
         resources = winfo.create_rpc.payload["resources"]
         winfo.breakdowns = list(
-            directivebreakdown._fetch_breakdowns(k8s_api, workflow)
+            directivebreakdown.fetch_breakdowns(k8s_api, workflow)
         )
         fh.respond(winfo.create_rpc, {"success": True, "resources": resources})
         winfo.create_rpc = None

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -50,7 +50,6 @@ class WorkflowInfo:
         self.post_run_rpc = None
         self.toredown = False
         self.deleted = False
-        self.breakdowns = None
         self.last_error_time = None
         self.last_error_message = None
 
@@ -160,7 +159,7 @@ def setup_cb(fh, t, msg, k8s_api):
         workflow["status"]["computes"]["name"],
         {"data": compute_nodes},
     )
-    for breakdown in winfo.breakdowns:
+    for breakdown in directivebreakdown.fetch_breakdowns(k8s_api, workflow):
         # if a breakdown doesn't have a storage field (e.g. persistentdw) directives
         # ignore it and proceed
         if "storage" in breakdown["status"]:
@@ -300,9 +299,6 @@ def _workflow_state_change_cb_inner(workflow, jobid, winfo, fh, k8s_api):
         return
     elif state_complete(workflow, "Proposal"):
         resources = winfo.create_rpc.payload["resources"]
-        winfo.breakdowns = list(
-            directivebreakdown.fetch_breakdowns(k8s_api, workflow)
-        )
         fh.respond(winfo.create_rpc, {"success": True, "resources": resources})
         winfo.create_rpc = None
     elif state_complete(workflow, "Setup"):

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -82,6 +82,8 @@ def message_callback_wrapper(func):
             fh.log(syslog.LOG_ERR, f"{os.path.basename(__file__)}: {errstr}")
             fh.respond(msg, {"success": False, "errstr": errstr})
             LOGGER.error("Error in responding to %s RPC for %s: %s", topic, jobid, errstr)
+        else:
+            fh.respond(msg, {"success": True})
 
     return wrapper
 

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -52,7 +52,7 @@ def build_allocation_sets(allocation_sets, local_allocations, nodes_per_nnf):
 
 def apply_breakdowns(k8s_api, workflow, resources):
     """Apply all of the directive breakdown information to a jobspec's `resources`."""
-    breakdown_list = list(_fetch_breakdowns(k8s_api, workflow))
+    breakdown_list = list(fetch_breakdowns(k8s_api, workflow))
     per_compute_total = 0  # total bytes of per-compute storage
     for breakdown in breakdown_list:
         if breakdown["kind"] != "DirectiveBreakdown":
@@ -73,7 +73,7 @@ def apply_breakdowns(k8s_api, workflow, resources):
     return breakdown_list
 
 
-def _fetch_breakdowns(k8s_api, workflow):
+def fetch_breakdowns(k8s_api, workflow):
     """Fetch all of the directive breakdowns associated with a workflow."""
     if not workflow["status"].get("directiveBreakdowns"):
         return []  # destroy_persistent DW directives have no breakdowns

--- a/t/python/t0001-directive-breakdown.py
+++ b/t/python/t0001-directive-breakdown.py
@@ -31,7 +31,7 @@ def read_yaml_breakdown(*paths):
 
 class TestDirectiveBreakdowns(unittest.TestCase):
     @unittest.expectedFailure
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_lustre10tb(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "lustre10tb.yaml")
         resources = []
@@ -46,7 +46,7 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             self.assertGreater(resource["with"][0]["count"], 10e8)
 
     @unittest.expectedFailure
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_xfs10mb(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "xfs10mb.yaml")
         for resources in (
@@ -69,7 +69,7 @@ class TestDirectiveBreakdowns(unittest.TestCase):
                 self.assertEqual(rabbit["with"][0]["count"], int(10e5))
 
     @unittest.expectedFailure
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_xfs10mb_aggregation(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(
             YAMLDIR / "xfs10mb.yaml", YAMLDIR / "xfs10mb.yaml"
@@ -97,7 +97,7 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         self.assertEqual(rabbit["with"][0]["count"], int(25e5))
 
     @unittest.expectedFailure
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_combination_xfs_lustre(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(
             YAMLDIR / "xfs10mb.yaml", YAMLDIR / "lustre10tb.yaml"
@@ -117,28 +117,28 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             self.assertEqual(resource["with"][0]["unit"], "B")
             self.assertGreater(resource["with"][0]["count"], 10e8)
 
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_xfs10mb_no_node_or_slot(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "xfs10mb.yaml")
         resources = []
         with self.assertRaisesRegex(ValueError, "Empty resources:.*"):
             directivebreakdown.apply_breakdowns(None, None, resources)
 
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_allocation_bad_label(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "bad_label.yaml")
         resources = []
         with self.assertRaisesRegex(KeyError, "foo"):
             directivebreakdown.apply_breakdowns(None, None, resources)
 
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_allocation_bad_kind(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "bad_kind.yaml")
         with self.assertRaisesRegex(ValueError, "unsupported breakdown kind"):
             directivebreakdown.apply_breakdowns(None, None, None)
 
     @unittest.expectedFailure
-    @unittest.mock.patch("flux_k8s.directivebreakdown._fetch_breakdowns")
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_bad_existing_units(self, patched_fetch):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "xfs10mb.yaml")
         resources = [

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -23,10 +23,12 @@ test_expect_success 'job-manager: dws jobtap plugin works when coral2_dws is abs
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -vt 1 ${jobid} exception
+	flux job wait-event -vt 1 ${jobid} clean
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when RPCs succeed' '
-	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT}) &&
+	create_jobid=$(flux submit -t 8 --output=dws1.out --error=dws1.out \
+		flux python ${DWS_SCRIPT}) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
@@ -41,22 +43,25 @@ test_expect_success 'job-manager: dws jobtap plugin works when RPCs succeed' '
 		${jobid} epilog-start &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 15 ${jobid} clean &&
+	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when creation RPC fails' '
-	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --create-fail) &&
+	create_jobid=$(flux submit -t 8 --output=dws2.out --error=dws2.out \
+		flux python ${DWS_SCRIPT} --create-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
 	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' '
-	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --setup-fail) &&
+	create_jobid=$(flux submit -t 8 --output=dws3.out --error=dws3.out \
+		flux python ${DWS_SCRIPT} --setup-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
@@ -64,11 +69,13 @@ test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' 
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when post_run RPC fails' '
-	create_jobid=$(flux submit -t 8 flux python ${DWS_SCRIPT} --post-run-fail) &&
+	create_jobid=$(flux submit -t 8 --output=dws3.out --error=dws3.out \
+		flux python ${DWS_SCRIPT} --post-run-fail) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
@@ -76,11 +83,13 @@ test_expect_success 'job-manager: dws jobtap plugin works when post_run RPC fail
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} -m status=1 \
 		${jobid} epilog-finish &&
 	flux job wait-event -vt 1 ${jobid} exception &&
+	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
 test_expect_success 'job-manager: dws jobtap plugin works when job hits exception during prolog' '
-	create_jobid=$(flux mini submit -t 8 flux python ${DWS_SCRIPT} --setup-hang) &&
+	create_jobid=$(flux mini submit -t 8 --output=dws4.out --error=dws4.out \
+		flux python ${DWS_SCRIPT} --setup-hang) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
 	jobid=$(flux mini submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
@@ -93,6 +102,7 @@ test_expect_success 'job-manager: dws jobtap plugin works when job hits exceptio
 		${jobid} epilog-start &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
+	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -37,7 +37,7 @@ test_expect_success 'exec dws service-providing script' '
 	DWS_JOBID=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws1.out --error=dws1.err \
-	        python ${DWS_MODULE_PATH} -e1) &&
+	        python ${DWS_MODULE_PATH} -e1 -v) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start
 '
 
@@ -69,7 +69,7 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job wait-event -vt 15 ${jobid} priority &&
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
@@ -95,12 +95,12 @@ test_expect_success 'job submission with multiple valid DW strings on different 
 	flux job wait-event -vt 15 ${jobid} priority &&
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 45 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
@@ -117,12 +117,12 @@ test_expect_success 'job submission with multiple valid DW strings on the same l
 	flux job wait-event -vt 15 ${jobid} priority &&
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 45 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
@@ -140,12 +140,12 @@ test_expect_success 'job submission with multiple valid DW strings in a JSON fil
 		${jobid} memo &&
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+	flux job wait-event -vt 45 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+	flux job wait-event -vt 50 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
@@ -173,7 +173,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '
@@ -185,10 +185,10 @@ test_expect_success 'job submission with valid DW string works after config chan
 		${jobid} dependency-add &&
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -vt 30 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
-	flux job wait-event -vt 15 ${jobid} clean
+	flux job wait-event -vt 25 ${jobid} clean
 '
 
 test_expect_success 'job submission with persistent DW string works' '


### PR DESCRIPTION
This PR is a substantial rewrite of `dws-jobtap.c` and `coral2_dws.py` to solve the problem of handling `coral2_dws.py` crashes. Before this PR is merged, the `coral2_dws.py` service assumes that its lifetime encompasses the lifetime of any job that it sees. It can't handle rabbit jobs that existed before it started. This is because it keeps an internal data structure of active rabbit jobs, and jobs can only be added to the data structure when they are being created. 

Furthermore, the `dws-jobtap.c` plugin sends a RPC to `coral2_dws.py` when a job is ready (by flux-core standards) to transition states, and `coral2_dws.py` responds to that RPC when HPE rabbit software gives the go-ahead. But HPE rabbit software can take a considerable amount of time to give the go-ahead. If the `coral2_dws.py` service crashes or restarts in the meanwhile, it won't be able to respond to the RPC it received, and the job will be stranded. In the worst case, the job is stranded in the dws epilog, and can't be canceled. That is intensely obnoxious.

Instead of making the `coral2_dws.py` service hold on to RPCs, make it respond more or less immediately, and send a new RPC to the jobtap plugin once the go-ahead is given by HPE rabbit software.

Fixes #64 