### PR TITLE
test: request too much rabbit storage

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -364,7 +364,7 @@ def _workflow_state_change_cb_inner(workflow, jobid, winfo, handle, k8s_api):
             payload={
                 "id": jobid,
                 "resources": directivebreakdown.apply_breakdowns(
-                    k8s_api, workflow, resources
+                    k8s_api, workflow, resources, _MIN_ALLOCATION_SIZE
                 ),
             },
         ).then(log_rpc_response)

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -363,7 +363,9 @@ def _workflow_state_change_cb_inner(workflow, jobid, winfo, handle, k8s_api):
             "job-manager.dws.resource-update",
             payload={
                 "id": jobid,
-                "resources": resources,
+                "resources": directivebreakdown.apply_breakdowns(
+                    k8s_api, workflow, resources
+                ),
             },
         ).then(log_rpc_response)
     elif state_complete(workflow, "Setup"):

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -90,6 +90,18 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job wait-event -vt 15 ${jobid} clean
 '
 
+test_expect_success 'job requesting too much storage is rejected' '
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=1000TiB type=xfs name=project1" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-remove &&
+	sleep 60 && flux job eventlog ${jobid} &&
+	flux job wait-event -t 10 ${jobid} exception &&
+	flux job wait-event -vt 5 ${jobid} clean
+'
+
 test_expect_success 'job submission with multiple valid DW strings on different lines works' '
 	jobid=$(flux submit --setattr=system.dw="
 											 #DW jobdw capacity=10GiB type=xfs name=project1


### PR DESCRIPTION
Fluxion should reject jobs that request an infeasible amount of rabbit storage. However, [this commit](https://github.com/jameshcorbett/flux-coral2/commit/297f1fc167e00f353016e26333a3d33a85c54e68) disabled Fluxion scheduling of rabbits. Revert that commit, fix a problem with reverting that commit, and add a test for the expected behavior.