### PR TITLE
docker: fix kubernetes install

### DIFF
--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -11,8 +11,7 @@ RUN \
    && sudo usermod -G wheel $USER; \
  fi
 
-RUN sudo yum install -y python3-pip \
-    && sudo pip3 install kubernetes
+RUN sudo pip3 install kubernetes
 
 COPY ./kubectl.sh ./sync-kube-config.sh /usr/local/share/
 RUN sudo chmod 755 /usr/local/share/kubectl.sh \


### PR DESCRIPTION
Problem: the el8 container build fails because an updated pip expects a more recent version of python than is provided (which is 3.6) when installing the kubernetes package.

Remove a line which upgrades pip to a newer version, keeping the old version is compatible with Python 3.6.

Fixes #111.