### PR TITLE
NEWS: add 0.8.0 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+flux-coral2 0.8.0 - 2023-10-04
+------------------------------
+
+### Fixes
+
+ * dws: update group of k8s crds (#101)
+ * rc: use posix shell (#98)
+
+### Testsuite
+
+ * testsuite: remove usage of 'flux mini' (#102)
+ * testsuite: load content module in rc scripts (#96)
+
 flux-coral2 0.7.0 - 2023-08-30
 ------------------------------
 


### PR DESCRIPTION
Problem: there are no release notes for 0.8.0.

Add them.