### PR TITLE
dws2jgf: use sorted hostlist to determine ranks

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -299,7 +299,7 @@ def main():
 
     input_r = json.load(sys.stdin)
     nnfs = [x for x in get_storage()["items"]]
-    r_hostlist = Hostlist(input_r["execution"]["nodelist"])
+    r_hostlist = Hostlist(input_r["execution"]["nodelist"]).sort()
     dws_computes = set(
         compute["name"]
         for nnf in nnfs


### PR DESCRIPTION
Problem: the dws2jgf script does not sort the hostlist it uses to determine the ranks of nodes, leading to mixups if the hostlist is not already sorted.

Sort the hostlist.