### PR TITLE
dws2jgf: fix node attributes

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -79,7 +79,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            self._rank_to_properties.get(rank, []),
+            self._rank_to_properties.get(rank, {}),
             hPath,
         )
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
@@ -103,7 +103,7 @@ class Coral2Graph(FluxionResourceGraphV1):
                 True,
                 "GiB",
                 to_gibibytes(nnf["capacity"] // self._chunks_per_nnf),
-                [],
+                {},
                 f"{parent.path}/{res_name}",
             )
             edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
@@ -123,7 +123,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            [],
+            {},
             f"{parent.path}/{res_name}",
             1,  # status=1 marks the rabbits as 'down' initially
         )
@@ -145,7 +145,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            [],
+            {},
             f"{parent.path}/{res_name}",
         )
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
@@ -183,7 +183,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            [],
+            {},
             f"/{self._cluster_name}0",
         )
         self._add_and_tick_uniq_id(vtx)
@@ -226,8 +226,8 @@ def get_node_properties(properties):
     rank_to_property = {}
     for prop_name, idset_str in properties.items():
         for rank in IDset(idset_str):
-            properties = rank_to_property.setdefault(rank, [])
-            properties.append(prop_name)
+            properties = rank_to_property.setdefault(rank, {})
+            properties[prop_name] = ""
     return rank_to_property
 
 

--- a/t/data/dws2jgf/R-properties
+++ b/t/data/dws2jgf/R-properties
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "execution": {
+    "R_lite": [
+      {
+        "rank": "0",
+        "children": {
+          "core": "0-9"
+        }
+      }
+    ],
+    "starttime": 0,
+    "expiration": 0,
+    "nodelist": [
+      "compute-01"
+    ],
+    "properties": {
+      "pdebug": "0"
+    }
+  }
+}

--- a/t/data/dws2jgf/expected-compute-01-04.jgf
+++ b/t/data/dws2jgf/expected-compute-01-04.jgf
@@ -31,7 +31,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0"
             }
@@ -49,7 +49,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -67,7 +67,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
             },
@@ -86,7 +86,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
             }
@@ -104,7 +104,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
             }
@@ -122,7 +122,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
             }
@@ -140,7 +140,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
             }
@@ -158,7 +158,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
             }
@@ -176,7 +176,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
             }
@@ -194,7 +194,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
             }
@@ -212,7 +212,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
             }
@@ -230,7 +230,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
             }
@@ -248,7 +248,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
             }
@@ -266,7 +266,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
             }
@@ -284,7 +284,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
             }
@@ -302,7 +302,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
             }
@@ -320,7 +320,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
             }
@@ -338,7 +338,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
             }
@@ -356,7 +356,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
             }
@@ -374,7 +374,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
             }
@@ -392,7 +392,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
             }
@@ -410,7 +410,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
             }
@@ -428,7 +428,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
             }
@@ -446,7 +446,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
             }
@@ -464,7 +464,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
             }
@@ -482,7 +482,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
             }
@@ -500,7 +500,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
             }
@@ -518,7 +518,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
             }
@@ -536,7 +536,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
             }
@@ -554,7 +554,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
             }
@@ -572,7 +572,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
             }
@@ -590,7 +590,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
             }
@@ -608,7 +608,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
             }
@@ -626,7 +626,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
             }
@@ -644,7 +644,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
             }
@@ -662,7 +662,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01"
             }
@@ -770,7 +770,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02"
             }
@@ -878,7 +878,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03"
             }
@@ -986,7 +986,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1"
             }
@@ -1004,7 +1004,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
             },
@@ -1023,7 +1023,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
             }
@@ -1041,7 +1041,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
             }
@@ -1059,7 +1059,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
             }
@@ -1077,7 +1077,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
             }
@@ -1095,7 +1095,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
             }
@@ -1113,7 +1113,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
             }
@@ -1131,7 +1131,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
             }
@@ -1149,7 +1149,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
             }
@@ -1167,7 +1167,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
             }
@@ -1185,7 +1185,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
             }
@@ -1203,7 +1203,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
             }
@@ -1221,7 +1221,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
             }
@@ -1239,7 +1239,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
             }
@@ -1257,7 +1257,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
             }
@@ -1275,7 +1275,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
             }
