### PR TITLE
Draining rabbits

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -623,7 +623,6 @@ def main():
         raise
     populate_rabbits_dict(k8s_api)
     handle = flux.Flux()
-    services = register_services(handle, k8s_api)
     # create a timer watcher for killing workflows that have been stuck in
     # the "Error" state for too long
     handle.timer_watcher_create(
@@ -636,6 +635,7 @@ def main():
     # or new RPCs are received
     with Watchers(handle, watch_interval=args.watch_interval) as watchers:
         init_rabbits(k8s_api, handle, watchers, args.resourcegraph)
+        services = register_services(handle, k8s_api)
         watchers.add_watch(
             Watch(k8s_api, WORKFLOW_CRD, 0, workflow_state_change_cb, handle, k8s_api)
         )

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -16,6 +16,7 @@ import argparse
 import logging
 import pwd
 import time
+import pathlib
 
 import kubernetes as k8s
 from kubernetes.client.rest import ApiException
@@ -507,6 +508,13 @@ def setup_parsing():
         default=None,
         metavar="FILE",
         help="Path to kubeconfig file to use",
+    )
+    parser.add_argument(
+        "--resourcegraph",
+        "-r",
+        default=str(pathlib.Path("/etc/flux/system/R").absolute()),
+        metavar="FILE",
+        help="Path to file containing Fluxion JGF resource graph",
     )
     return parser
 

--- a/t/data/nnf-watch/down.yaml
+++ b/t/data/nnf-watch/down.yaml
@@ -1,3 +1,2 @@
-data:
-  capacity: 100000
-  status: NotReady
+spec:
+  state: Disabled

--- a/t/data/nnf-watch/up.yaml
+++ b/t/data/nnf-watch/up.yaml
@@ -1,3 +1,2 @@
-data:
-  capacity: 50000
-  status: Ready
+spec:
+  state: Enabled

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -48,7 +48,7 @@ test_expect_success 'exec dws service-providing script' '
 	DWS_JOBID=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws1.out --error=dws1.err \
-	        python ${DWS_MODULE_PATH} -e1 -v) &&
+	        python ${DWS_MODULE_PATH} -e1 -v -rR.local) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start
 '
 
@@ -184,7 +184,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v -rR.local) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '
@@ -240,7 +240,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v -rR.local) &&
 	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -14,10 +14,6 @@ DATA_DIR=${SHARNESS_TEST_SRCDIR}/data/nnf-watch/
 DWS_MODULE_PATH=${FLUX_SOURCE_DIR}/src/modules/coral2_dws.py
 RPC=${FLUX_BUILD_DIR}/t/util/rpc
 
-check_dmesg_for_pattern() {
-	flux dmesg | grep -q "$1" || return 1
-}
-
 if test_have_prereq NO_DWS_K8S; then
     skip_all='skipping DWS workflow tests due to no DWS K8s'
     test_done
@@ -27,12 +23,13 @@ test_expect_success 'job-manager: load alloc-bypass plugin' '
 	flux jobtap load alloc-bypass.so
 '
 
-test_expect_success 'exec nnf watching script' '
+test_expect_success 'exec Storage watching script' '
 	echo $PYTHONPATH >&2 &&
-	R=$(flux R encode -r 0) &&
+	flux R encode -l | flux python ${FLUX_SOURCE_DIR}/src/cmd/flux-dws2jgf.py \
+	--no-validate | jq . > R.local &&
 	jobid=$(flux submit \
-	        --setattr=system.alloc-bypass.R="$R" \
-	        -o per-resource.type=node flux python ${DWS_MODULE_PATH}) &&
+	        --setattr=system.alloc-bypass.R="$(cat R.local)" --output=dws.out --error=dws.err \
+	        -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start
 '
 
@@ -41,25 +38,26 @@ test_expect_success 'exec nnf watching script' '
 # is implemented/closed, this can be replaced with that solution.
 test_expect_success 'wait for service to register and send test RPC' '
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${jobid} exception &&
-	${RPC} "dws.watch_test" 
+	${RPC} "dws.watch_test"
 '
 
-test_expect_failure 'updating the NNF status is caught by the watch' '
-	flux dmesg -C &&
-	kubectl patch storages flux-test-storage0 \
-		--type merge --patch "$(cat ${DATA_DIR}/down.yaml)" &&
-	${RPC} "dws.watch_test" &&
-	check_dmesg_for_pattern "flux-test-storage0 status changed to NotReady" &&
-	check_dmesg_for_pattern "flux-test-storage0 capacity changed to 100000"
+test_expect_success 'updating the Storage status is caught by the watch' '
+	kubectl patch storages kind-worker2 \
+		--type merge --patch-file ${DATA_DIR}/down.yaml &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".spec.state == \"Disabled\"" &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.status == \"Disabled\"" &&
+	sleep 2 &&
+	grep "kind-worker2 as down, status is Disabled" dws.err
 '
 
-test_expect_failure 'revert the changes to the NNF' '
-	flux dmesg -C &&
-	kubectl patch storages flux-test-storage0 \
-		--type merge --patch "$(cat ${DATA_DIR}/up.yaml)" &&
-	${RPC} "dws.watch_test" &&
-	check_dmesg_for_pattern "flux-test-storage0 status changed to Ready" &&
-	check_dmesg_for_pattern "flux-test-storage0 capacity changed to 50000"
+test_expect_success 'revert the changes to the Storage' '
+	kubectl patch storages kind-worker2 \
+		--type merge --patch-file ${DATA_DIR}/up.yaml &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".spec.state == \"Enabled\"" &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.status == \"Ready\"" &&
+	sleep 2 &&
+	flux cancel $jobid &&
+	tail -n1 dws.err | grep "kind-worker2 as up"
 '
 
 test_done


### PR DESCRIPTION
Leverages functionality provided by [this flux-sched PR](https://github.com/flux-framework/flux-sched/pull/1110) to mark rabbits up or down based on status reported by Kubernetes 'Storage' objects.