### PR TITLE
test: update expected JGF after fluxion update

### DIFF
--- a/t/data/dws2jgf/expected-compute-01-04.jgf
+++ b/t/data/dws2jgf/expected-compute-01-04.jgf
@@ -680,7 +680,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core0"
             }
@@ -698,7 +698,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core1"
             }
@@ -716,7 +716,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core2"
             }
@@ -734,7 +734,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core3"
             }
@@ -752,7 +752,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core4"
             }
@@ -788,7 +788,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core0"
             }
@@ -806,7 +806,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core1"
             }
@@ -824,7 +824,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core2"
             }
@@ -842,7 +842,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core3"
             }
@@ -860,7 +860,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core4"
             }
@@ -896,7 +896,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core0"
             }
@@ -914,7 +914,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core1"
             }
@@ -932,7 +932,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core2"
             }
@@ -950,7 +950,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core3"
             }
@@ -968,7 +968,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core4"
             }
@@ -1617,7 +1617,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core0"
             }
@@ -1635,7 +1635,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core1"
             }
@@ -1653,7 +1653,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core2"
             }
@@ -1671,7 +1671,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core3"
             }
@@ -1689,7 +1689,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core4"
             }

--- a/t/data/dws2jgf/expected-compute-01-nodws.jgf
+++ b/t/data/dws2jgf/expected-compute-01-nodws.jgf
@@ -680,7 +680,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core0"
             }
@@ -698,7 +698,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core1"
             }
@@ -716,7 +716,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core2"
             }
@@ -734,7 +734,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core3"
             }
@@ -752,7 +752,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core4"
             }
@@ -788,7 +788,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core0"
             }
@@ -806,7 +806,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core1"
             }
@@ -824,7 +824,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core2"
             }
@@ -842,7 +842,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core3"
             }
@@ -860,7 +860,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-02/core4"
             }
@@ -896,7 +896,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core0"
             }
@@ -914,7 +914,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core1"
             }
@@ -932,7 +932,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core2"
             }
@@ -950,7 +950,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core3"
             }
@@ -968,7 +968,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-03/core4"
             }
@@ -1617,7 +1617,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core0"
             }
@@ -1635,7 +1635,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core1"
             }
@@ -1653,7 +1653,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core2"
             }
@@ -1671,7 +1671,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core3"
             }
@@ -1689,7 +1689,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack1/compute-04/core4"
             }
@@ -1725,7 +1725,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws0/core0"
             }
@@ -1743,7 +1743,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws0/core1"
             }
@@ -1761,7 +1761,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws0/core2"
             }
@@ -1779,7 +1779,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws0/core3"
             }
@@ -1797,7 +1797,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws0/core4"
             }
@@ -1833,7 +1833,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws1/core0"
             }
@@ -1851,7 +1851,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws1/core1"
             }
@@ -1869,7 +1869,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws1/core2"
             }
@@ -1887,7 +1887,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws1/core3"
             }
@@ -1905,7 +1905,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws1/core4"
             }
@@ -1941,7 +1941,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws2/core0"
             }
@@ -1959,7 +1959,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws2/core1"
             }
@@ -1977,7 +1977,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws2/core2"
             }
@@ -1995,7 +1995,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws2/core3"
             }
@@ -2013,7 +2013,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws2/core4"
             }
@@ -2049,7 +2049,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws3/core0"
             }
@@ -2067,7 +2067,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws3/core1"
             }
@@ -2085,7 +2085,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws3/core2"
             }
@@ -2103,7 +2103,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws3/core3"
             }
@@ -2121,7 +2121,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws3/core4"
             }
@@ -2157,7 +2157,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws4/core0"
             }
@@ -2175,7 +2175,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws4/core1"
             }
@@ -2193,7 +2193,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws4/core2"
             }
@@ -2211,7 +2211,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws4/core3"
             }
@@ -2229,7 +2229,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws4/core4"
             }
@@ -2265,7 +2265,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws5/core0"
             }
@@ -2283,7 +2283,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws5/core1"
             }
@@ -2301,7 +2301,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws5/core2"
             }
@@ -2319,7 +2319,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws5/core3"
             }
@@ -2337,7 +2337,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/nodws5/core4"
             }

--- a/t/data/dws2jgf/expected-compute-01.jgf
+++ b/t/data/dws2jgf/expected-compute-01.jgf
@@ -680,7 +680,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core0"
             }

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -685,7 +685,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core0"
             }
@@ -703,7 +703,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core1"
             }
@@ -721,7 +721,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core2"
             }
@@ -739,7 +739,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core3"
             }
@@ -757,7 +757,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core4"
             }
@@ -775,7 +775,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core5"
             }
@@ -793,7 +793,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core6"
             }
@@ -811,7 +811,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core7"
             }
@@ -829,7 +829,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core8"
             }
@@ -847,7 +847,7 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": [],
+            "properties": {},
             "paths": {
               "containment": "/ElCapitan0/rack0/compute-01/core9"
             }


### PR DESCRIPTION
With https://github.com/flux-framework/flux-sched/pull/1149, Fluxion has updated the way it writes out vertex properties. It now writes them out (correctly) as a mapping instead of a list.

Update the expected JGFs generated by flux-dws2jgf.