### PR TITLE
testsuite: load content module in rc scripts

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -28,6 +28,7 @@ modload() {
 }
 
 
+modload all content || :
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -29,3 +29,4 @@ modrm all kvs
 flux content flush
 
 modrm 0 content-sqlite
+modrm all content


### PR DESCRIPTION
Problem: flux-core is migrating the content service from the broker to a broker module.

Load the content module in test rc scripts.

Ignore any errors from 'flux module load' so that flux-coral2 continues to work with older flux-core versions.