@@ -1293,7 +1293,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
             }
@@ -1311,7 +1311,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
             }
@@ -1329,7 +1329,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
             }
@@ -1347,7 +1347,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
             }
@@ -1365,7 +1365,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
             }
@@ -1383,7 +1383,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
             }
@@ -1401,7 +1401,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
             }
@@ -1419,7 +1419,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
             }
@@ -1437,7 +1437,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
             }
@@ -1455,7 +1455,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
             }
@@ -1473,7 +1473,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
             }
@@ -1491,7 +1491,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
             }
@@ -1509,7 +1509,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
             }
@@ -1527,7 +1527,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
             }
@@ -1545,7 +1545,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
             }
@@ -1563,7 +1563,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
             }
@@ -1581,7 +1581,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
             }
@@ -1599,7 +1599,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04"
             }

--- a/t/data/dws2jgf/expected-compute-01.jgf
+++ b/t/data/dws2jgf/expected-compute-01.jgf
@@ -31,7 +31,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0"
             }
@@ -49,7 +49,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -67,7 +67,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
             },
@@ -86,7 +86,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
             }
@@ -104,7 +104,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
             }
@@ -122,7 +122,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
             }
@@ -140,7 +140,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
             }
@@ -158,7 +158,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
             }
@@ -176,7 +176,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
             }
@@ -194,7 +194,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
             }
@@ -212,7 +212,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
             }
@@ -230,7 +230,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
             }
@@ -248,7 +248,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
             }
@@ -266,7 +266,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
             }
@@ -284,7 +284,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
             }
@@ -302,7 +302,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
             }
@@ -320,7 +320,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
             }
@@ -338,7 +338,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
             }
@@ -356,7 +356,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
             }
@@ -374,7 +374,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
             }
@@ -392,7 +392,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
             }
@@ -410,7 +410,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
             }
@@ -428,7 +428,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
             }
@@ -446,7 +446,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
             }
@@ -464,7 +464,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
             }
@@ -482,7 +482,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
             }
@@ -500,7 +500,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
             }
@@ -518,7 +518,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
             }
@@ -536,7 +536,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
             }
@@ -554,7 +554,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
             }
@@ -572,7 +572,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
             }
@@ -590,7 +590,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
             }
@@ -608,7 +608,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
             }
@@ -626,7 +626,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
             }
@@ -644,7 +644,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
             }
@@ -662,7 +662,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01"
             }
@@ -698,7 +698,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1"
             }
@@ -716,7 +716,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
             },
@@ -735,7 +735,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
             }
@@ -753,7 +753,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
             }
@@ -771,7 +771,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
             }
@@ -789,7 +789,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
             }
@@ -807,7 +807,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
             }
@@ -825,7 +825,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
             }
@@ -843,7 +843,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
             }
@@ -861,7 +861,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
             }
@@ -879,7 +879,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
             }
@@ -897,7 +897,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
             }
@@ -915,7 +915,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
             }
@@ -933,7 +933,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
             }
@@ -951,7 +951,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
             }
@@ -969,7 +969,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
             }
@@ -987,7 +987,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
             }
@@ -1005,7 +1005,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
             }
@@ -1023,7 +1023,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
             }
@@ -1041,7 +1041,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
             }
@@ -1059,7 +1059,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
             }
@@ -1077,7 +1077,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
             }
@@ -1095,7 +1095,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
             }
@@ -1113,7 +1113,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
             }
@@ -1131,7 +1131,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
             }
@@ -1149,7 +1149,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
             }
@@ -1167,7 +1167,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
             }
@@ -1185,7 +1185,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
             }
@@ -1203,7 +1203,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
             }
@@ -1221,7 +1221,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
             }
@@ -1239,7 +1239,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
             }
@@ -1257,7 +1257,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
             }
@@ -1275,7 +1275,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
             }
