### PR TITLE
Handle rabbits with no computes

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -151,7 +151,7 @@ class Coral2Graph(FluxionResourceGraphV1):
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
         self._add_and_tick_uniq_id(vtx, edg)
         self._encode_rabbit(vtx, nnf)
-        for node in nnf["status"]["access"]["computes"]:
+        for node in nnf["status"]["access"].get("computes", []):
             try:
                 index = self._r_hostlist.index(node["name"])[0]
             except FileNotFoundError:
@@ -193,7 +193,7 @@ class Coral2Graph(FluxionResourceGraphV1):
         dws_computes = set(
             compute["name"]
             for nnf in self._nnfs
-            for compute in nnf["status"]["access"]["computes"]
+            for compute in nnf["status"]["access"].get("computes", [])
         )
         dws_computes |= set(nnf["metadata"]["name"] for nnf in self._nnfs)
         for rank, node in enumerate(self._r_hostlist):
@@ -303,7 +303,7 @@ def main():
     dws_computes = set(
         compute["name"]
         for nnf in nnfs
-        for compute in nnf["status"]["access"]["computes"]
+        for compute in nnf["status"]["access"].get("computes", [])
     )
     if not args.no_validate and not dws_computes <= set(r_hostlist):
         raise RuntimeError(

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -491,7 +491,7 @@ def rabbit_state_change_cb(event, handle, rabbit_rpaths, disable_draining):
         return
     mark_rabbit(handle, status, rabbit_rpaths[name])
     drain_offline_nodes(
-        handle, name, rabbit["status"]["access"]["computes"], disable_draining
+        handle, name, rabbit["status"]["access"].get("computes", []), disable_draining
     )
     # TODO: add some check for whether rabbit capacity has changed
     # TODO: update capacity of rabbit in resource graph (mark some slices down?)
@@ -531,9 +531,10 @@ def init_rabbits(k8s_api, handle, watchers, graph_path, disable_draining):
             LOGGER.error(
                 "Encountered an unknown Storage object '%s' in the event stream", name
             )
-        mark_rabbit(handle, rabbit["status"]["status"], rabbit_rpaths[name])
+        else:
+            mark_rabbit(handle, rabbit["status"]["status"], rabbit_rpaths[name])
         drain_offline_nodes(
-            handle, name, rabbit["status"]["access"]["computes"], disable_draining
+            handle, name, rabbit["status"]["access"].get("computes", []), disable_draining
         )
     watchers.add_watch(
         Watch(


### PR DESCRIPTION
Problem: flux-dws2jgf assumes storages always have a
`.status.access.computes` field, but recent experience on rzvernal
has shown this to be false.

Make .status.access.computes optional.