### PR TITLE
dws: disable fluxion scheduling of rabbits

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -341,9 +341,7 @@ def _workflow_state_change_cb_inner(workflow, jobid, winfo, handle, k8s_api):
             "job-manager.dws.resource-update",
             payload={
                 "id": jobid,
-                "resources": directivebreakdown.apply_breakdowns(
-                    k8s_api, workflow, resources
-                ),
+                "resources": resources,
             },
         )
     elif state_complete(workflow, "Setup"):


### PR DESCRIPTION
Problem: fluxion scheduling of rabbits is working but requires some configuration changes on the machines it would be used on (LC's El Cap EA machines).

Disable fluxion scheduling temporarily until the config changes can be worked out.

This commit should be reverted before the next major release.