@@ -1293,7 +1293,7 @@
             "exclusive": true,
             "unit": "GiB",
             "size": 1152,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
             }

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -3,17 +3,20 @@
   "execution": {
     "R_lite": [
       {
-        "rank": "0-9",
+        "rank": "0",
         "children": {
-          "core": "0-4"
+          "core": "0-9"
         }
       }
     ],
-    "starttime": 0.0,
-    "expiration": 0.0,
+    "starttime": 0,
+    "expiration": 0,
     "nodelist": [
-      "compute-[01-04],nodws[0-5]"
-    ]
+      "compute-01"
+    ],
+    "properties": {
+      "pdebug": "0"
+    }
   },
   "scheduling": {
     "graph": {
@@ -662,7 +665,9 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": {
+              "pdebug": ""
+            },
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01"
             }
@@ -761,18 +766,18 @@
         {
           "id": "41",
           "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "compute-02",
-            "id": 2,
+            "type": "core",
+            "basename": "core",
+            "name": "core5",
+            "id": 5,
             "uniq_id": 41,
-            "rank": 1,
+            "rank": 0,
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": [],
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02"
+              "containment": "/ElCapitan0/rack0/compute-01/core5"
             }
           }
         },
@@ -781,16 +786,16 @@
           "metadata": {
             "type": "core",
             "basename": "core",
-            "name": "core0",
-            "id": 0,
+            "name": "core6",
+            "id": 6,
             "uniq_id": 42,
-            "rank": 1,
+            "rank": 0,
             "exclusive": true,
             "unit": "",
             "size": 1,
             "properties": [],
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core0"
+              "containment": "/ElCapitan0/rack0/compute-01/core6"
             }
           }
         },
@@ -799,16 +804,16 @@
           "metadata": {
             "type": "core",
             "basename": "core",
-            "name": "core1",
-            "id": 1,
+            "name": "core7",
+            "id": 7,
             "uniq_id": 43,
-            "rank": 1,
+            "rank": 0,
             "exclusive": true,
             "unit": "",
             "size": 1,
             "properties": [],
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core1"
+              "containment": "/ElCapitan0/rack0/compute-01/core7"
             }
           }
         },
@@ -817,16 +822,16 @@
           "metadata": {
             "type": "core",
             "basename": "core",
-            "name": "core2",
-            "id": 2,
+            "name": "core8",
+            "id": 8,
             "uniq_id": 44,
-            "rank": 1,
+            "rank": 0,
             "exclusive": true,
             "unit": "",
             "size": 1,
             "properties": [],
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core2"
+              "containment": "/ElCapitan0/rack0/compute-01/core8"
             }
           }
         },
