### PR TITLE
cray-pals: edit LD_LIBRARY_PATH to avoid Flux libpmi2.so

### DIFF
--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -837,3 +837,5 @@ int flux_plugin_init (flux_plugin_t *p)
 
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -120,6 +120,14 @@ test_expect_success 'shell: cray-pals ignores LD_LIBRARY_PATH=/noexist' '
 	EOT
 	test_cmp libedit2.exp libedit2.out
 '
+test_expect_success 'shell: the -o cray-pals=no-edit-env shell option works' '
+	pmidir=$(dirname $(flux config builtin pmi_library_path)) &&
+	flux run -o pmi=cray-pals -o cray-pals.no-edit-env \
+	    -o userrc=$(pwd)/$USERRC_NAME --env=LD_LIBRARY_PATH=$pmidir \
+	    printenv LD_LIBRARY_PATH >libedit3.out &&
+	echo $pmidir >libedit3.exp &&
+	test_cmp libedit3.exp libedit3.out
+'
 
 test_expect_success 'shell: pals shell plugin sets environment' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 env) &&


### PR DESCRIPTION
Problem: it was proposed in flux-framework/flux-core#5714 that we should add the Flux PMI libdir to LD_LIBRARY_PATH in the job environment to improve the user experience, but that would break the `cray-pals` plugin which wouldn't be used if Cray MPICH finds Flux's `libpmi2.so` before its own.

In `cray-pals`, if LD_LIBRARY_PATH is found to include the Flux PMI libdir, edit it out.