### PR TITLE
Fluxion scheduling for rabbits

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -30,8 +30,6 @@ from flux_k8s import directivebreakdown
 
 
 _WORKFLOWINFO_CACHE = {}  # maps jobids to WorkflowInfo objects
-# Regex will match only rack-local allocations due to the rack\d+/ part
-_XFS_REGEX = re.compile(r"rack\d+/(.*?)/ssd\d+")
 _HOSTNAMES_TO_RABBITS = {}  # maps compute hostnames to rabbit names
 LOGGER = logging.getLogger(__name__)
 WORKFLOWS_IN_TC = set()  # tc for TransientCondition

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -162,6 +162,10 @@ def setup_cb(handle, _t, msg, k8s_api):
     for hostname in hlist:
         nnf_name = _HOSTNAMES_TO_RABBITS[hostname]
         nodes_per_nnf[nnf_name] = nodes_per_nnf.get(nnf_name, 0) + 1
+    handle.rpc(
+        "job-manager.memo",
+        payload={"id": jobid, "memo": {"rabbits": list(nodes_per_nnf.keys())}},
+    )
     k8s_api.patch_namespaced_custom_object(
         COMPUTE_CRD.group,
         COMPUTE_CRD.version,


### PR DESCRIPTION
The final piece after #88, #89, and #90 for getting rabbit allocations through Fluxion. The logic for building a resource graph with rabbits is there already, and so is the logic for creating jobspecs which request rabbits. But at the moment the scheduler never actually gets to see the jobspecs that request rabbits, because the plugins hold them back. This PR fixes that.

It also fixes (or at least minimizes) a major limitation of the previous implementation's handling of lustre file systems, which stuck each lustre allocation on a single rabbit. Now lustre file systems are split across rabbits by default.