@@ -835,153 +840,27 @@
           "metadata": {
             "type": "core",
             "basename": "core",
-            "name": "core3",
-            "id": 3,
+            "name": "core9",
+            "id": 9,
             "uniq_id": 45,
-            "rank": 1,
+            "rank": 0,
             "exclusive": true,
             "unit": "",
             "size": 1,
             "properties": [],
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core3"
+              "containment": "/ElCapitan0/rack0/compute-01/core9"
             }
           }
         },
         {
           "id": "46",
           "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 46,
-            "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core4"
-            }
-          }
-        },
-        {
-          "id": "47",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "compute-03",
-            "id": 3,
-            "uniq_id": 47,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03"
-            }
-          }
-        },
-        {
-          "id": "48",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 48,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core0"
-            }
-          }
-        },
-        {
-          "id": "49",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 49,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core1"
-            }
-          }
-        },
-        {
-          "id": "50",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 50,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core2"
-            }
-          }
-        },
-        {
-          "id": "51",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 51,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core3"
-            }
-          }
-        },
-        {
-          "id": "52",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 52,
-            "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core4"
-            }
-          }
-        },
-        {
-          "id": "53",
-          "metadata": {
             "type": "rack",
             "basename": "rack",
             "name": "rack1",
             "id": 1,
-            "uniq_id": 53,
+            "uniq_id": 46,
             "rank": -1,
             "exclusive": true,
             "unit": "",
@@ -993,13 +872,13 @@
           }
         },
         {
-          "id": "54",
+          "id": "47",
           "metadata": {
             "type": "rabbit",
             "basename": "rabbit",
             "name": "rabbit-kind-worker3",
             "id": 1,
-            "uniq_id": 54,
+            "uniq_id": 47,
             "rank": -1,
             "exclusive": true,
             "unit": "",
@@ -1012,13 +891,13 @@
           }
         },
         {
-          "id": "55",
+          "id": "48",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd0",
             "id": 0,
-            "uniq_id": 55,
+            "uniq_id": 48,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1030,13 +909,13 @@
           }
         },
         {
-          "id": "56",
+          "id": "49",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd1",
             "id": 1,
-            "uniq_id": 56,
+            "uniq_id": 49,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1048,13 +927,13 @@
           }
         },
         {
-          "id": "57",
+          "id": "50",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd2",
             "id": 2,
-            "uniq_id": 57,
+            "uniq_id": 50,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1066,13 +945,13 @@
           }
         },
         {
-          "id": "58",
+          "id": "51",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd3",
             "id": 3,
-            "uniq_id": 58,
+            "uniq_id": 51,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1084,13 +963,13 @@
           }
         },
         {
-          "id": "59",
+          "id": "52",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd4",
             "id": 4,
-            "uniq_id": 59,
+            "uniq_id": 52,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1102,13 +981,13 @@
           }
         },
         {
-          "id": "60",
+          "id": "53",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd5",
             "id": 5,
-            "uniq_id": 60,
+            "uniq_id": 53,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1120,13 +999,13 @@
           }
         },
         {
-          "id": "61",
+          "id": "54",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd6",
             "id": 6,
-            "uniq_id": 61,
+            "uniq_id": 54,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1138,13 +1017,13 @@
           }
         },
         {
-          "id": "62",
+          "id": "55",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd7",
             "id": 7,
-            "uniq_id": 62,
+            "uniq_id": 55,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1156,13 +1035,13 @@
           }
         },
         {
-          "id": "63",
+          "id": "56",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd8",
             "id": 8,
-            "uniq_id": 63,
+            "uniq_id": 56,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1174,13 +1053,13 @@
           }
         },
         {
-          "id": "64",
+          "id": "57",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd9",
             "id": 9,
-            "uniq_id": 64,
+            "uniq_id": 57,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1192,13 +1071,13 @@
           }
         },
         {
-          "id": "65",
+          "id": "58",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd10",
             "id": 10,
-            "uniq_id": 65,
+            "uniq_id": 58,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1210,13 +1089,13 @@
           }
         },
         {
-          "id": "66",
+          "id": "59",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd11",
             "id": 11,
-            "uniq_id": 66,
+            "uniq_id": 59,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1228,13 +1107,13 @@
           }
         },
         {
-          "id": "67",
+          "id": "60",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd12",
             "id": 12,
-            "uniq_id": 67,
+            "uniq_id": 60,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1246,13 +1125,13 @@
           }
         },
         {
-          "id": "68",
+          "id": "61",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd13",
             "id": 13,
-            "uniq_id": 68,
+            "uniq_id": 61,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1264,13 +1143,13 @@
           }
         },
         {
-          "id": "69",
+          "id": "62",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd14",
             "id": 14,
-            "uniq_id": 69,
+            "uniq_id": 62,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1282,13 +1161,13 @@
           }
         },
         {
-          "id": "70",
+          "id": "63",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd15",
             "id": 15,
-            "uniq_id": 70,
+            "uniq_id": 63,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1300,13 +1179,13 @@
           }
         },
         {
-          "id": "71",
+          "id": "64",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd16",
             "id": 16,
-            "uniq_id": 71,
+            "uniq_id": 64,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1318,13 +1197,13 @@
           }
         },
         {
-          "id": "72",
+          "id": "65",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd17",
             "id": 17,
-            "uniq_id": 72,
+            "uniq_id": 65,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1336,13 +1215,13 @@
           }
         },
         {
-          "id": "73",
+          "id": "66",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd18",
             "id": 18,
-            "uniq_id": 73,
+            "uniq_id": 66,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1354,13 +1233,13 @@
           }
         },
         {
-          "id": "74",
+          "id": "67",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd19",
             "id": 19,
-            "uniq_id": 74,
+            "uniq_id": 67,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1372,13 +1251,13 @@
           }
         },
         {
-          "id": "75",
+          "id": "68",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd20",
             "id": 20,
-            "uniq_id": 75,
+            "uniq_id": 68,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1390,13 +1269,13 @@
           }
         },
         {
-          "id": "76",
+          "id": "69",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd21",
             "id": 21,
-            "uniq_id": 76,
+            "uniq_id": 69,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1408,13 +1287,13 @@
           }
         },
         {
-          "id": "77",
+          "id": "70",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd22",
             "id": 22,
-            "uniq_id": 77,
+            "uniq_id": 70,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1426,13 +1305,13 @@
           }
         },
         {
-          "id": "78",
+          "id": "71",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd23",
             "id": 23,
-            "uniq_id": 78,
+            "uniq_id": 71,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1444,13 +1323,13 @@
           }
         },
         {
-          "id": "79",
+          "id": "72",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd24",
             "id": 24,
-            "uniq_id": 79,
+            "uniq_id": 72,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1462,13 +1341,13 @@
           }
         },
         {
-          "id": "80",
+          "id": "73",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd25",
             "id": 25,
-            "uniq_id": 80,
+            "uniq_id": 73,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1480,13 +1359,13 @@
           }
         },
         {
-          "id": "81",
+          "id": "74",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd26",
             "id": 26,
-            "uniq_id": 81,
+            "uniq_id": 74,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1498,13 +1377,13 @@
           }
         },
         {
-          "id": "82",
+          "id": "75",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd27",
             "id": 27,
-            "uniq_id": 82,
+            "uniq_id": 75,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1516,13 +1395,13 @@
           }
         },
         {
-          "id": "83",
+          "id": "76",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd28",
             "id": 28,
-            "uniq_id": 83,
+            "uniq_id": 76,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1534,13 +1413,13 @@
           }
         },
         {
-          "id": "84",
+          "id": "77",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd29",
             "id": 29,
-            "uniq_id": 84,
+            "uniq_id": 77,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1552,13 +1431,13 @@
           }
         },
         {
-          "id": "85",
+          "id": "78",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd30",
             "id": 30,
-            "uniq_id": 85,
+            "uniq_id": 78,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1570,13 +1449,13 @@
           }
         },
         {
-          "id": "86",
+          "id": "79",
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
             "name": "ssd31",
             "id": 31,
-            "uniq_id": 86,
+            "uniq_id": 79,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
@@ -1584,762 +1463,6 @@
             "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
-            }
-          }
-        },
-        {
-          "id": "87",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "compute-04",
-            "id": 4,
-            "uniq_id": 87,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04"
-            }
-          }
-        },
-        {
-          "id": "88",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 88,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core0"
-            }
-          }
-        },
-        {
-          "id": "89",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 89,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core1"
-            }
-          }
-        },
-        {
-          "id": "90",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 90,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core2"
-            }
-          }
-        },
-        {
-          "id": "91",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 91,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core3"
-            }
-          }
-        },
-        {
-          "id": "92",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 92,
-            "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core4"
-            }
-          }
-        },
-        {
-          "id": "93",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws0",
-            "id": 0,
-            "uniq_id": 93,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws0"
-            }
-          }
-        },
-        {
-          "id": "94",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 94,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws0/core0"
-            }
-          }
-        },
-        {
-          "id": "95",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 95,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws0/core1"
-            }
-          }
-        },
-        {
-          "id": "96",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 96,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws0/core2"
-            }
-          }
-        },
-        {
-          "id": "97",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 97,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws0/core3"
-            }
-          }
-        },
-        {
-          "id": "98",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 98,
-            "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws0/core4"
-            }
-          }
-        },
-        {
-          "id": "99",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws1",
-            "id": 1,
-            "uniq_id": 99,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws1"
-            }
-          }
-        },
-        {
-          "id": "100",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 100,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws1/core0"
-            }
-          }
-        },
-        {
-          "id": "101",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 101,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws1/core1"
-            }
-          }
-        },
-        {
-          "id": "102",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 102,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws1/core2"
-            }
-          }
-        },
-        {
-          "id": "103",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 103,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws1/core3"
-            }
-          }
-        },
-        {
-          "id": "104",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 104,
-            "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws1/core4"
-            }
-          }
-        },
-        {
-          "id": "105",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws2",
-            "id": 2,
-            "uniq_id": 105,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws2"
-            }
-          }
-        },
-        {
-          "id": "106",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 106,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws2/core0"
-            }
-          }
-        },
-        {
-          "id": "107",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 107,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws2/core1"
-            }
-          }
-        },
-        {
-          "id": "108",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 108,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws2/core2"
-            }
-          }
-        },
-        {
-          "id": "109",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 109,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws2/core3"
-            }
-          }
-        },
-        {
-          "id": "110",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 110,
-            "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws2/core4"
-            }
-          }
-        },
-        {
-          "id": "111",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws3",
-            "id": 3,
-            "uniq_id": 111,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws3"
-            }
-          }
-        },
-        {
-          "id": "112",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 112,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws3/core0"
-            }
-          }
-        },
-        {
-          "id": "113",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 113,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws3/core1"
-            }
-          }
-        },
-        {
-          "id": "114",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 114,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws3/core2"
-            }
-          }
-        },
-        {
-          "id": "115",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 115,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws3/core3"
-            }
-          }
-        },
-        {
-          "id": "116",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 116,
-            "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws3/core4"
-            }
-          }
-        },
-        {
-          "id": "117",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws4",
-            "id": 4,
-            "uniq_id": 117,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws4"
-            }
-          }
-        },
-        {
-          "id": "118",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 118,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws4/core0"
-            }
-          }
-        },
-        {
-          "id": "119",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 119,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws4/core1"
-            }
-          }
-        },
-        {
-          "id": "120",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 120,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws4/core2"
-            }
-          }
-        },
-        {
-          "id": "121",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 121,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws4/core3"
-            }
-          }
-        },
-        {
-          "id": "122",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 122,
-            "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws4/core4"
-            }
-          }
-        },
-        {
-          "id": "123",
-          "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "nodws5",
-            "id": 5,
-            "uniq_id": 123,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/nodws5"
-            }
-          }
-        },
-        {
-          "id": "124",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core0",
-            "id": 0,
-            "uniq_id": 124,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws5/core0"
-            }
-          }
-        },
-        {
-          "id": "125",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core1",
-            "id": 1,
-            "uniq_id": 125,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws5/core1"
-            }
-          }
-        },
-        {
-          "id": "126",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core2",
-            "id": 2,
-            "uniq_id": 126,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws5/core2"
-            }
-          }
-        },
-        {
-          "id": "127",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core3",
-            "id": 3,
-            "uniq_id": 127,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws5/core3"
-            }
-          }
-        },
-        {
-          "id": "128",
-          "metadata": {
-            "type": "core",
-            "basename": "core",
-            "name": "core4",
-            "id": 4,
-            "uniq_id": 128,
-            "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": [],
-            "paths": {
-              "containment": "/ElCapitan0/nodws5/core4"
             }
           }
         }
