### PR TITLE
dws: fix floating-point truncation

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -237,8 +237,8 @@ def setup_cb(handle, _t, msg, k8s_api):
                     == directivebreakdown.AllocationStrategy.ACROSS_SERVERS.value
                 ):
                     nodecount_gcd = functools.reduce(math.gcd, nodes_per_nnf.values())
-                    server_alloc_set["allocationSize"] = (
-                        nodecount_gcd * alloc_set["minimumCapacity"] // len(hlist)
+                    server_alloc_set["allocationSize"] = math.ceil(
+                        nodecount_gcd * alloc_set["minimumCapacity"] / len(hlist)
                     )
                     # split lustre across every rabbit, weighting the split based on
                     # the number of the job's nodes associated with each rabbit


### PR DESCRIPTION
Problem: when splitting an allocation across multiple rabbits, the size of each individual allocation must not be rounded down or the total size may not meet the minimum required.

Round up instead of rounding down when splitting allocations.