### PR TITLE
dws: fix group of k8s crds

### DIFF
--- a/k8s/flux-test-storage0.yaml
+++ b/k8s/flux-test-storage0.yaml
@@ -1,4 +1,4 @@
-apiVersion: dws.cray.hpe.com/v1alpha2
+apiVersion: dataworkflowservices.github.io/v1alpha2
 spec:
   state: Enabled
 status:
@@ -46,6 +46,6 @@ status:
 kind: Storage
 metadata:
   labels:
-    dws.cray.hpe.com/storage: Rabbit
+    dataworkflowservices.github.io/storage: Rabbit
   name: flux-test-storage0
   namespace: default

--- a/k8s/flux-test-storage1.yaml
+++ b/k8s/flux-test-storage1.yaml
@@ -1,4 +1,4 @@
-apiVersion: dws.cray.hpe.com/v1alpha2
+apiVersion: dataworkflowservices.github.io/v1alpha2
 spec:
   state: Enabled
 status:
@@ -46,6 +46,6 @@ status:
 kind: Storage
 metadata:
   labels:
-    dws.cray.hpe.com/storage: Rabbit
+    dataworkflowservices.github.io/storage: Rabbit
   name: flux-test-storage1
   namespace: default

--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -248,7 +248,7 @@ def get_storage():
             )
         raise
 
-    group = "dws.cray.hpe.com"
+    group = "dataworkflowservices.github.io"
     version = "v1alpha2"
     plural = "storages"
     try:

--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -3,35 +3,35 @@ from collections import namedtuple
 CRD = namedtuple("CRD", ["group", "version", "namespace", "plural"])
 
 WORKFLOW_CRD = CRD(
-    group="dws.cray.hpe.com",
+    group="dataworkflowservices.github.io",
     version="v1alpha2",
     namespace="default",
     plural="workflows",
 )
 
 RABBIT_CRD = CRD(
-    group="dws.cray.hpe.com",
+    group="dataworkflowservices.github.io",
     version="v1alpha2",
     namespace="default",
     plural="storages",
 )
 
 DIRECTIVEBREAKDOWN_CRD = CRD(
-    group="dws.cray.hpe.com",
+    group="dataworkflowservices.github.io",
     version="v1alpha2",
     namespace="default",
     plural="directivebreakdowns",
 )
 
 COMPUTE_CRD = CRD(
-    group="dws.cray.hpe.com",
+    group="dataworkflowservices.github.io",
     version="v1alpha2",
     namespace="default",
     plural="computes",
 )
 
 SERVER_CRD = CRD(
-    group="dws.cray.hpe.com",
+    group="dataworkflowservices.github.io",
     version="v1alpha2",
     namespace="default",
     plural="servers",

--- a/t/sharness.d/03-kube.sh
+++ b/t/sharness.d/03-kube.sh
@@ -5,7 +5,7 @@ export KUBECONFIG=${REAL_HOME}/.kube/config
 
 #  Set DWS_K8S or NO_DWS_K8S prereq
 if type "kubectl" > /dev/null \
-   && kubectl get crd 2> /dev/null | grep -q dws.cray.hpe.com; then
+   && kubectl get crd 2> /dev/null | grep -q dataworkflowservices.github.io; then
     test_set_prereq DWS_K8S
 else
     test_set_prereq NO_DWS_K8S


### PR DESCRIPTION
Problem: HPE updates the group of various kubernetes objects from 'dws.cray.hpe.com' to 'dataworkflowservices.github.io'. This breaks code that is looking for resources under the former group.

Update the group to the new name.