### PR TITLE
rc: use posix shell

### DIFF
--- a/etc/01-coral2-rc
+++ b/etc/01-coral2-rc
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/sh -e
 
 # Load jobtap plugin, unless it's already loaded (e.g. by config)
 jobtap_load() {


### PR DESCRIPTION
Problem: 01-coral2-rc has a bash shebang, but when a user sets BASH_ENV, it potentially sources unnecessary stuff.

Switch to a posix shebang.
Re-add the -e since this also fixes #95.

Sorry I shouldn't have let that last PR go in.  The solution kind of changed to this better one right about then.