### PR TITLE
dws: enforce minimum rabbit allocation size

### DIFF
--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -94,7 +94,7 @@ test_expect_success 'job-manager: dws jobtap plugin works when job hits exceptio
 	jobid=$(flux submit --setattr=system.dw="foo" hostname) &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
-	flux job cancel $jobid
+	flux cancel $jobid
 	flux job wait-event -vt 1 ${jobid} exception &&
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
 		${jobid} prolog-finish &&

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -179,7 +179,7 @@ test_expect_success 'dws service kills workflows in Error properly' '
 '
 
 test_expect_success 'exec dws service-providing script with custom config path' '
-	flux job cancel ${DWS_JOBID} &&
+	flux cancel ${DWS_JOBID} &&
 	cp $REAL_HOME/.kube/config ./kubeconfig
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
@@ -236,7 +236,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
 		${jobid} prolog-start &&
 	flux job wait-event -vt 30 ${jobid} start &&
-	flux job cancel ${DWS_JOBID} &&
+	flux cancel ${DWS_JOBID} &&
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \
@@ -252,7 +252,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 test_expect_success 'cleanup: unload fluxion' '
 	# all jobs must be canceled before unloading fluxion or a hang will occur during
 	# shutdown, unless another scheduler is loaded afterwards
-	flux job cancel $DWS_JOBID && flux queue drain &&
+	flux cancel $DWS_JOBID && flux queue drain &&
 	flux module remove sched-fluxion-qmanager &&
 	flux module remove sched-fluxion-resource &&
 	flux module load sched-simple


### PR DESCRIPTION
This PR fixes one problem with rabbit allocations and alleviates another problem.

The fixed problem is that rabbit allocations have an implicit minimum size: allocations smaller than around 2 GiB fail or hang. Fix this by enforcing a configurable minimum size that defaults to 4GiB.

The alleviated problem is that lustre allocations are always split `N` ways for `N` the number of compute nodes. This means that sometimes a single rack will have many lustre allocations on it for a single job and lustre file system, when ideally all those allocations would be combined into one, thus saving some NVMe namespaces. However, this is a bit tricky due to the way DWS requires allocations to be specified; it's impossible to specify an allocation size for one rack independent of the size of the allocation on the other racks. However, allocation fragmentation can be reduced by finding the GCD of nodecounts on each rack and scaling up the allocation size accordingly.