### PR TITLE
k8s watch exception handling

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -8,6 +8,7 @@ Data Workflow Services is DWS for short.
 """
 
 import os
+import sys
 import syslog
 import json
 import re

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -33,10 +33,10 @@ test_expect_success 'job-manager: load dws-jobtap plugin' '
 '
 
 test_expect_success 'exec dws service-providing script with bad arguments' '
-    KUBECONFIG=/dev/null test_expect_code 1 flux python ${DWS_MODULE_PATH} \
+    KUBECONFIG=/dev/null test_expect_code 3 flux python ${DWS_MODULE_PATH} \
         -e1 -v -rR.local &&
     unset KUBECONFIG &&
-    test_expect_code 1 flux python ${DWS_MODULE_PATH} -e1 -v -rR.local \
+    test_expect_code 3 flux python ${DWS_MODULE_PATH} -e1 -v -rR.local \
         --kubeconfig /dev/null &&
     test_expect_code 2 flux python ${DWS_MODULE_PATH} \
         -e1 -v -rR.local --foobar


### PR DESCRIPTION
Problem: while watching for k8s resources, a resourceversion > 0
is required. When there are only old resources lying around and
no new ones, the resourceversion will be > 0 but too old for
kubernetes to accept it, and an exception may be raised.

Catch the exception and set the resource version to 0.