### PR TITLE
rc: call set -e after shebang in 01-coral2-rc

### DIFF
--- a/etc/01-coral2-rc
+++ b/etc/01-coral2-rc
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 # Load jobtap plugin, unless it's already loaded (e.g. by config)
 jobtap_load() {


### PR DESCRIPTION
Problem: If BASH_ENV is set to a script that is not errexit clean, the 01-coral2-rc script may immediately.

Drop -e from the shebang and add a "set -e" afterwards.

Fixes #95