### PR TITLE
Cray pals env vars

### DIFF
--- a/src/job-manager/plugins/cray_pals_port_distributor.c
+++ b/src/job-manager/plugins/cray_pals_port_distributor.c
@@ -14,8 +14,10 @@
 
 #include <stdio.h>
 #include <syslog.h>
+#include <stdint.h>
 
 #include <jansson.h>
+#include <sodium.h>
 
 #include <flux/core.h>
 #include <flux/hostlist.h>
@@ -93,6 +95,7 @@ static void count_job_shells (flux_future_t *fut, void *arg)
     flux_t *h;
     json_t *arr = NULL;
     int prolog_status = 0;
+    json_int_t random;
 
     if (!(h = flux_future_get_flux (fut))) {
         prolog_status = 1;
@@ -113,15 +116,18 @@ static void count_job_shells (flux_future_t *fut, void *arg)
     if (hostlist_count (hlist) == 1) {
         goto cleanup;  // no need to post ports
     }
+    randombytes_buf (&random, sizeof (json_int_t));
     // assign ports to the job
     if ((port1 = get_port (triple->range)) < 0 || (port2 = get_port (triple->range)) < 0
         || !(arr = json_pack ("[I, I]", port1, port2))
         || flux_jobtap_event_post_pack (triple->plugin,
                                         triple->jobid,
                                         "cray_port_distribution",
-                                        "{s:O}",
+                                        "{s:O, s:I}",
                                         "ports",
-                                        arr) < 0
+                                        arr,
+                                        "random_integer",
+                                        random) < 0
         || flux_jobtap_job_aux_set (triple->plugin,
                                     triple->jobid,
                                     CRAY_PALS_AUX_NAME,
@@ -269,6 +275,10 @@ int flux_plugin_init (flux_plugin_t *p)
                   port_max);
     }
 
+    if (sodium_init () == -1) {
+        flux_log (h, LOG_ERR, "error initializing libsodium");
+        return -1;
+    }
     // check that port range falls within acceptable bounds
     // ports less than 1024 require root, max port is 2^16 -
     if (port_min < 1024 || port_max < 1024 || port_max > (1 << 16)) {

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -768,7 +768,12 @@ static int unset_pals_env (flux_shell_t *shell)
 {
     char *pals_env[] = { "PALS_NODEID", "PALS_RANKID",
                          "PALS_APINFO", "PALS_APID",
-                         "PALS_SPOOL_DIR", "PMI_CONTROL_PORT" };
+                         "PALS_SPOOL_DIR", "PALS_FD",
+                         "PALS_DEPTH", "PALS_LOCAL_RANKID",
+                         "PALS_LOCAL_SIZE", "PMI_JOBID",
+                         "PMI_CONTROL_PORT", "PMI_SHARED_SECRET",
+                         "PMI_JOBID", "PMI_LOCAL_RANK",
+                         "PMI_LOCAL_SIZE"};
     for (int i = 0; i < sizeof (pals_env) / sizeof (pals_env[0]); i++)
     {
         flux_shell_unsetenv (shell, pals_env[i]);

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -12,7 +12,7 @@ test_under_flux 2 job
 
 flux setattr log-stderr-level 1
 
-unset PALS_RANKID PALS_NODEID PMI_CONTROL_PORT
+unset PALS_RANKID PALS_NODEID PMI_CONTROL_PORT PMI_SHARED_SECRET
 
 test_expect_success 'job-manager: load cray_pals_port_distributor plugin with invalid config' '
 	test_expect_code 1 flux jobtap load ${JOBTAP_PLUGINPATH}/cray_pals_port_distributor.so \
@@ -95,13 +95,15 @@ test_expect_success 'shell: pals shell plugin sets environment' '
 	echo "$environment" | grep PALS_APID &&
 	echo "$environment" | grep PALS_SPOOL_DIR &&
 	echo "$environment" | grep PALS_APINFO &&
-	echo "$environment" | test_must_fail grep PMI_CONTROL_PORT
+	echo "$environment" | test_must_fail grep PMI_CONTROL_PORT &&
+	echo "$environment" | test_must_fail grep PMI_SHARED_SECRET
 '
 
-test_expect_success 'shell: pals shell plugin sets PMI_CONTROL_PORT' '
+test_expect_success 'shell: pals shell plugin sets CONTROL_PORT and SHARED_SECRET' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N2 -n4 env) &&
 	(echo "$environment" | grep PMI_CONTROL_PORT=11999,11998 ||
 	echo "$environment" | grep PMI_CONTROL_PORT=11998,11999) &&
+	echo "$environment" | grep PMI_SHARED_SECRET &&
 	echo "$environment" | grep PALS_NODEID=0 &&
 	echo "$environment" | grep PALS_RANKID=0 &&
 	echo "$environment" | grep PALS_RANKID=1 &&

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -79,11 +79,13 @@ test_expect_success 'shell: cray-pals is active with -opmi includes cray-pals' '
 	    printenv PALS_RANKID
 '
 test_expect_success 'shell: cray-pals unsets PALS variables when inactive' '
-	(export PALS_RANKID=0 PMI_CONTROL_PORT=6 && PALS_NODEID=1 &&
+	(export PALS_RANKID=0 PMI_CONTROL_PORT=6 PALS_NODEID=1 PMI_SHARED_SECRET=1 &&
 	test_must_fail flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=none \
 		printenv PALS_RANKID &&
 	test_must_fail flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=none \
 		printenv PALS_NODEID &&
+	test_must_fail flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=none \
+		printenv PMI_SHARED_SECRET &&
 	test_must_fail flux run -o userrc=$(pwd)/$USERRC_NAME -o pmi=none \
 		printenv PMI_CONTROL_PORT)
 '


### PR DESCRIPTION
This is a partial resolution of #79. The only new variable set is `PMI_SHARED_SECRET`. Some additional variables are unset.

We could set more variables listed in #79, but only `PMI_SHARED_SECRET` has resulted in an error.