### PR TITLE
Revert docker home mount and change hostname

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -12,7 +12,7 @@ BASE_DOCKER_REPO=fluxrm/flux-sched
 
 IMAGE=focal
 JOBS=2
-MOUNT_HOME_ARGS="--volume=$HOME:$HOME -e HOME"
+MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 MOUNT_KUBE_ARGS="--volume=$HOME/.kube:/usr/local/share/kube-localhost"
 
 if test "$PROJECT" = "flux-core"; then
@@ -134,7 +134,7 @@ checks_group "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
     || die "docker build failed"
 
 if [[ -n "$MOUNT_HOME_ARGS" ]]; then
-    echo "mounting $HOME as $HOME"
+    echo "mounting $HOME as /home/$USER"
 fi
 if [[ -n "$MOUNT_KUBE_ARGS" ]]; then
     echo "mounting kube config inside container with ${MOUNT_KUBE_ARGS}"

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -170,6 +170,7 @@ else
         --volume=$TOP:/usr/src \
         $MOUNT_HOME_ARGS \
         $MOUNT_KUBE_ARGS \
+        -h compute-01 \
         -e CC \
         -e CXX \
         -e LDFLAGS \


### PR DESCRIPTION
PR #154 was opened too hastily. By default, `kubectl` (which is used all over the place in flux-coral2 tests) looks for a kubeconfig file in `$HOME/.kube/config`. And the flux-coral2 testsuite has logic in place, such as [here](https://github.com/flux-framework/flux-coral2/blob/master/t/sharness.d/03-kube.sh), to manipulate kubernetes into working properly which was affected by PR #154. It caused test failures which were only visible when running with kubernetes (which CI doesn't do).

The changes introduced by #154 are still desirable (see issue #156), but they will need to be introduced with more extensive changes which hopefully would make the kubernetes manipulations more straightforward.