### PR TITLE
Rabbit env vars

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -618,10 +618,10 @@ static void prolog_remove_msg_cb (flux_t *h,
 {
     flux_plugin_t *p = (flux_plugin_t *)arg;
     json_int_t jobid;
-    json_t *env = NULL;
+    json_t *env = NULL, *rabbit_mapping = NULL;
     int *prolog_active, junk_prolog_active = 1;
 
-    if (flux_msg_unpack (msg, "{s:I, s:o}", "id", &jobid, "variables", &env) < 0) {
+    if (flux_msg_unpack (msg, "{s:I, s:o, s:o}", "id", &jobid, "variables", &env, "rabbits", &rabbit_mapping) < 0) {
         flux_log_error (h, "received malformed dws.prolog-remove RPC");
         return;
     }
@@ -639,9 +639,11 @@ static void prolog_remove_msg_cb (flux_t *h,
     if (flux_jobtap_event_post_pack (p,
                                      jobid,
                                      "dws_environment",
-                                     "{s:O}",
+                                     "{s:O, s:O}",
                                      "variables",
-                                     env)
+                                     env,
+                                     "rabbits",
+                                     rabbit_mapping)
             < 0
         || flux_jobtap_job_aux_set (p, jobid, "flux::dws_run_started", (void *)1, NULL)
                < 0) {

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -31,6 +31,7 @@ dws_environment_la_SOURCES = dws_environment.c \
 dws_environment_la_CPPFLAGS = $(AM_CPPFLAGS)
 dws_environment_la_LIBADD = \
 	$(FLUX_CORE_LIBS) \
+	$(FLUX_HOSTLIST_LIBS) \
 	$(JANSSON_LIBS)
 dws_environment_la_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/src/shell/plugins/dws_environment.c
+++ b/src/shell/plugins/dws_environment.c
@@ -33,10 +33,18 @@
 /*
  * Apply a JSON object defining environment variables to the job's environment
  */
-static int set_environment (flux_shell_t *shell, json_t *env_object)
+static int set_environment (flux_shell_t *shell,
+                            json_t *env_object,
+                            json_t *rabbit_mapping)
 {
     const char *key, *value_string;
     json_t *value;
+    struct hostlist *h;
+    char hostname[HOST_NAME_MAX + 1];
+
+    if (gethostname (hostname, HOST_NAME_MAX + 1) < 0)
+        return -1;
+    hostname[HOST_NAME_MAX] = '\0';
 
     json_object_foreach (env_object, key, value) {
         if (!(value_string = json_string_value (value))) {
@@ -49,7 +57,30 @@ static int set_environment (flux_shell_t *shell, json_t *env_object)
             return -1;
         }
     }
-    return 0;
+
+    json_object_foreach (rabbit_mapping, key, value) {
+        if (!(value_string = json_string_value (value))) {
+            shell_log_error (
+                "variables in dws_environment event must have string values");
+            return -1;
+        }
+        if (!(h = hostlist_decode (value_string))){
+            shell_log_error ("Failed initializing hostlist");
+            return -1;
+        }
+        if (hostlist_find (h, hostname) >= 0){
+            if (flux_shell_setenvf (shell, 1, "FLUX_LOCAL_RABBIT", "%s", key) < 0){
+                shell_log_error ("Failed setting FLUX_LOCAL_RABBIT");
+                hostlist_destroy (h);
+                return -1;
+            }
+            hostlist_destroy (h);
+            return 0;
+        }
+        hostlist_destroy (h);
+    }
+    shell_log_error ("Failed to find current node in rabbit mapping");
+    return -1;
 }
 
 /*
@@ -59,7 +90,7 @@ static int read_future (flux_shell_t *shell, flux_future_t *fut)
 {
     json_t *o = NULL;
     json_t *context = NULL;
-    json_t *env;
+    json_t *env, *rabbit_mapping;
     const char *name, *event = NULL;
 
     while (flux_future_wait_for (fut, 2.0) == 0
@@ -74,12 +105,20 @@ static int read_future (flux_shell_t *shell, flux_future_t *fut)
             return -1;
         }
         if (!strcmp (name, "dws_environment")) {
-            if (!(env = json_object_get (context, "variables"))) {
-                shell_log_error ("No 'variables' context in dws_environment event");
+            if (json_unpack (context,
+                             "{s:o, s:o}",
+                             "variables",
+                             &env,
+                             "rabbits",
+                             &rabbit_mapping)
+                < 0) {
+                shell_log_error (
+                    "No 'variables' or 'rabbits' context "
+                    "in dws_environment event");
                 json_decref (o);
                 return -1;
             }
-            if (set_environment (shell, env) < 0) {
+            if (set_environment (shell, env, rabbit_mapping) < 0) {
                 json_decref (o);
                 return -1;
             }

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -38,7 +38,7 @@ def setup_cb(fh, t, msg, arg):
     fh.respond(msg, payload)
     fh.rpc(
         "job-manager.dws.prolog-remove",
-        payload={"id": msg.payload["jobid"], "variables": {}},
+        payload={"id": msg.payload["jobid"], "variables": {}, "rabbits": {}},
     )
 
 def post_run_cb(fh, t, msg, arg):

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -22,7 +22,7 @@ test_expect_success 'job-manager: dws jobtap plugin works when coral2_dws is abs
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
 		${jobid} dependency-add &&
-	flux job wait-event -vt 1 ${jobid} exception -m note="dws.create RPC could not be sent"
+	flux job wait-event -vt 1 -m severity=0 ${jobid} exception &&
 	flux job wait-event -vt 1 ${jobid} clean
 '
 

--- a/t/t1004-dws-environment.t
+++ b/t/t1004-dws-environment.t
@@ -32,10 +32,26 @@ test_expect_success 'shell: plugin sets env vars properly' '
 		--setattr=dw="foo" env) &&
 	kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog dws_environment \
-		"{\"variables\":{\"DWS_TEST_VAR1\": \"foo\", \"DWS_TEST_VAR2\": \"bar\"}}" &&
+		"{\"variables\":{\"DWS_TEST_VAR1\": \"foo\", \"DWS_TEST_VAR2\": \"bar\"}, \
+		\"rabbits\":{\"rabbit1\": \"$(hostname)\"}}" &&
 	environment=$(flux job attach ${jobid}) &&
 	echo "$environment" | grep DWS_TEST_VAR1=foo &&
-	echo "$environment" | grep DWS_TEST_VAR2=bar
-'
+	echo "$environment" | grep DWS_TEST_VAR2=bar &&
+	echo "$environment" | grep FLUX_LOCAL_RABBIT=rabbit1
+	'
+
+test_expect_success 'shell: plugin sets env vars properly with multiple rabbits' '
+	jobid=$(flux submit -o userrc=$(pwd)/$USERRC_NAME \
+		--setattr=dw="foo" env) &&
+	kvsdir=$(flux job id --to=kvs $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog dws_environment \
+		"{\"variables\":{\"DWS_TEST_VAR1\": \"foo\", \"DWS_TEST_VAR2\": \"bar\"}, \
+		\"rabbits\":{\"rabbit96\": \"compute[265-1056]\", \"rabbit7\": \"compute[01-72]\", \
+		\"rabbit15\": \"$(hostname)\"}}" &&
+	environment=$(flux job attach ${jobid}) &&
+	echo "$environment" | grep DWS_TEST_VAR1=foo &&
+	echo "$environment" | grep DWS_TEST_VAR2=bar &&
+	echo "$environment" | grep FLUX_LOCAL_RABBIT=rabbit15
+	'
 
 test_done


### PR DESCRIPTION
As discussed in #104, export the hostname of the rabbit local to each compute node as the FLUX_LOCAL_RABBIT environment variable.