### PR TITLE
mergify: remove status check requirement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,6 @@ queue_rules:
   - name: default
     conditions:
       - base=master
-      - status-success="validate commits"
-      - status-success="el8"
-      - status-success="focal"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"


### PR DESCRIPTION
Problem: mergify is configured to require status
checks to pass before merging, but we can use
GitHub's branch protections instead.

Remove mergify's status checks requirements.