@@ -2746,7 +1869,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "35",
           "target": "41",
           "directed": true,
           "metadata": {
@@ -2756,7 +1879,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "35",
           "target": "42",
           "directed": true,
           "metadata": {
@@ -2766,7 +1889,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "35",
           "target": "43",
           "directed": true,
           "metadata": {
@@ -2776,7 +1899,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "35",
           "target": "44",
           "directed": true,
           "metadata": {
@@ -2786,7 +1909,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "35",
           "target": "45",
           "directed": true,
           "metadata": {
@@ -2796,7 +1919,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "0",
           "target": "46",
           "directed": true,
           "metadata": {
@@ -2806,7 +1929,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "46",
           "target": "47",
           "directed": true,
           "metadata": {
@@ -2866,7 +1989,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "47",
           "target": "53",
           "directed": true,
           "metadata": {
@@ -2876,7 +1999,7 @@
           }
         },
         {
-          "source": "53",
+          "source": "47",
           "target": "54",
           "directed": true,
           "metadata": {
@@ -2886,7 +2009,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "55",
           "directed": true,
           "metadata": {
@@ -2896,7 +2019,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "56",
           "directed": true,
           "metadata": {
@@ -2906,7 +2029,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "57",
           "directed": true,
           "metadata": {
@@ -2916,7 +2039,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "58",
           "directed": true,
           "metadata": {
@@ -2926,7 +2049,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "59",
           "directed": true,
           "metadata": {
@@ -2936,7 +2059,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "60",
           "directed": true,
           "metadata": {
@@ -2946,7 +2069,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "61",
           "directed": true,
           "metadata": {
@@ -2956,7 +2079,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "62",
           "directed": true,
           "metadata": {
@@ -2966,7 +2089,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "63",
           "directed": true,
           "metadata": {
@@ -2976,7 +2099,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "64",
           "directed": true,
           "metadata": {
@@ -2986,7 +2109,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "65",
           "directed": true,
           "metadata": {
@@ -2996,7 +2119,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "66",
           "directed": true,
           "metadata": {
@@ -3006,7 +2129,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "67",
           "directed": true,
           "metadata": {
@@ -3016,7 +2139,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "68",
           "directed": true,
           "metadata": {
@@ -3026,7 +2149,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "69",
           "directed": true,
           "metadata": {
@@ -3036,7 +2159,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "70",
           "directed": true,
           "metadata": {
@@ -3046,7 +2169,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "71",
           "directed": true,
           "metadata": {
@@ -3056,7 +2179,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "72",
           "directed": true,
           "metadata": {
@@ -3066,7 +2189,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "73",
           "directed": true,
           "metadata": {
@@ -3076,7 +2199,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "74",
           "directed": true,
           "metadata": {
@@ -3086,7 +2209,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "75",
           "directed": true,
           "metadata": {
@@ -3096,7 +2219,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "76",
           "directed": true,
           "metadata": {
@@ -3106,7 +2229,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "77",
           "directed": true,
           "metadata": {
@@ -3116,7 +2239,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "78",
           "directed": true,
           "metadata": {
@@ -3126,498 +2249,8 @@
           }
         },
         {
-          "source": "54",
+          "source": "47",
           "target": "79",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "80",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "81",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "82",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "83",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "84",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "85",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "54",
-          "target": "86",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "53",
-          "target": "87",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "87",
-          "target": "88",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "87",
-          "target": "89",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "87",
-          "target": "90",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "87",
-          "target": "91",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "87",
-          "target": "92",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "93",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "93",
-          "target": "94",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "93",
-          "target": "95",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "93",
-          "target": "96",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "93",
-          "target": "97",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "93",
-          "target": "98",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "99",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "99",
-          "target": "100",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "99",
-          "target": "101",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "99",
-          "target": "102",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "99",
-          "target": "103",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "99",
-          "target": "104",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "105",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "105",
-          "target": "106",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "105",
-          "target": "107",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "105",
-          "target": "108",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "105",
-          "target": "109",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "105",
-          "target": "110",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "111",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "111",
-          "target": "112",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "111",
-          "target": "113",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "111",
-          "target": "114",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "111",
-          "target": "115",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "111",
-          "target": "116",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "117",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "117",
-          "target": "118",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "117",
-          "target": "119",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "117",
-          "target": "120",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "117",
-          "target": "121",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "117",
-          "target": "122",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "0",
-          "target": "123",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "123",
-          "target": "124",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "123",
-          "target": "125",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "123",
-          "target": "126",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "123",
-          "target": "127",
-          "directed": true,
-          "metadata": {
-            "name": {
-              "containment": "contains"
-            }
-          }
-        },
-        {
-          "source": "123",
-          "target": "128",
           "directed": true,
           "metadata": {
             "name": {

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -50,6 +50,12 @@ test_expect_success HAVE_JQ 'flux-dws2jgf.py outputs expected JGF for compute no
 	test_cmp ${DATADIR}/expected-compute-01-nodws.jgf actual-compute-01-nodws.jgf
 '
 
+test_expect_success HAVE_JQ 'flux-dws2jgf.py handles properties correctly' '
+	cat ${DATADIR}/R-properties | \
+	flux python ${CMD} --no-validate | jq . > actual-properties.jgf &&
+	test_cmp ${DATADIR}/expected-properties.jgf actual-properties.jgf
+'
+
 test_expect_success HAVE_JQ 'fluxion rejects a rack/rabbit job when no rabbits are recognized' '
 	flux module remove -f sched-fluxion-qmanager &&
 	flux module remove -f sched-fluxion-resource &&


### PR DESCRIPTION
Problem: flux-dws2jgf writes out vertex properties as a python list,
but Fluxion's JGF reader expects a JSON object.

Write out properties as keys in a mapping with empty string values.

See also https://github.com/flux-framework/flux-sched/pull/1149.