### PR TITLE
configure: downgrade required kubernetes version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,9 +67,9 @@ AS_IF([test "x$enable_pylint" = "xyes"], [
 ])
 AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 AM_CHECK_PYMOD(kubernetes,
-                  [StrictVersion(kubernetes.__version__) >= StrictVersion('12.0.0')],
+                  [StrictVersion(kubernetes.__version__) >= StrictVersion('11.0.0')],
                   ,
-                  [AC_MSG_ERROR([could not find python module kubernetes, version 12.0.0+ required])]
+                  [AC_MSG_ERROR([could not find python module kubernetes, version 11.0.0+ required])]
                 )
 
 # Checks for header files.


### PR DESCRIPTION
Problem: LC EAS3 clusters have the python kubernetes package version 11.0.0, not anything higher.

The code appears to work with version 11, so downgrade the required version to 11.