### PR TITLE
dws: fix rabbit name manipulation logic

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -505,9 +505,12 @@ def map_rabbits_to_fluxion_paths(graph_path):
     for vertex in nodes:
         metadata = vertex["metadata"]
         if metadata["type"] == "rabbit":
-            rabbit_rpaths[metadata["name"].strip("rabbit-")] = metadata["paths"][
-                "containment"
-            ]
+            # strip off 'rabbit-' prefix
+            if metadata["name"].startswith("rabbit-"):
+                name = metadata["name"][len("rabbit-") :]
+            else:
+                name = metadata["name"]
+            rabbit_rpaths[name] = metadata["paths"]["containment"]
     return rabbit_rpaths
 
 


### PR DESCRIPTION
Problem: coral2_dws tries to strip a 'rabbit-' prefix from the names
of rabbit vertices it finds in JGF. However, it uses the str.strip()
method incorrectly and in fact strips the characters 'r', 'a', 'b',
'i', 't', and '-' from the beginning and end of the rabbit name.

Strip the prefix correctly.