### PR TITLE
dws-jobtap: fix race conditions with exception-raising

### DIFF
--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -46,10 +46,11 @@ def post_run_cb(fh, t, msg, arg):
     if args.post_run_fail:
         payload['errstr'] = "post_run RPC failed for test purposes"
     fh.respond(msg, payload)
-    fh.rpc(
-        "job-manager.dws.epilog-remove",
-        payload={"id": msg.payload["jobid"]},
-    )
+    if not args.post_run_fail:
+        fh.rpc(
+            "job-manager.dws.epilog-remove",
+            payload={"id": msg.payload["jobid"]},
+        )
     fh.reactor_stop()
 
 fh = flux.Flux()

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -69,6 +69,6 @@ fi
 
 test $RANK -ne 0 || flux admin cleanup-push <<-EOT
 	flux queue stop
-	flux job cancelall -f --states RUN
+	flux cancel --all --states RUN
 	flux queue idle
 EOT


### PR DESCRIPTION
Problem: the `dws-jobtap` plugin has a race condition in its exception-raising logic. 