### PR TITLE
Resource graph: rack-parent ssds

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -105,31 +105,10 @@ class Coral2Graph(FluxionResourceGraphV1):
                 to_gibibytes(nnf["capacity"] // self._chunks_per_nnf),
                 {},
                 f"{parent.path}/{res_name}",
+                1,  # status=1 marks the ssds as 'down' initially
             )
             edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
             self._add_and_tick_uniq_id(vtx, edg)
-
-    def _encode_rabbit(self, parent, nnf):
-        res_type = "rabbit"
-        res_name = f"{res_type}-{nnf['metadata']['name']}"
-        vtx = ElCapResourcePoolV1(
-            self._uniqId,
-            res_type,
-            res_type,
-            res_name,
-            self._rackids,
-            self._uniqId,
-            -1,
-            True,
-            "",
-            1,
-            {},
-            f"{parent.path}/{res_name}",
-            1,  # status=1 marks the rabbits as 'down' initially
-        )
-        edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
-        self._add_and_tick_uniq_id(vtx, edg)
-        self._encode_ssds(vtx, nnf["status"])
 
     def _encode_rack(self, parent, nnf):
         res_type = "rack"
@@ -150,7 +129,7 @@ class Coral2Graph(FluxionResourceGraphV1):
         )
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())
         self._add_and_tick_uniq_id(vtx, edg)
-        self._encode_rabbit(vtx, nnf)
+        self._encode_ssds(vtx, nnf["status"])
         for node in nnf["status"]["access"].get("computes", []):
             try:
                 index = self._r_hostlist.index(node["name"])[0]

--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -265,7 +265,7 @@ def main():
             "Higher numbers allow finer-grained scheduling at the possible cost "
             "of scheduler performance."
         ),
-        default=32,
+        default=36,
         metavar="N",
         type=int,
     )

--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -124,7 +124,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            {},
+            {"rabbit": nnf["metadata"]["name"]},
             f"{parent.path}/{res_name}",
         )
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())

--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -124,7 +124,7 @@ class Coral2Graph(FluxionResourceGraphV1):
             True,
             "",
             1,
-            {"rabbit": nnf["metadata"]["name"]},
+            {"rabbit": nnf["metadata"]["name"], "ssdcount": str(self._chunks_per_nnf)},
             f"{parent.path}/{res_name}",
         )
         edg = ElCapResourceRelationshipV1(parent.get_id(), vtx.get_id())

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -65,14 +65,15 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
     ssd_resources = {"type": "ssd", "count": 0, "exclusive": True}
     nodecount = resources[0]["count"]
     resources[0]["count"] = 1
-    # construct a new jobspec resources with top-level 'rack' resources
+    # construct a new jobspec resources with top-level 'slot' resources
     new_resources = [
         {
-            "type": "rack",
-            "count": nodecount,  # the old nodecount, now for racks
+            "type": "slot",
+            "count": nodecount,  # the old nodecount, now for slots
+            "label": "rabbit",
             "with": [
                 resources[0],
-                {"type": "rabbit", "count": 1, "with": [ssd_resources]},
+                ssd_resources,
             ],
         }
     ]

--- a/t/data/dws2jgf/expected-compute-01-04.jgf
+++ b/t/data/dws2jgf/expected-compute-01-04.jgf
@@ -49,7 +49,10 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": {
+              "rabbit": "kind-worker2",
+              "ssdcount": "36"
+            },
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -58,18 +61,18 @@
         {
           "id": "2",
           "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker2",
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd0",
             "id": 0,
             "uniq_id": 2,
             "rank": -1,
             "exclusive": true,
-            "unit": "",
-            "size": 1,
+            "unit": "GiB",
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
+              "containment": "/ElCapitan0/rack0/ssd0"
             },
             "status": 1
           }
@@ -79,17 +82,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 3,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
-            }
+              "containment": "/ElCapitan0/rack0/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -97,17 +101,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 4,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
-            }
+              "containment": "/ElCapitan0/rack0/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -115,17 +120,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 5,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
-            }
+              "containment": "/ElCapitan0/rack0/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -133,17 +139,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 6,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
-            }
+              "containment": "/ElCapitan0/rack0/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -151,17 +158,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 7,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
-            }
+              "containment": "/ElCapitan0/rack0/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -169,17 +177,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 8,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
-            }
+              "containment": "/ElCapitan0/rack0/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -187,17 +196,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 9,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
-            }
+              "containment": "/ElCapitan0/rack0/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -205,17 +215,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 10,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
-            }
+              "containment": "/ElCapitan0/rack0/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -223,17 +234,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 11,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
-            }
+              "containment": "/ElCapitan0/rack0/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -241,17 +253,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 12,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
-            }
+              "containment": "/ElCapitan0/rack0/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -259,17 +272,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 13,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
-            }
+              "containment": "/ElCapitan0/rack0/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -277,17 +291,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 14,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
-            }
+              "containment": "/ElCapitan0/rack0/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -295,17 +310,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 15,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
-            }
+              "containment": "/ElCapitan0/rack0/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -313,17 +329,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 16,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
-            }
+              "containment": "/ElCapitan0/rack0/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -331,17 +348,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 17,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
-            }
+              "containment": "/ElCapitan0/rack0/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -349,17 +367,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 18,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
-            }
+              "containment": "/ElCapitan0/rack0/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -367,17 +386,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 19,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
-            }
+              "containment": "/ElCapitan0/rack0/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -385,17 +405,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 20,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
-            }
+              "containment": "/ElCapitan0/rack0/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -403,17 +424,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 21,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
-            }
+              "containment": "/ElCapitan0/rack0/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -421,17 +443,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 22,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
-            }
+              "containment": "/ElCapitan0/rack0/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -439,17 +462,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 23,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
-            }
+              "containment": "/ElCapitan0/rack0/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -457,17 +481,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 24,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
-            }
+              "containment": "/ElCapitan0/rack0/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -475,17 +500,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 25,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
-            }
+              "containment": "/ElCapitan0/rack0/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -493,17 +519,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 26,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
-            }
+              "containment": "/ElCapitan0/rack0/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -511,17 +538,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 27,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
-            }
+              "containment": "/ElCapitan0/rack0/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -529,17 +557,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 28,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
-            }
+              "containment": "/ElCapitan0/rack0/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -547,17 +576,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 29,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
-            }
+              "containment": "/ElCapitan0/rack0/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -565,17 +595,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 30,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
-            }
+              "containment": "/ElCapitan0/rack0/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -583,17 +614,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 31,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
-            }
+              "containment": "/ElCapitan0/rack0/ssd29"
+            },
+            "status": 1
           }
         },
         {
@@ -601,17 +633,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd30",
+            "id": 30,
             "uniq_id": 32,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
-            }
+              "containment": "/ElCapitan0/rack0/ssd30"
+            },
+            "status": 1
           }
         },
         {
@@ -619,17 +652,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd31",
+            "id": 31,
             "uniq_id": 33,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
-            }
+              "containment": "/ElCapitan0/rack0/ssd31"
+            },
+            "status": 1
           }
         },
         {
@@ -637,27 +671,85 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd32",
+            "id": 32,
             "uniq_id": 34,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
-            }
+              "containment": "/ElCapitan0/rack0/ssd32"
+            },
+            "status": 1
           }
         },
         {
           "id": "35",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 35,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "36",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 36,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "37",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 37,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "38",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-01",
             "id": 1,
-            "uniq_id": 35,
+            "uniq_id": 38,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -669,13 +761,13 @@
           }
         },
         {
-          "id": "36",
+          "id": "39",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 36,
+            "uniq_id": 39,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -687,13 +779,13 @@
           }
         },
         {
-          "id": "37",
+          "id": "40",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 37,
+            "uniq_id": 40,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -705,13 +797,13 @@
           }
         },
         {
-          "id": "38",
+          "id": "41",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 38,
+            "uniq_id": 41,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -723,13 +815,13 @@
           }
         },
         {
-          "id": "39",
+          "id": "42",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 39,
+            "uniq_id": 42,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -741,13 +833,13 @@
           }
         },
         {
-          "id": "40",
+          "id": "43",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 40,
+            "uniq_id": 43,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -759,13 +851,13 @@
           }
         },
         {
-          "id": "41",
+          "id": "44",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-02",
             "id": 2,
-            "uniq_id": 41,
+            "uniq_id": 44,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -777,13 +869,13 @@
           }
         },
         {
-          "id": "42",
+          "id": "45",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 42,
+            "uniq_id": 45,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -795,13 +887,13 @@
           }
         },
         {
-          "id": "43",
+          "id": "46",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 43,
+            "uniq_id": 46,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -813,13 +905,13 @@
           }
         },
         {
-          "id": "44",
+          "id": "47",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 44,
+            "uniq_id": 47,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -831,13 +923,13 @@
           }
         },
         {
-          "id": "45",
+          "id": "48",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 45,
+            "uniq_id": 48,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -849,13 +941,13 @@
           }
         },
         {
-          "id": "46",
+          "id": "49",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 46,
+            "uniq_id": 49,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -867,13 +959,13 @@
           }
         },
         {
-          "id": "47",
+          "id": "50",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-03",
             "id": 3,
-            "uniq_id": 47,
+            "uniq_id": 50,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -885,13 +977,13 @@
           }
         },
         {
-          "id": "48",
+          "id": "51",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 48,
+            "uniq_id": 51,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -903,13 +995,13 @@
           }
         },
         {
-          "id": "49",
+          "id": "52",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 49,
+            "uniq_id": 52,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -921,13 +1013,13 @@
           }
         },
         {
-          "id": "50",
+          "id": "53",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 50,
+            "uniq_id": 53,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -939,13 +1031,13 @@
           }
         },
         {
-          "id": "51",
+          "id": "54",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 51,
+            "uniq_id": 54,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -957,13 +1049,13 @@
           }
         },
         {
-          "id": "52",
+          "id": "55",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 52,
+            "uniq_id": 55,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -975,75 +1067,23 @@
           }
         },
         {
-          "id": "53",
+          "id": "56",
           "metadata": {
             "type": "rack",
             "basename": "rack",
             "name": "rack1",
             "id": 1,
-            "uniq_id": 53,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1"
-            }
-          }
-        },
-        {
-          "id": "54",
-          "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker3",
-            "id": 1,
-            "uniq_id": 54,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
-            },
-            "status": 1
-          }
-        },
-        {
-          "id": "55",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 55,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
-            }
-          }
-        },
-        {
-          "id": "56",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
             "uniq_id": 56,
             "rank": -1,
             "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
+            "unit": "",
+            "size": 1,
+            "properties": {
+              "rabbit": "kind-worker3",
+              "ssdcount": "36"
+            },
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
+              "containment": "/ElCapitan0/rack1"
             }
           }
         },
@@ -1052,17 +1092,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd0",
+            "id": 0,
             "uniq_id": 57,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
-            }
+              "containment": "/ElCapitan0/rack1/ssd0"
+            },
+            "status": 1
           }
         },
         {
@@ -1070,17 +1111,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 58,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
-            }
+              "containment": "/ElCapitan0/rack1/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -1088,17 +1130,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 59,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
-            }
+              "containment": "/ElCapitan0/rack1/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -1106,17 +1149,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 60,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
-            }
+              "containment": "/ElCapitan0/rack1/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -1124,17 +1168,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 61,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
-            }
+              "containment": "/ElCapitan0/rack1/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -1142,17 +1187,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 62,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
-            }
+              "containment": "/ElCapitan0/rack1/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -1160,17 +1206,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 63,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
-            }
+              "containment": "/ElCapitan0/rack1/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -1178,17 +1225,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 64,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
-            }
+              "containment": "/ElCapitan0/rack1/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -1196,17 +1244,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 65,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
-            }
+              "containment": "/ElCapitan0/rack1/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -1214,17 +1263,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 66,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
-            }
+              "containment": "/ElCapitan0/rack1/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -1232,17 +1282,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 67,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
-            }
+              "containment": "/ElCapitan0/rack1/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -1250,17 +1301,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 68,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
-            }
+              "containment": "/ElCapitan0/rack1/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -1268,17 +1320,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 69,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
-            }
+              "containment": "/ElCapitan0/rack1/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -1286,17 +1339,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 70,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
-            }
+              "containment": "/ElCapitan0/rack1/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -1304,17 +1358,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 71,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
-            }
+              "containment": "/ElCapitan0/rack1/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -1322,17 +1377,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 72,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
-            }
+              "containment": "/ElCapitan0/rack1/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -1340,17 +1396,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 73,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
-            }
+              "containment": "/ElCapitan0/rack1/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -1358,17 +1415,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 74,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
-            }
+              "containment": "/ElCapitan0/rack1/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -1376,17 +1434,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 75,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
-            }
+              "containment": "/ElCapitan0/rack1/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -1394,17 +1453,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 76,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
-            }
+              "containment": "/ElCapitan0/rack1/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -1412,17 +1472,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 77,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
-            }
+              "containment": "/ElCapitan0/rack1/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -1430,17 +1491,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 78,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
-            }
+              "containment": "/ElCapitan0/rack1/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -1448,17 +1510,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 79,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
-            }
+              "containment": "/ElCapitan0/rack1/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -1466,17 +1529,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 80,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
-            }
+              "containment": "/ElCapitan0/rack1/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -1484,17 +1548,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 81,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
-            }
+              "containment": "/ElCapitan0/rack1/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -1502,17 +1567,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 82,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
-            }
+              "containment": "/ElCapitan0/rack1/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -1520,17 +1586,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 83,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
-            }
+              "containment": "/ElCapitan0/rack1/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -1538,17 +1605,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 84,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
-            }
+              "containment": "/ElCapitan0/rack1/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -1556,17 +1624,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 85,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
-            }
+              "containment": "/ElCapitan0/rack1/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -1574,27 +1643,142 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 86,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
-            }
+              "containment": "/ElCapitan0/rack1/ssd29"
+            },
+            "status": 1
           }
         },
         {
           "id": "87",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd30",
+            "id": 30,
+            "uniq_id": 87,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "88",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd31",
+            "id": 31,
+            "uniq_id": 88,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "89",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd32",
+            "id": 32,
+            "uniq_id": 89,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "90",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 90,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "91",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 91,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "92",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 92,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "93",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-04",
             "id": 4,
-            "uniq_id": 87,
+            "uniq_id": 93,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1606,13 +1790,13 @@
           }
         },
         {
-          "id": "88",
+          "id": "94",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 88,
+            "uniq_id": 94,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1624,13 +1808,13 @@
           }
         },
         {
-          "id": "89",
+          "id": "95",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 89,
+            "uniq_id": 95,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1642,13 +1826,13 @@
           }
         },
         {
-          "id": "90",
+          "id": "96",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 90,
+            "uniq_id": 96,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1660,13 +1844,13 @@
           }
         },
         {
-          "id": "91",
+          "id": "97",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 91,
+            "uniq_id": 97,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1678,13 +1862,13 @@
           }
         },
         {
-          "id": "92",
+          "id": "98",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 92,
+            "uniq_id": 98,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1718,7 +1902,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "3",
           "directed": true,
           "metadata": {
@@ -1728,7 +1912,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "4",
           "directed": true,
           "metadata": {
@@ -1738,7 +1922,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "5",
           "directed": true,
           "metadata": {
@@ -1748,7 +1932,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "6",
           "directed": true,
           "metadata": {
@@ -1758,7 +1942,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "7",
           "directed": true,
           "metadata": {
@@ -1768,7 +1952,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "8",
           "directed": true,
           "metadata": {
@@ -1778,7 +1962,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "9",
           "directed": true,
           "metadata": {
@@ -1788,7 +1972,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "10",
           "directed": true,
           "metadata": {
@@ -1798,7 +1982,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "11",
           "directed": true,
           "metadata": {
@@ -1808,7 +1992,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "12",
           "directed": true,
           "metadata": {
@@ -1818,7 +2002,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "13",
           "directed": true,
           "metadata": {
@@ -1828,7 +2012,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "14",
           "directed": true,
           "metadata": {
@@ -1838,7 +2022,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "15",
           "directed": true,
           "metadata": {
@@ -1848,7 +2032,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "16",
           "directed": true,
           "metadata": {
@@ -1858,7 +2042,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "17",
           "directed": true,
           "metadata": {
@@ -1868,7 +2052,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "18",
           "directed": true,
           "metadata": {
@@ -1878,7 +2062,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "19",
           "directed": true,
           "metadata": {
@@ -1888,7 +2072,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "20",
           "directed": true,
           "metadata": {
@@ -1898,7 +2082,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "21",
           "directed": true,
           "metadata": {
@@ -1908,7 +2092,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "22",
           "directed": true,
           "metadata": {
@@ -1918,7 +2102,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "23",
           "directed": true,
           "metadata": {
@@ -1928,7 +2112,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "24",
           "directed": true,
           "metadata": {
@@ -1938,7 +2122,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "25",
           "directed": true,
           "metadata": {
@@ -1948,7 +2132,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "26",
           "directed": true,
           "metadata": {
@@ -1958,7 +2142,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "27",
           "directed": true,
           "metadata": {
@@ -1968,7 +2152,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "28",
           "directed": true,
           "metadata": {
@@ -1978,7 +2162,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "29",
           "directed": true,
           "metadata": {
@@ -1988,7 +2172,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "30",
           "directed": true,
           "metadata": {
@@ -1998,7 +2182,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "31",
           "directed": true,
           "metadata": {
@@ -2008,7 +2192,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "32",
           "directed": true,
           "metadata": {
@@ -2018,7 +2202,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "33",
           "directed": true,
           "metadata": {
@@ -2028,7 +2212,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "34",
           "directed": true,
           "metadata": {
@@ -2048,7 +2232,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "36",
           "directed": true,
           "metadata": {
@@ -2058,7 +2242,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "37",
           "directed": true,
           "metadata": {
@@ -2068,7 +2252,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "38",
           "directed": true,
           "metadata": {
@@ -2078,7 +2262,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "39",
           "directed": true,
           "metadata": {
@@ -2088,7 +2272,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "40",
           "directed": true,
           "metadata": {
@@ -2098,7 +2282,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "38",
           "target": "41",
           "directed": true,
           "metadata": {
@@ -2108,7 +2292,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "38",
           "target": "42",
           "directed": true,
           "metadata": {
@@ -2118,7 +2302,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "38",
           "target": "43",
           "directed": true,
           "metadata": {
@@ -2128,7 +2312,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "1",
           "target": "44",
           "directed": true,
           "metadata": {
@@ -2138,7 +2322,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "44",
           "target": "45",
           "directed": true,
           "metadata": {
@@ -2148,7 +2332,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "44",
           "target": "46",
           "directed": true,
           "metadata": {
@@ -2158,7 +2342,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "44",
           "target": "47",
           "directed": true,
           "metadata": {
@@ -2168,7 +2352,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "44",
           "target": "48",
           "directed": true,
           "metadata": {
@@ -2178,7 +2362,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "44",
           "target": "49",
           "directed": true,
           "metadata": {
@@ -2188,7 +2372,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "1",
           "target": "50",
           "directed": true,
           "metadata": {
@@ -2198,7 +2382,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "50",
           "target": "51",
           "directed": true,
           "metadata": {
@@ -2208,7 +2392,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "50",
           "target": "52",
           "directed": true,
           "metadata": {
@@ -2218,7 +2402,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "50",
           "target": "53",
           "directed": true,
           "metadata": {
@@ -2228,7 +2412,7 @@
           }
         },
         {
-          "source": "53",
+          "source": "50",
           "target": "54",
           "directed": true,
           "metadata": {
@@ -2238,7 +2422,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "50",
           "target": "55",
           "directed": true,
           "metadata": {
@@ -2248,7 +2432,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "0",
           "target": "56",
           "directed": true,
           "metadata": {
@@ -2258,7 +2442,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "57",
           "directed": true,
           "metadata": {
@@ -2268,7 +2452,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "58",
           "directed": true,
           "metadata": {
@@ -2278,7 +2462,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "59",
           "directed": true,
           "metadata": {
@@ -2288,7 +2472,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "60",
           "directed": true,
           "metadata": {
@@ -2298,7 +2482,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "61",
           "directed": true,
           "metadata": {
@@ -2308,7 +2492,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "62",
           "directed": true,
           "metadata": {
@@ -2318,7 +2502,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "63",
           "directed": true,
           "metadata": {
@@ -2328,7 +2512,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "64",
           "directed": true,
           "metadata": {
@@ -2338,7 +2522,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "65",
           "directed": true,
           "metadata": {
@@ -2348,7 +2532,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "66",
           "directed": true,
           "metadata": {
@@ -2358,7 +2542,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "67",
           "directed": true,
           "metadata": {
@@ -2368,7 +2552,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "68",
           "directed": true,
           "metadata": {
@@ -2378,7 +2562,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "69",
           "directed": true,
           "metadata": {
@@ -2388,7 +2572,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "70",
           "directed": true,
           "metadata": {
@@ -2398,7 +2582,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "71",
           "directed": true,
           "metadata": {
@@ -2408,7 +2592,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "72",
           "directed": true,
           "metadata": {
@@ -2418,7 +2602,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "73",
           "directed": true,
           "metadata": {
@@ -2428,7 +2612,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "74",
           "directed": true,
           "metadata": {
@@ -2438,7 +2622,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "75",
           "directed": true,
           "metadata": {
@@ -2448,7 +2632,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "76",
           "directed": true,
           "metadata": {
@@ -2458,7 +2642,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "77",
           "directed": true,
           "metadata": {
@@ -2468,7 +2652,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "78",
           "directed": true,
           "metadata": {
@@ -2478,7 +2662,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "79",
           "directed": true,
           "metadata": {
@@ -2488,7 +2672,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "80",
           "directed": true,
           "metadata": {
@@ -2498,7 +2682,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "81",
           "directed": true,
           "metadata": {
@@ -2508,7 +2692,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "82",
           "directed": true,
           "metadata": {
@@ -2518,7 +2702,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "83",
           "directed": true,
           "metadata": {
@@ -2528,7 +2712,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "84",
           "directed": true,
           "metadata": {
@@ -2538,7 +2722,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "85",
           "directed": true,
           "metadata": {
@@ -2548,7 +2732,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "86",
           "directed": true,
           "metadata": {
@@ -2558,7 +2742,7 @@
           }
         },
         {
-          "source": "53",
+          "source": "56",
           "target": "87",
           "directed": true,
           "metadata": {
@@ -2568,7 +2752,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "88",
           "directed": true,
           "metadata": {
@@ -2578,7 +2762,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "89",
           "directed": true,
           "metadata": {
@@ -2588,7 +2772,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "90",
           "directed": true,
           "metadata": {
@@ -2598,7 +2782,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "91",
           "directed": true,
           "metadata": {
@@ -2608,8 +2792,68 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "92",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "56",
+          "target": "93",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "93",
+          "target": "94",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "93",
+          "target": "95",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "93",
+          "target": "96",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "93",
+          "target": "97",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "93",
+          "target": "98",
           "directed": true,
           "metadata": {
             "name": {

--- a/t/data/dws2jgf/expected-compute-01-nodws.jgf
+++ b/t/data/dws2jgf/expected-compute-01-nodws.jgf
@@ -49,7 +49,10 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": {
+              "rabbit": "kind-worker2",
+              "ssdcount": "36"
+            },
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -58,18 +61,18 @@
         {
           "id": "2",
           "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker2",
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd0",
             "id": 0,
             "uniq_id": 2,
             "rank": -1,
             "exclusive": true,
-            "unit": "",
-            "size": 1,
+            "unit": "GiB",
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
+              "containment": "/ElCapitan0/rack0/ssd0"
             },
             "status": 1
           }
@@ -79,17 +82,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 3,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
-            }
+              "containment": "/ElCapitan0/rack0/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -97,17 +101,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 4,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
-            }
+              "containment": "/ElCapitan0/rack0/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -115,17 +120,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 5,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
-            }
+              "containment": "/ElCapitan0/rack0/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -133,17 +139,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 6,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
-            }
+              "containment": "/ElCapitan0/rack0/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -151,17 +158,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 7,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
-            }
+              "containment": "/ElCapitan0/rack0/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -169,17 +177,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 8,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
-            }
+              "containment": "/ElCapitan0/rack0/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -187,17 +196,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 9,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
-            }
+              "containment": "/ElCapitan0/rack0/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -205,17 +215,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 10,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
-            }
+              "containment": "/ElCapitan0/rack0/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -223,17 +234,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 11,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
-            }
+              "containment": "/ElCapitan0/rack0/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -241,17 +253,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 12,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
-            }
+              "containment": "/ElCapitan0/rack0/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -259,17 +272,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 13,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
-            }
+              "containment": "/ElCapitan0/rack0/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -277,17 +291,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 14,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
-            }
+              "containment": "/ElCapitan0/rack0/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -295,17 +310,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 15,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
-            }
+              "containment": "/ElCapitan0/rack0/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -313,17 +329,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 16,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
-            }
+              "containment": "/ElCapitan0/rack0/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -331,17 +348,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 17,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
-            }
+              "containment": "/ElCapitan0/rack0/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -349,17 +367,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 18,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
-            }
+              "containment": "/ElCapitan0/rack0/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -367,17 +386,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 19,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
-            }
+              "containment": "/ElCapitan0/rack0/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -385,17 +405,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 20,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
-            }
+              "containment": "/ElCapitan0/rack0/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -403,17 +424,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 21,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
-            }
+              "containment": "/ElCapitan0/rack0/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -421,17 +443,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 22,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
-            }
+              "containment": "/ElCapitan0/rack0/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -439,17 +462,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 23,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
-            }
+              "containment": "/ElCapitan0/rack0/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -457,17 +481,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 24,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
-            }
+              "containment": "/ElCapitan0/rack0/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -475,17 +500,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 25,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
-            }
+              "containment": "/ElCapitan0/rack0/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -493,17 +519,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 26,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
-            }
+              "containment": "/ElCapitan0/rack0/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -511,17 +538,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 27,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
-            }
+              "containment": "/ElCapitan0/rack0/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -529,17 +557,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 28,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
-            }
+              "containment": "/ElCapitan0/rack0/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -547,17 +576,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 29,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
-            }
+              "containment": "/ElCapitan0/rack0/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -565,17 +595,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 30,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
-            }
+              "containment": "/ElCapitan0/rack0/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -583,17 +614,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 31,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
-            }
+              "containment": "/ElCapitan0/rack0/ssd29"
+            },
+            "status": 1
           }
         },
         {
@@ -601,17 +633,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd30",
+            "id": 30,
             "uniq_id": 32,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
-            }
+              "containment": "/ElCapitan0/rack0/ssd30"
+            },
+            "status": 1
           }
         },
         {
@@ -619,17 +652,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd31",
+            "id": 31,
             "uniq_id": 33,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
-            }
+              "containment": "/ElCapitan0/rack0/ssd31"
+            },
+            "status": 1
           }
         },
         {
@@ -637,27 +671,85 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd32",
+            "id": 32,
             "uniq_id": 34,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
-            }
+              "containment": "/ElCapitan0/rack0/ssd32"
+            },
+            "status": 1
           }
         },
         {
           "id": "35",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 35,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "36",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 36,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "37",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 37,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "38",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-01",
             "id": 1,
-            "uniq_id": 35,
+            "uniq_id": 38,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -669,13 +761,13 @@
           }
         },
         {
-          "id": "36",
+          "id": "39",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 36,
+            "uniq_id": 39,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -687,13 +779,13 @@
           }
         },
         {
-          "id": "37",
+          "id": "40",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 37,
+            "uniq_id": 40,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -705,13 +797,13 @@
           }
         },
         {
-          "id": "38",
+          "id": "41",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 38,
+            "uniq_id": 41,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -723,13 +815,13 @@
           }
         },
         {
-          "id": "39",
+          "id": "42",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 39,
+            "uniq_id": 42,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -741,13 +833,13 @@
           }
         },
         {
-          "id": "40",
+          "id": "43",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 40,
+            "uniq_id": 43,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -759,13 +851,13 @@
           }
         },
         {
-          "id": "41",
+          "id": "44",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-02",
             "id": 2,
-            "uniq_id": 41,
+            "uniq_id": 44,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -777,13 +869,13 @@
           }
         },
         {
-          "id": "42",
+          "id": "45",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 42,
+            "uniq_id": 45,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -795,13 +887,13 @@
           }
         },
         {
-          "id": "43",
+          "id": "46",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 43,
+            "uniq_id": 46,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -813,13 +905,13 @@
           }
         },
         {
-          "id": "44",
+          "id": "47",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 44,
+            "uniq_id": 47,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -831,13 +923,13 @@
           }
         },
         {
-          "id": "45",
+          "id": "48",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 45,
+            "uniq_id": 48,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -849,13 +941,13 @@
           }
         },
         {
-          "id": "46",
+          "id": "49",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 46,
+            "uniq_id": 49,
             "rank": 1,
             "exclusive": true,
             "unit": "",
@@ -867,13 +959,13 @@
           }
         },
         {
-          "id": "47",
+          "id": "50",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-03",
             "id": 3,
-            "uniq_id": 47,
+            "uniq_id": 50,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -885,13 +977,13 @@
           }
         },
         {
-          "id": "48",
+          "id": "51",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 48,
+            "uniq_id": 51,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -903,13 +995,13 @@
           }
         },
         {
-          "id": "49",
+          "id": "52",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 49,
+            "uniq_id": 52,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -921,13 +1013,13 @@
           }
         },
         {
-          "id": "50",
+          "id": "53",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 50,
+            "uniq_id": 53,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -939,13 +1031,13 @@
           }
         },
         {
-          "id": "51",
+          "id": "54",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 51,
+            "uniq_id": 54,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -957,13 +1049,13 @@
           }
         },
         {
-          "id": "52",
+          "id": "55",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 52,
+            "uniq_id": 55,
             "rank": 2,
             "exclusive": true,
             "unit": "",
@@ -975,75 +1067,23 @@
           }
         },
         {
-          "id": "53",
+          "id": "56",
           "metadata": {
             "type": "rack",
             "basename": "rack",
             "name": "rack1",
             "id": 1,
-            "uniq_id": 53,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1"
-            }
-          }
-        },
-        {
-          "id": "54",
-          "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker3",
-            "id": 1,
-            "uniq_id": 54,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
-            },
-            "status": 1
-          }
-        },
-        {
-          "id": "55",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 55,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
-            }
-          }
-        },
-        {
-          "id": "56",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
             "uniq_id": 56,
             "rank": -1,
             "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
+            "unit": "",
+            "size": 1,
+            "properties": {
+              "rabbit": "kind-worker3",
+              "ssdcount": "36"
+            },
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
+              "containment": "/ElCapitan0/rack1"
             }
           }
         },
@@ -1052,17 +1092,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd0",
+            "id": 0,
             "uniq_id": 57,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
-            }
+              "containment": "/ElCapitan0/rack1/ssd0"
+            },
+            "status": 1
           }
         },
         {
@@ -1070,17 +1111,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 58,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
-            }
+              "containment": "/ElCapitan0/rack1/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -1088,17 +1130,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 59,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
-            }
+              "containment": "/ElCapitan0/rack1/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -1106,17 +1149,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 60,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
-            }
+              "containment": "/ElCapitan0/rack1/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -1124,17 +1168,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 61,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
-            }
+              "containment": "/ElCapitan0/rack1/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -1142,17 +1187,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 62,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
-            }
+              "containment": "/ElCapitan0/rack1/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -1160,17 +1206,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 63,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
-            }
+              "containment": "/ElCapitan0/rack1/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -1178,17 +1225,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 64,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
-            }
+              "containment": "/ElCapitan0/rack1/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -1196,17 +1244,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 65,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
-            }
+              "containment": "/ElCapitan0/rack1/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -1214,17 +1263,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 66,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
-            }
+              "containment": "/ElCapitan0/rack1/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -1232,17 +1282,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 67,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
-            }
+              "containment": "/ElCapitan0/rack1/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -1250,17 +1301,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 68,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
-            }
+              "containment": "/ElCapitan0/rack1/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -1268,17 +1320,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 69,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
-            }
+              "containment": "/ElCapitan0/rack1/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -1286,17 +1339,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 70,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
-            }
+              "containment": "/ElCapitan0/rack1/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -1304,17 +1358,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 71,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
-            }
+              "containment": "/ElCapitan0/rack1/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -1322,17 +1377,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 72,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
-            }
+              "containment": "/ElCapitan0/rack1/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -1340,17 +1396,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 73,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
-            }
+              "containment": "/ElCapitan0/rack1/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -1358,17 +1415,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 74,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
-            }
+              "containment": "/ElCapitan0/rack1/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -1376,17 +1434,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 75,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
-            }
+              "containment": "/ElCapitan0/rack1/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -1394,17 +1453,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 76,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
-            }
+              "containment": "/ElCapitan0/rack1/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -1412,17 +1472,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 77,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
-            }
+              "containment": "/ElCapitan0/rack1/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -1430,17 +1491,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 78,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
-            }
+              "containment": "/ElCapitan0/rack1/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -1448,17 +1510,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 79,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
-            }
+              "containment": "/ElCapitan0/rack1/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -1466,17 +1529,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 80,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
-            }
+              "containment": "/ElCapitan0/rack1/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -1484,17 +1548,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 81,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
-            }
+              "containment": "/ElCapitan0/rack1/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -1502,17 +1567,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 82,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
-            }
+              "containment": "/ElCapitan0/rack1/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -1520,17 +1586,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 83,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
-            }
+              "containment": "/ElCapitan0/rack1/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -1538,17 +1605,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 84,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
-            }
+              "containment": "/ElCapitan0/rack1/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -1556,17 +1624,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 85,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
-            }
+              "containment": "/ElCapitan0/rack1/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -1574,27 +1643,142 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 86,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
-            }
+              "containment": "/ElCapitan0/rack1/ssd29"
+            },
+            "status": 1
           }
         },
         {
           "id": "87",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd30",
+            "id": 30,
+            "uniq_id": 87,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "88",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd31",
+            "id": 31,
+            "uniq_id": 88,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "89",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd32",
+            "id": 32,
+            "uniq_id": 89,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "90",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 90,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "91",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 91,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "92",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 92,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "93",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-04",
             "id": 4,
-            "uniq_id": 87,
+            "uniq_id": 93,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1606,13 +1790,13 @@
           }
         },
         {
-          "id": "88",
+          "id": "94",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 88,
+            "uniq_id": 94,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1624,13 +1808,13 @@
           }
         },
         {
-          "id": "89",
+          "id": "95",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 89,
+            "uniq_id": 95,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1642,13 +1826,13 @@
           }
         },
         {
-          "id": "90",
+          "id": "96",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 90,
+            "uniq_id": 96,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1660,13 +1844,13 @@
           }
         },
         {
-          "id": "91",
+          "id": "97",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 91,
+            "uniq_id": 97,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1678,13 +1862,13 @@
           }
         },
         {
-          "id": "92",
+          "id": "98",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 92,
+            "uniq_id": 98,
             "rank": 3,
             "exclusive": true,
             "unit": "",
@@ -1696,13 +1880,13 @@
           }
         },
         {
-          "id": "93",
+          "id": "99",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws0",
             "id": 0,
-            "uniq_id": 93,
+            "uniq_id": 99,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1714,13 +1898,13 @@
           }
         },
         {
-          "id": "94",
+          "id": "100",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 94,
+            "uniq_id": 100,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1732,13 +1916,13 @@
           }
         },
         {
-          "id": "95",
+          "id": "101",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 95,
+            "uniq_id": 101,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1750,13 +1934,13 @@
           }
         },
         {
-          "id": "96",
+          "id": "102",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 96,
+            "uniq_id": 102,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1768,13 +1952,13 @@
           }
         },
         {
-          "id": "97",
+          "id": "103",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 97,
+            "uniq_id": 103,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1786,13 +1970,13 @@
           }
         },
         {
-          "id": "98",
+          "id": "104",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 98,
+            "uniq_id": 104,
             "rank": 4,
             "exclusive": true,
             "unit": "",
@@ -1804,13 +1988,13 @@
           }
         },
         {
-          "id": "99",
+          "id": "105",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws1",
             "id": 1,
-            "uniq_id": 99,
+            "uniq_id": 105,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1822,13 +2006,13 @@
           }
         },
         {
-          "id": "100",
+          "id": "106",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 100,
+            "uniq_id": 106,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1840,13 +2024,13 @@
           }
         },
         {
-          "id": "101",
+          "id": "107",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 101,
+            "uniq_id": 107,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1858,13 +2042,13 @@
           }
         },
         {
-          "id": "102",
+          "id": "108",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 102,
+            "uniq_id": 108,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1876,13 +2060,13 @@
           }
         },
         {
-          "id": "103",
+          "id": "109",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 103,
+            "uniq_id": 109,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1894,13 +2078,13 @@
           }
         },
         {
-          "id": "104",
+          "id": "110",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 104,
+            "uniq_id": 110,
             "rank": 5,
             "exclusive": true,
             "unit": "",
@@ -1912,13 +2096,13 @@
           }
         },
         {
-          "id": "105",
+          "id": "111",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws2",
             "id": 2,
-            "uniq_id": 105,
+            "uniq_id": 111,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -1930,13 +2114,13 @@
           }
         },
         {
-          "id": "106",
+          "id": "112",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 106,
+            "uniq_id": 112,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -1948,13 +2132,13 @@
           }
         },
         {
-          "id": "107",
+          "id": "113",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 107,
+            "uniq_id": 113,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -1966,13 +2150,13 @@
           }
         },
         {
-          "id": "108",
+          "id": "114",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 108,
+            "uniq_id": 114,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -1984,13 +2168,13 @@
           }
         },
         {
-          "id": "109",
+          "id": "115",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 109,
+            "uniq_id": 115,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -2002,13 +2186,13 @@
           }
         },
         {
-          "id": "110",
+          "id": "116",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 110,
+            "uniq_id": 116,
             "rank": 6,
             "exclusive": true,
             "unit": "",
@@ -2020,13 +2204,13 @@
           }
         },
         {
-          "id": "111",
+          "id": "117",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws3",
             "id": 3,
-            "uniq_id": 111,
+            "uniq_id": 117,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2038,13 +2222,13 @@
           }
         },
         {
-          "id": "112",
+          "id": "118",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 112,
+            "uniq_id": 118,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2056,13 +2240,13 @@
           }
         },
         {
-          "id": "113",
+          "id": "119",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 113,
+            "uniq_id": 119,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2074,13 +2258,13 @@
           }
         },
         {
-          "id": "114",
+          "id": "120",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 114,
+            "uniq_id": 120,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2092,13 +2276,13 @@
           }
         },
         {
-          "id": "115",
+          "id": "121",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 115,
+            "uniq_id": 121,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2110,13 +2294,13 @@
           }
         },
         {
-          "id": "116",
+          "id": "122",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 116,
+            "uniq_id": 122,
             "rank": 7,
             "exclusive": true,
             "unit": "",
@@ -2128,13 +2312,13 @@
           }
         },
         {
-          "id": "117",
+          "id": "123",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws4",
             "id": 4,
-            "uniq_id": 117,
+            "uniq_id": 123,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2146,13 +2330,13 @@
           }
         },
         {
-          "id": "118",
+          "id": "124",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 118,
+            "uniq_id": 124,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2164,13 +2348,13 @@
           }
         },
         {
-          "id": "119",
+          "id": "125",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 119,
+            "uniq_id": 125,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2182,13 +2366,13 @@
           }
         },
         {
-          "id": "120",
+          "id": "126",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 120,
+            "uniq_id": 126,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2200,13 +2384,13 @@
           }
         },
         {
-          "id": "121",
+          "id": "127",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 121,
+            "uniq_id": 127,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2218,13 +2402,13 @@
           }
         },
         {
-          "id": "122",
+          "id": "128",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 122,
+            "uniq_id": 128,
             "rank": 8,
             "exclusive": true,
             "unit": "",
@@ -2236,13 +2420,13 @@
           }
         },
         {
-          "id": "123",
+          "id": "129",
           "metadata": {
             "type": "node",
             "basename": "node",
             "name": "nodws5",
             "id": 5,
-            "uniq_id": 123,
+            "uniq_id": 129,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2254,13 +2438,13 @@
           }
         },
         {
-          "id": "124",
+          "id": "130",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 124,
+            "uniq_id": 130,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2272,13 +2456,13 @@
           }
         },
         {
-          "id": "125",
+          "id": "131",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 125,
+            "uniq_id": 131,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2290,13 +2474,13 @@
           }
         },
         {
-          "id": "126",
+          "id": "132",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 126,
+            "uniq_id": 132,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2308,13 +2492,13 @@
           }
         },
         {
-          "id": "127",
+          "id": "133",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 127,
+            "uniq_id": 133,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2326,13 +2510,13 @@
           }
         },
         {
-          "id": "128",
+          "id": "134",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 128,
+            "uniq_id": 134,
             "rank": 9,
             "exclusive": true,
             "unit": "",
@@ -2366,7 +2550,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "3",
           "directed": true,
           "metadata": {
@@ -2376,7 +2560,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "4",
           "directed": true,
           "metadata": {
@@ -2386,7 +2570,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "5",
           "directed": true,
           "metadata": {
@@ -2396,7 +2580,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "6",
           "directed": true,
           "metadata": {
@@ -2406,7 +2590,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "7",
           "directed": true,
           "metadata": {
@@ -2416,7 +2600,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "8",
           "directed": true,
           "metadata": {
@@ -2426,7 +2610,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "9",
           "directed": true,
           "metadata": {
@@ -2436,7 +2620,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "10",
           "directed": true,
           "metadata": {
@@ -2446,7 +2630,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "11",
           "directed": true,
           "metadata": {
@@ -2456,7 +2640,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "12",
           "directed": true,
           "metadata": {
@@ -2466,7 +2650,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "13",
           "directed": true,
           "metadata": {
@@ -2476,7 +2660,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "14",
           "directed": true,
           "metadata": {
@@ -2486,7 +2670,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "15",
           "directed": true,
           "metadata": {
@@ -2496,7 +2680,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "16",
           "directed": true,
           "metadata": {
@@ -2506,7 +2690,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "17",
           "directed": true,
           "metadata": {
@@ -2516,7 +2700,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "18",
           "directed": true,
           "metadata": {
@@ -2526,7 +2710,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "19",
           "directed": true,
           "metadata": {
@@ -2536,7 +2720,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "20",
           "directed": true,
           "metadata": {
@@ -2546,7 +2730,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "21",
           "directed": true,
           "metadata": {
@@ -2556,7 +2740,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "22",
           "directed": true,
           "metadata": {
@@ -2566,7 +2750,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "23",
           "directed": true,
           "metadata": {
@@ -2576,7 +2760,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "24",
           "directed": true,
           "metadata": {
@@ -2586,7 +2770,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "25",
           "directed": true,
           "metadata": {
@@ -2596,7 +2780,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "26",
           "directed": true,
           "metadata": {
@@ -2606,7 +2790,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "27",
           "directed": true,
           "metadata": {
@@ -2616,7 +2800,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "28",
           "directed": true,
           "metadata": {
@@ -2626,7 +2810,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "29",
           "directed": true,
           "metadata": {
@@ -2636,7 +2820,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "30",
           "directed": true,
           "metadata": {
@@ -2646,7 +2830,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "31",
           "directed": true,
           "metadata": {
@@ -2656,7 +2840,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "32",
           "directed": true,
           "metadata": {
@@ -2666,7 +2850,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "33",
           "directed": true,
           "metadata": {
@@ -2676,7 +2860,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "34",
           "directed": true,
           "metadata": {
@@ -2696,7 +2880,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "36",
           "directed": true,
           "metadata": {
@@ -2706,7 +2890,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "37",
           "directed": true,
           "metadata": {
@@ -2716,7 +2900,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "38",
           "directed": true,
           "metadata": {
@@ -2726,7 +2910,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "39",
           "directed": true,
           "metadata": {
@@ -2736,7 +2920,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "40",
           "directed": true,
           "metadata": {
@@ -2746,7 +2930,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "38",
           "target": "41",
           "directed": true,
           "metadata": {
@@ -2756,7 +2940,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "38",
           "target": "42",
           "directed": true,
           "metadata": {
@@ -2766,7 +2950,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "38",
           "target": "43",
           "directed": true,
           "metadata": {
@@ -2776,7 +2960,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "1",
           "target": "44",
           "directed": true,
           "metadata": {
@@ -2786,7 +2970,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "44",
           "target": "45",
           "directed": true,
           "metadata": {
@@ -2796,7 +2980,7 @@
           }
         },
         {
-          "source": "41",
+          "source": "44",
           "target": "46",
           "directed": true,
           "metadata": {
@@ -2806,7 +2990,7 @@
           }
         },
         {
-          "source": "1",
+          "source": "44",
           "target": "47",
           "directed": true,
           "metadata": {
@@ -2816,7 +3000,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "44",
           "target": "48",
           "directed": true,
           "metadata": {
@@ -2826,7 +3010,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "44",
           "target": "49",
           "directed": true,
           "metadata": {
@@ -2836,7 +3020,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "1",
           "target": "50",
           "directed": true,
           "metadata": {
@@ -2846,7 +3030,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "50",
           "target": "51",
           "directed": true,
           "metadata": {
@@ -2856,7 +3040,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "50",
           "target": "52",
           "directed": true,
           "metadata": {
@@ -2866,7 +3050,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "50",
           "target": "53",
           "directed": true,
           "metadata": {
@@ -2876,7 +3060,7 @@
           }
         },
         {
-          "source": "53",
+          "source": "50",
           "target": "54",
           "directed": true,
           "metadata": {
@@ -2886,7 +3070,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "50",
           "target": "55",
           "directed": true,
           "metadata": {
@@ -2896,7 +3080,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "0",
           "target": "56",
           "directed": true,
           "metadata": {
@@ -2906,7 +3090,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "57",
           "directed": true,
           "metadata": {
@@ -2916,7 +3100,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "58",
           "directed": true,
           "metadata": {
@@ -2926,7 +3110,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "59",
           "directed": true,
           "metadata": {
@@ -2936,7 +3120,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "60",
           "directed": true,
           "metadata": {
@@ -2946,7 +3130,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "61",
           "directed": true,
           "metadata": {
@@ -2956,7 +3140,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "62",
           "directed": true,
           "metadata": {
@@ -2966,7 +3150,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "63",
           "directed": true,
           "metadata": {
@@ -2976,7 +3160,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "64",
           "directed": true,
           "metadata": {
@@ -2986,7 +3170,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "65",
           "directed": true,
           "metadata": {
@@ -2996,7 +3180,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "66",
           "directed": true,
           "metadata": {
@@ -3006,7 +3190,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "67",
           "directed": true,
           "metadata": {
@@ -3016,7 +3200,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "68",
           "directed": true,
           "metadata": {
@@ -3026,7 +3210,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "69",
           "directed": true,
           "metadata": {
@@ -3036,7 +3220,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "70",
           "directed": true,
           "metadata": {
@@ -3046,7 +3230,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "71",
           "directed": true,
           "metadata": {
@@ -3056,7 +3240,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "72",
           "directed": true,
           "metadata": {
@@ -3066,7 +3250,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "73",
           "directed": true,
           "metadata": {
@@ -3076,7 +3260,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "74",
           "directed": true,
           "metadata": {
@@ -3086,7 +3270,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "75",
           "directed": true,
           "metadata": {
@@ -3096,7 +3280,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "76",
           "directed": true,
           "metadata": {
@@ -3106,7 +3290,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "77",
           "directed": true,
           "metadata": {
@@ -3116,7 +3300,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "78",
           "directed": true,
           "metadata": {
@@ -3126,7 +3310,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "79",
           "directed": true,
           "metadata": {
@@ -3136,7 +3320,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "80",
           "directed": true,
           "metadata": {
@@ -3146,7 +3330,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "81",
           "directed": true,
           "metadata": {
@@ -3156,7 +3340,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "82",
           "directed": true,
           "metadata": {
@@ -3166,7 +3350,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "83",
           "directed": true,
           "metadata": {
@@ -3176,7 +3360,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "84",
           "directed": true,
           "metadata": {
@@ -3186,7 +3370,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "85",
           "directed": true,
           "metadata": {
@@ -3196,7 +3380,7 @@
           }
         },
         {
-          "source": "54",
+          "source": "56",
           "target": "86",
           "directed": true,
           "metadata": {
@@ -3206,7 +3390,7 @@
           }
         },
         {
-          "source": "53",
+          "source": "56",
           "target": "87",
           "directed": true,
           "metadata": {
@@ -3216,7 +3400,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "88",
           "directed": true,
           "metadata": {
@@ -3226,7 +3410,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "89",
           "directed": true,
           "metadata": {
@@ -3236,7 +3420,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "90",
           "directed": true,
           "metadata": {
@@ -3246,7 +3430,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "91",
           "directed": true,
           "metadata": {
@@ -3256,7 +3440,7 @@
           }
         },
         {
-          "source": "87",
+          "source": "56",
           "target": "92",
           "directed": true,
           "metadata": {
@@ -3266,7 +3450,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "56",
           "target": "93",
           "directed": true,
           "metadata": {
@@ -3618,6 +3802,66 @@
         {
           "source": "123",
           "target": "128",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "0",
+          "target": "129",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "129",
+          "target": "130",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "129",
+          "target": "131",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "129",
+          "target": "132",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "129",
+          "target": "133",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "129",
+          "target": "134",
           "directed": true,
           "metadata": {
             "name": {

--- a/t/data/dws2jgf/expected-compute-01.jgf
+++ b/t/data/dws2jgf/expected-compute-01.jgf
@@ -49,7 +49,10 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": {
+              "rabbit": "kind-worker2",
+              "ssdcount": "36"
+            },
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -58,18 +61,18 @@
         {
           "id": "2",
           "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker2",
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd0",
             "id": 0,
             "uniq_id": 2,
             "rank": -1,
             "exclusive": true,
-            "unit": "",
-            "size": 1,
+            "unit": "GiB",
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
+              "containment": "/ElCapitan0/rack0/ssd0"
             },
             "status": 1
           }
@@ -79,17 +82,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 3,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
-            }
+              "containment": "/ElCapitan0/rack0/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -97,17 +101,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 4,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
-            }
+              "containment": "/ElCapitan0/rack0/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -115,17 +120,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 5,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
-            }
+              "containment": "/ElCapitan0/rack0/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -133,17 +139,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 6,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
-            }
+              "containment": "/ElCapitan0/rack0/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -151,17 +158,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 7,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
-            }
+              "containment": "/ElCapitan0/rack0/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -169,17 +177,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 8,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
-            }
+              "containment": "/ElCapitan0/rack0/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -187,17 +196,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 9,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
-            }
+              "containment": "/ElCapitan0/rack0/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -205,17 +215,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 10,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
-            }
+              "containment": "/ElCapitan0/rack0/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -223,17 +234,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 11,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
-            }
+              "containment": "/ElCapitan0/rack0/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -241,17 +253,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 12,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
-            }
+              "containment": "/ElCapitan0/rack0/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -259,17 +272,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 13,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
-            }
+              "containment": "/ElCapitan0/rack0/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -277,17 +291,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 14,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
-            }
+              "containment": "/ElCapitan0/rack0/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -295,17 +310,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 15,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
-            }
+              "containment": "/ElCapitan0/rack0/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -313,17 +329,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 16,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
-            }
+              "containment": "/ElCapitan0/rack0/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -331,17 +348,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 17,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
-            }
+              "containment": "/ElCapitan0/rack0/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -349,17 +367,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 18,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
-            }
+              "containment": "/ElCapitan0/rack0/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -367,17 +386,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 19,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
-            }
+              "containment": "/ElCapitan0/rack0/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -385,17 +405,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 20,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
-            }
+              "containment": "/ElCapitan0/rack0/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -403,17 +424,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 21,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
-            }
+              "containment": "/ElCapitan0/rack0/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -421,17 +443,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 22,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
-            }
+              "containment": "/ElCapitan0/rack0/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -439,17 +462,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 23,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
-            }
+              "containment": "/ElCapitan0/rack0/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -457,17 +481,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 24,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
-            }
+              "containment": "/ElCapitan0/rack0/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -475,17 +500,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 25,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
-            }
+              "containment": "/ElCapitan0/rack0/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -493,17 +519,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 26,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
-            }
+              "containment": "/ElCapitan0/rack0/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -511,17 +538,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 27,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
-            }
+              "containment": "/ElCapitan0/rack0/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -529,17 +557,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 28,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
-            }
+              "containment": "/ElCapitan0/rack0/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -547,17 +576,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 29,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
-            }
+              "containment": "/ElCapitan0/rack0/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -565,17 +595,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 30,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
-            }
+              "containment": "/ElCapitan0/rack0/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -583,17 +614,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 31,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
-            }
+              "containment": "/ElCapitan0/rack0/ssd29"
+            },
+            "status": 1
           }
         },
         {
@@ -601,17 +633,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd30",
+            "id": 30,
             "uniq_id": 32,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
-            }
+              "containment": "/ElCapitan0/rack0/ssd30"
+            },
+            "status": 1
           }
         },
         {
@@ -619,17 +652,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd31",
+            "id": 31,
             "uniq_id": 33,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
-            }
+              "containment": "/ElCapitan0/rack0/ssd31"
+            },
+            "status": 1
           }
         },
         {
@@ -637,27 +671,85 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd32",
+            "id": 32,
             "uniq_id": 34,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
-            }
+              "containment": "/ElCapitan0/rack0/ssd32"
+            },
+            "status": 1
           }
         },
         {
           "id": "35",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 35,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "36",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 36,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "37",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 37,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "38",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-01",
             "id": 1,
-            "uniq_id": 35,
+            "uniq_id": 38,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -669,13 +761,13 @@
           }
         },
         {
-          "id": "36",
+          "id": "39",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 36,
+            "uniq_id": 39,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -687,75 +779,23 @@
           }
         },
         {
-          "id": "37",
+          "id": "40",
           "metadata": {
             "type": "rack",
             "basename": "rack",
             "name": "rack1",
             "id": 1,
-            "uniq_id": 37,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1"
-            }
-          }
-        },
-        {
-          "id": "38",
-          "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker3",
-            "id": 1,
-            "uniq_id": 38,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
-            },
-            "status": 1
-          }
-        },
-        {
-          "id": "39",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 39,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
-            }
-          }
-        },
-        {
-          "id": "40",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
             "uniq_id": 40,
             "rank": -1,
             "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
+            "unit": "",
+            "size": 1,
+            "properties": {
+              "rabbit": "kind-worker3",
+              "ssdcount": "36"
+            },
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
+              "containment": "/ElCapitan0/rack1"
             }
           }
         },
@@ -764,17 +804,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd0",
+            "id": 0,
             "uniq_id": 41,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
-            }
+              "containment": "/ElCapitan0/rack1/ssd0"
+            },
+            "status": 1
           }
         },
         {
@@ -782,17 +823,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 42,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
-            }
+              "containment": "/ElCapitan0/rack1/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -800,17 +842,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 43,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
-            }
+              "containment": "/ElCapitan0/rack1/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -818,17 +861,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 44,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
-            }
+              "containment": "/ElCapitan0/rack1/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -836,17 +880,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 45,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
-            }
+              "containment": "/ElCapitan0/rack1/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -854,17 +899,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 46,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
-            }
+              "containment": "/ElCapitan0/rack1/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -872,17 +918,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 47,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
-            }
+              "containment": "/ElCapitan0/rack1/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -890,17 +937,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 48,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
-            }
+              "containment": "/ElCapitan0/rack1/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -908,17 +956,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 49,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
-            }
+              "containment": "/ElCapitan0/rack1/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -926,17 +975,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 50,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
-            }
+              "containment": "/ElCapitan0/rack1/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -944,17 +994,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 51,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
-            }
+              "containment": "/ElCapitan0/rack1/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -962,17 +1013,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 52,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
-            }
+              "containment": "/ElCapitan0/rack1/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -980,17 +1032,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 53,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
-            }
+              "containment": "/ElCapitan0/rack1/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -998,17 +1051,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 54,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
-            }
+              "containment": "/ElCapitan0/rack1/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -1016,17 +1070,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 55,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
-            }
+              "containment": "/ElCapitan0/rack1/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -1034,17 +1089,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 56,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
-            }
+              "containment": "/ElCapitan0/rack1/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -1052,17 +1108,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 57,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
-            }
+              "containment": "/ElCapitan0/rack1/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -1070,17 +1127,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 58,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
-            }
+              "containment": "/ElCapitan0/rack1/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -1088,17 +1146,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 59,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
-            }
+              "containment": "/ElCapitan0/rack1/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -1106,17 +1165,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 60,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
-            }
+              "containment": "/ElCapitan0/rack1/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -1124,17 +1184,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 61,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
-            }
+              "containment": "/ElCapitan0/rack1/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -1142,17 +1203,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 62,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
-            }
+              "containment": "/ElCapitan0/rack1/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -1160,17 +1222,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 63,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
-            }
+              "containment": "/ElCapitan0/rack1/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -1178,17 +1241,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 64,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
-            }
+              "containment": "/ElCapitan0/rack1/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -1196,17 +1260,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 65,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
-            }
+              "containment": "/ElCapitan0/rack1/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -1214,17 +1279,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 66,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
-            }
+              "containment": "/ElCapitan0/rack1/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -1232,17 +1298,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 67,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
-            }
+              "containment": "/ElCapitan0/rack1/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -1250,17 +1317,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 68,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
-            }
+              "containment": "/ElCapitan0/rack1/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -1268,17 +1336,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 69,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
-            }
+              "containment": "/ElCapitan0/rack1/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -1286,17 +1355,132 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 70,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
-            }
+              "containment": "/ElCapitan0/rack1/ssd29"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "71",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd30",
+            "id": 30,
+            "uniq_id": 71,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "72",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd31",
+            "id": 31,
+            "uniq_id": 72,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "73",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd32",
+            "id": 32,
+            "uniq_id": 73,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "74",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 74,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "75",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 75,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "76",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 76,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd35"
+            },
+            "status": 1
           }
         }
       ],
@@ -1322,7 +1506,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "3",
           "directed": true,
           "metadata": {
@@ -1332,7 +1516,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "4",
           "directed": true,
           "metadata": {
@@ -1342,7 +1526,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "5",
           "directed": true,
           "metadata": {
@@ -1352,7 +1536,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "6",
           "directed": true,
           "metadata": {
@@ -1362,7 +1546,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "7",
           "directed": true,
           "metadata": {
@@ -1372,7 +1556,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "8",
           "directed": true,
           "metadata": {
@@ -1382,7 +1566,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "9",
           "directed": true,
           "metadata": {
@@ -1392,7 +1576,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "10",
           "directed": true,
           "metadata": {
@@ -1402,7 +1586,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "11",
           "directed": true,
           "metadata": {
@@ -1412,7 +1596,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "12",
           "directed": true,
           "metadata": {
@@ -1422,7 +1606,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "13",
           "directed": true,
           "metadata": {
@@ -1432,7 +1616,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "14",
           "directed": true,
           "metadata": {
@@ -1442,7 +1626,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "15",
           "directed": true,
           "metadata": {
@@ -1452,7 +1636,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "16",
           "directed": true,
           "metadata": {
@@ -1462,7 +1646,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "17",
           "directed": true,
           "metadata": {
@@ -1472,7 +1656,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "18",
           "directed": true,
           "metadata": {
@@ -1482,7 +1666,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "19",
           "directed": true,
           "metadata": {
@@ -1492,7 +1676,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "20",
           "directed": true,
           "metadata": {
@@ -1502,7 +1686,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "21",
           "directed": true,
           "metadata": {
@@ -1512,7 +1696,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "22",
           "directed": true,
           "metadata": {
@@ -1522,7 +1706,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "23",
           "directed": true,
           "metadata": {
@@ -1532,7 +1716,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "24",
           "directed": true,
           "metadata": {
@@ -1542,7 +1726,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "25",
           "directed": true,
           "metadata": {
@@ -1552,7 +1736,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "26",
           "directed": true,
           "metadata": {
@@ -1562,7 +1746,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "27",
           "directed": true,
           "metadata": {
@@ -1572,7 +1756,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "28",
           "directed": true,
           "metadata": {
@@ -1582,7 +1766,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "29",
           "directed": true,
           "metadata": {
@@ -1592,7 +1776,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "30",
           "directed": true,
           "metadata": {
@@ -1602,7 +1786,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "31",
           "directed": true,
           "metadata": {
@@ -1612,7 +1796,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "32",
           "directed": true,
           "metadata": {
@@ -1622,7 +1806,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "33",
           "directed": true,
           "metadata": {
@@ -1632,7 +1816,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "34",
           "directed": true,
           "metadata": {
@@ -1652,7 +1836,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "36",
           "directed": true,
           "metadata": {
@@ -1662,7 +1846,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "1",
           "target": "37",
           "directed": true,
           "metadata": {
@@ -1672,7 +1856,7 @@
           }
         },
         {
-          "source": "37",
+          "source": "1",
           "target": "38",
           "directed": true,
           "metadata": {
@@ -1692,7 +1876,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "0",
           "target": "40",
           "directed": true,
           "metadata": {
@@ -1702,7 +1886,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "41",
           "directed": true,
           "metadata": {
@@ -1712,7 +1896,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "42",
           "directed": true,
           "metadata": {
@@ -1722,7 +1906,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "43",
           "directed": true,
           "metadata": {
@@ -1732,7 +1916,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "44",
           "directed": true,
           "metadata": {
@@ -1742,7 +1926,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "45",
           "directed": true,
           "metadata": {
@@ -1752,7 +1936,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "46",
           "directed": true,
           "metadata": {
@@ -1762,7 +1946,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "47",
           "directed": true,
           "metadata": {
@@ -1772,7 +1956,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "48",
           "directed": true,
           "metadata": {
@@ -1782,7 +1966,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "49",
           "directed": true,
           "metadata": {
@@ -1792,7 +1976,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "50",
           "directed": true,
           "metadata": {
@@ -1802,7 +1986,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "51",
           "directed": true,
           "metadata": {
@@ -1812,7 +1996,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "52",
           "directed": true,
           "metadata": {
@@ -1822,7 +2006,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "53",
           "directed": true,
           "metadata": {
@@ -1832,7 +2016,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "54",
           "directed": true,
           "metadata": {
@@ -1842,7 +2026,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "55",
           "directed": true,
           "metadata": {
@@ -1852,7 +2036,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "56",
           "directed": true,
           "metadata": {
@@ -1862,7 +2046,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "57",
           "directed": true,
           "metadata": {
@@ -1872,7 +2056,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "58",
           "directed": true,
           "metadata": {
@@ -1882,7 +2066,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "59",
           "directed": true,
           "metadata": {
@@ -1892,7 +2076,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "60",
           "directed": true,
           "metadata": {
@@ -1902,7 +2086,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "61",
           "directed": true,
           "metadata": {
@@ -1912,7 +2096,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "62",
           "directed": true,
           "metadata": {
@@ -1922,7 +2106,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "63",
           "directed": true,
           "metadata": {
@@ -1932,7 +2116,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "64",
           "directed": true,
           "metadata": {
@@ -1942,7 +2126,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "65",
           "directed": true,
           "metadata": {
@@ -1952,7 +2136,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "66",
           "directed": true,
           "metadata": {
@@ -1962,7 +2146,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "67",
           "directed": true,
           "metadata": {
@@ -1972,7 +2156,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "68",
           "directed": true,
           "metadata": {
@@ -1982,7 +2166,7 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "69",
           "directed": true,
           "metadata": {
@@ -1992,8 +2176,68 @@
           }
         },
         {
-          "source": "38",
+          "source": "40",
           "target": "70",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "71",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "72",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "73",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "74",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "75",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "40",
+          "target": "76",
           "directed": true,
           "metadata": {
             "name": {

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -52,7 +52,10 @@
             "exclusive": true,
             "unit": "",
             "size": 1,
-            "properties": {},
+            "properties": {
+              "rabbit": "kind-worker2",
+              "ssdcount": "36"
+            },
             "paths": {
               "containment": "/ElCapitan0/rack0"
             }
@@ -61,18 +64,18 @@
         {
           "id": "2",
           "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker2",
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd0",
             "id": 0,
             "uniq_id": 2,
             "rank": -1,
             "exclusive": true,
-            "unit": "",
-            "size": 1,
+            "unit": "GiB",
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2"
+              "containment": "/ElCapitan0/rack0/ssd0"
             },
             "status": 1
           }
@@ -82,17 +85,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 3,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd0"
-            }
+              "containment": "/ElCapitan0/rack0/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -100,17 +104,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 4,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd1"
-            }
+              "containment": "/ElCapitan0/rack0/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -118,17 +123,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 5,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd2"
-            }
+              "containment": "/ElCapitan0/rack0/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -136,17 +142,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 6,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd3"
-            }
+              "containment": "/ElCapitan0/rack0/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -154,17 +161,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 7,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd4"
-            }
+              "containment": "/ElCapitan0/rack0/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -172,17 +180,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 8,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd5"
-            }
+              "containment": "/ElCapitan0/rack0/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -190,17 +199,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 9,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd6"
-            }
+              "containment": "/ElCapitan0/rack0/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -208,17 +218,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 10,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd7"
-            }
+              "containment": "/ElCapitan0/rack0/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -226,17 +237,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 11,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd8"
-            }
+              "containment": "/ElCapitan0/rack0/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -244,17 +256,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 12,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd9"
-            }
+              "containment": "/ElCapitan0/rack0/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -262,17 +275,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 13,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd10"
-            }
+              "containment": "/ElCapitan0/rack0/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -280,17 +294,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 14,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd11"
-            }
+              "containment": "/ElCapitan0/rack0/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -298,17 +313,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 15,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd12"
-            }
+              "containment": "/ElCapitan0/rack0/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -316,17 +332,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 16,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd13"
-            }
+              "containment": "/ElCapitan0/rack0/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -334,17 +351,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 17,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd14"
-            }
+              "containment": "/ElCapitan0/rack0/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -352,17 +370,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 18,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd15"
-            }
+              "containment": "/ElCapitan0/rack0/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -370,17 +389,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 19,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd16"
-            }
+              "containment": "/ElCapitan0/rack0/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -388,17 +408,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 20,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd17"
-            }
+              "containment": "/ElCapitan0/rack0/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -406,17 +427,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 21,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd18"
-            }
+              "containment": "/ElCapitan0/rack0/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -424,17 +446,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 22,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd19"
-            }
+              "containment": "/ElCapitan0/rack0/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -442,17 +465,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 23,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd20"
-            }
+              "containment": "/ElCapitan0/rack0/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -460,17 +484,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 24,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd21"
-            }
+              "containment": "/ElCapitan0/rack0/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -478,17 +503,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 25,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd22"
-            }
+              "containment": "/ElCapitan0/rack0/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -496,17 +522,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 26,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd23"
-            }
+              "containment": "/ElCapitan0/rack0/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -514,17 +541,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 27,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd24"
-            }
+              "containment": "/ElCapitan0/rack0/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -532,17 +560,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 28,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd25"
-            }
+              "containment": "/ElCapitan0/rack0/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -550,17 +579,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 29,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd26"
-            }
+              "containment": "/ElCapitan0/rack0/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -568,17 +598,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 30,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd27"
-            }
+              "containment": "/ElCapitan0/rack0/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -586,17 +617,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 31,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd28"
-            }
+              "containment": "/ElCapitan0/rack0/ssd29"
+            },
+            "status": 1
           }
         },
         {
@@ -604,17 +636,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd30",
+            "id": 30,
             "uniq_id": 32,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd29"
-            }
+              "containment": "/ElCapitan0/rack0/ssd30"
+            },
+            "status": 1
           }
         },
         {
@@ -622,17 +655,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd31",
+            "id": 31,
             "uniq_id": 33,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd30"
-            }
+              "containment": "/ElCapitan0/rack0/ssd31"
+            },
+            "status": 1
           }
         },
         {
@@ -640,27 +674,85 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd32",
+            "id": 32,
             "uniq_id": 34,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/rabbit-kind-worker2/ssd31"
-            }
+              "containment": "/ElCapitan0/rack0/ssd32"
+            },
+            "status": 1
           }
         },
         {
           "id": "35",
           "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 35,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "36",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 36,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "37",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 37,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack0/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "38",
+          "metadata": {
             "type": "node",
             "basename": "node",
             "name": "compute-01",
             "id": 1,
-            "uniq_id": 35,
+            "uniq_id": 38,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -674,13 +766,13 @@
           }
         },
         {
-          "id": "36",
+          "id": "39",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core0",
             "id": 0,
-            "uniq_id": 36,
+            "uniq_id": 39,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -692,13 +784,13 @@
           }
         },
         {
-          "id": "37",
+          "id": "40",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core1",
             "id": 1,
-            "uniq_id": 37,
+            "uniq_id": 40,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -710,13 +802,13 @@
           }
         },
         {
-          "id": "38",
+          "id": "41",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core2",
             "id": 2,
-            "uniq_id": 38,
+            "uniq_id": 41,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -728,13 +820,13 @@
           }
         },
         {
-          "id": "39",
+          "id": "42",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core3",
             "id": 3,
-            "uniq_id": 39,
+            "uniq_id": 42,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -746,13 +838,13 @@
           }
         },
         {
-          "id": "40",
+          "id": "43",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core4",
             "id": 4,
-            "uniq_id": 40,
+            "uniq_id": 43,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -764,13 +856,13 @@
           }
         },
         {
-          "id": "41",
+          "id": "44",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core5",
             "id": 5,
-            "uniq_id": 41,
+            "uniq_id": 44,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -782,13 +874,13 @@
           }
         },
         {
-          "id": "42",
+          "id": "45",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core6",
             "id": 6,
-            "uniq_id": 42,
+            "uniq_id": 45,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -800,13 +892,13 @@
           }
         },
         {
-          "id": "43",
+          "id": "46",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core7",
             "id": 7,
-            "uniq_id": 43,
+            "uniq_id": 46,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -818,13 +910,13 @@
           }
         },
         {
-          "id": "44",
+          "id": "47",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core8",
             "id": 8,
-            "uniq_id": 44,
+            "uniq_id": 47,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -836,13 +928,13 @@
           }
         },
         {
-          "id": "45",
+          "id": "48",
           "metadata": {
             "type": "core",
             "basename": "core",
             "name": "core9",
             "id": 9,
-            "uniq_id": 45,
+            "uniq_id": 48,
             "rank": 0,
             "exclusive": true,
             "unit": "",
@@ -854,75 +946,23 @@
           }
         },
         {
-          "id": "46",
+          "id": "49",
           "metadata": {
             "type": "rack",
             "basename": "rack",
             "name": "rack1",
             "id": 1,
-            "uniq_id": 46,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1"
-            }
-          }
-        },
-        {
-          "id": "47",
-          "metadata": {
-            "type": "rabbit",
-            "basename": "rabbit",
-            "name": "rabbit-kind-worker3",
-            "id": 1,
-            "uniq_id": 47,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3"
-            },
-            "status": 1
-          }
-        },
-        {
-          "id": "48",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 48,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
-            "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd0"
-            }
-          }
-        },
-        {
-          "id": "49",
-          "metadata": {
-            "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
             "uniq_id": 49,
             "rank": -1,
             "exclusive": true,
-            "unit": "GiB",
-            "size": 1152,
-            "properties": {},
+            "unit": "",
+            "size": 1,
+            "properties": {
+              "rabbit": "kind-worker3",
+              "ssdcount": "36"
+            },
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd1"
+              "containment": "/ElCapitan0/rack1"
             }
           }
         },
@@ -931,17 +971,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
+            "name": "ssd0",
+            "id": 0,
             "uniq_id": 50,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd2"
-            }
+              "containment": "/ElCapitan0/rack1/ssd0"
+            },
+            "status": 1
           }
         },
         {
@@ -949,17 +990,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
+            "name": "ssd1",
+            "id": 1,
             "uniq_id": 51,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd3"
-            }
+              "containment": "/ElCapitan0/rack1/ssd1"
+            },
+            "status": 1
           }
         },
         {
@@ -967,17 +1009,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
+            "name": "ssd2",
+            "id": 2,
             "uniq_id": 52,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd4"
-            }
+              "containment": "/ElCapitan0/rack1/ssd2"
+            },
+            "status": 1
           }
         },
         {
@@ -985,17 +1028,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
+            "name": "ssd3",
+            "id": 3,
             "uniq_id": 53,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd5"
-            }
+              "containment": "/ElCapitan0/rack1/ssd3"
+            },
+            "status": 1
           }
         },
         {
@@ -1003,17 +1047,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
+            "name": "ssd4",
+            "id": 4,
             "uniq_id": 54,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd6"
-            }
+              "containment": "/ElCapitan0/rack1/ssd4"
+            },
+            "status": 1
           }
         },
         {
@@ -1021,17 +1066,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
+            "name": "ssd5",
+            "id": 5,
             "uniq_id": 55,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd7"
-            }
+              "containment": "/ElCapitan0/rack1/ssd5"
+            },
+            "status": 1
           }
         },
         {
@@ -1039,17 +1085,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
+            "name": "ssd6",
+            "id": 6,
             "uniq_id": 56,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd8"
-            }
+              "containment": "/ElCapitan0/rack1/ssd6"
+            },
+            "status": 1
           }
         },
         {
@@ -1057,17 +1104,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
+            "name": "ssd7",
+            "id": 7,
             "uniq_id": 57,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd9"
-            }
+              "containment": "/ElCapitan0/rack1/ssd7"
+            },
+            "status": 1
           }
         },
         {
@@ -1075,17 +1123,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
+            "name": "ssd8",
+            "id": 8,
             "uniq_id": 58,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd10"
-            }
+              "containment": "/ElCapitan0/rack1/ssd8"
+            },
+            "status": 1
           }
         },
         {
@@ -1093,17 +1142,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
+            "name": "ssd9",
+            "id": 9,
             "uniq_id": 59,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd11"
-            }
+              "containment": "/ElCapitan0/rack1/ssd9"
+            },
+            "status": 1
           }
         },
         {
@@ -1111,17 +1161,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
+            "name": "ssd10",
+            "id": 10,
             "uniq_id": 60,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd12"
-            }
+              "containment": "/ElCapitan0/rack1/ssd10"
+            },
+            "status": 1
           }
         },
         {
@@ -1129,17 +1180,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
+            "name": "ssd11",
+            "id": 11,
             "uniq_id": 61,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd13"
-            }
+              "containment": "/ElCapitan0/rack1/ssd11"
+            },
+            "status": 1
           }
         },
         {
@@ -1147,17 +1199,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
+            "name": "ssd12",
+            "id": 12,
             "uniq_id": 62,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd14"
-            }
+              "containment": "/ElCapitan0/rack1/ssd12"
+            },
+            "status": 1
           }
         },
         {
@@ -1165,17 +1218,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
+            "name": "ssd13",
+            "id": 13,
             "uniq_id": 63,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd15"
-            }
+              "containment": "/ElCapitan0/rack1/ssd13"
+            },
+            "status": 1
           }
         },
         {
@@ -1183,17 +1237,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
+            "name": "ssd14",
+            "id": 14,
             "uniq_id": 64,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd16"
-            }
+              "containment": "/ElCapitan0/rack1/ssd14"
+            },
+            "status": 1
           }
         },
         {
@@ -1201,17 +1256,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
+            "name": "ssd15",
+            "id": 15,
             "uniq_id": 65,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd17"
-            }
+              "containment": "/ElCapitan0/rack1/ssd15"
+            },
+            "status": 1
           }
         },
         {
@@ -1219,17 +1275,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
+            "name": "ssd16",
+            "id": 16,
             "uniq_id": 66,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd18"
-            }
+              "containment": "/ElCapitan0/rack1/ssd16"
+            },
+            "status": 1
           }
         },
         {
@@ -1237,17 +1294,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
+            "name": "ssd17",
+            "id": 17,
             "uniq_id": 67,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd19"
-            }
+              "containment": "/ElCapitan0/rack1/ssd17"
+            },
+            "status": 1
           }
         },
         {
@@ -1255,17 +1313,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
+            "name": "ssd18",
+            "id": 18,
             "uniq_id": 68,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd20"
-            }
+              "containment": "/ElCapitan0/rack1/ssd18"
+            },
+            "status": 1
           }
         },
         {
@@ -1273,17 +1332,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
+            "name": "ssd19",
+            "id": 19,
             "uniq_id": 69,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd21"
-            }
+              "containment": "/ElCapitan0/rack1/ssd19"
+            },
+            "status": 1
           }
         },
         {
@@ -1291,17 +1351,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
+            "name": "ssd20",
+            "id": 20,
             "uniq_id": 70,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd22"
-            }
+              "containment": "/ElCapitan0/rack1/ssd20"
+            },
+            "status": 1
           }
         },
         {
@@ -1309,17 +1370,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
+            "name": "ssd21",
+            "id": 21,
             "uniq_id": 71,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd23"
-            }
+              "containment": "/ElCapitan0/rack1/ssd21"
+            },
+            "status": 1
           }
         },
         {
@@ -1327,17 +1389,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
+            "name": "ssd22",
+            "id": 22,
             "uniq_id": 72,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd24"
-            }
+              "containment": "/ElCapitan0/rack1/ssd22"
+            },
+            "status": 1
           }
         },
         {
@@ -1345,17 +1408,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
+            "name": "ssd23",
+            "id": 23,
             "uniq_id": 73,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd25"
-            }
+              "containment": "/ElCapitan0/rack1/ssd23"
+            },
+            "status": 1
           }
         },
         {
@@ -1363,17 +1427,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
+            "name": "ssd24",
+            "id": 24,
             "uniq_id": 74,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd26"
-            }
+              "containment": "/ElCapitan0/rack1/ssd24"
+            },
+            "status": 1
           }
         },
         {
@@ -1381,17 +1446,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
+            "name": "ssd25",
+            "id": 25,
             "uniq_id": 75,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd27"
-            }
+              "containment": "/ElCapitan0/rack1/ssd25"
+            },
+            "status": 1
           }
         },
         {
@@ -1399,17 +1465,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
+            "name": "ssd26",
+            "id": 26,
             "uniq_id": 76,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd28"
-            }
+              "containment": "/ElCapitan0/rack1/ssd26"
+            },
+            "status": 1
           }
         },
         {
@@ -1417,17 +1484,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
+            "name": "ssd27",
+            "id": 27,
             "uniq_id": 77,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd29"
-            }
+              "containment": "/ElCapitan0/rack1/ssd27"
+            },
+            "status": 1
           }
         },
         {
@@ -1435,17 +1503,18 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
+            "name": "ssd28",
+            "id": 28,
             "uniq_id": 78,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd30"
-            }
+              "containment": "/ElCapitan0/rack1/ssd28"
+            },
+            "status": 1
           }
         },
         {
@@ -1453,17 +1522,132 @@
           "metadata": {
             "type": "ssd",
             "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
+            "name": "ssd29",
+            "id": 29,
             "uniq_id": 79,
             "rank": -1,
             "exclusive": true,
             "unit": "GiB",
-            "size": 1152,
+            "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/rabbit-kind-worker3/ssd31"
-            }
+              "containment": "/ElCapitan0/rack1/ssd29"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "80",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd30",
+            "id": 30,
+            "uniq_id": 80,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "81",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd31",
+            "id": 31,
+            "uniq_id": 81,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "82",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd32",
+            "id": 32,
+            "uniq_id": 82,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "83",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd33",
+            "id": 33,
+            "uniq_id": 83,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "84",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd34",
+            "id": 34,
+            "uniq_id": 84,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "85",
+          "metadata": {
+            "type": "ssd",
+            "basename": "ssd",
+            "name": "ssd35",
+            "id": 35,
+            "uniq_id": 85,
+            "rank": -1,
+            "exclusive": true,
+            "unit": "GiB",
+            "size": 1024,
+            "properties": {},
+            "paths": {
+              "containment": "/ElCapitan0/rack1/ssd35"
+            },
+            "status": 1
           }
         }
       ],
@@ -1489,7 +1673,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "3",
           "directed": true,
           "metadata": {
@@ -1499,7 +1683,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "4",
           "directed": true,
           "metadata": {
@@ -1509,7 +1693,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "5",
           "directed": true,
           "metadata": {
@@ -1519,7 +1703,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "6",
           "directed": true,
           "metadata": {
@@ -1529,7 +1713,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "7",
           "directed": true,
           "metadata": {
@@ -1539,7 +1723,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "8",
           "directed": true,
           "metadata": {
@@ -1549,7 +1733,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "9",
           "directed": true,
           "metadata": {
@@ -1559,7 +1743,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "10",
           "directed": true,
           "metadata": {
@@ -1569,7 +1753,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "11",
           "directed": true,
           "metadata": {
@@ -1579,7 +1763,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "12",
           "directed": true,
           "metadata": {
@@ -1589,7 +1773,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "13",
           "directed": true,
           "metadata": {
@@ -1599,7 +1783,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "14",
           "directed": true,
           "metadata": {
@@ -1609,7 +1793,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "15",
           "directed": true,
           "metadata": {
@@ -1619,7 +1803,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "16",
           "directed": true,
           "metadata": {
@@ -1629,7 +1813,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "17",
           "directed": true,
           "metadata": {
@@ -1639,7 +1823,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "18",
           "directed": true,
           "metadata": {
@@ -1649,7 +1833,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "19",
           "directed": true,
           "metadata": {
@@ -1659,7 +1843,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "20",
           "directed": true,
           "metadata": {
@@ -1669,7 +1853,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "21",
           "directed": true,
           "metadata": {
@@ -1679,7 +1863,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "22",
           "directed": true,
           "metadata": {
@@ -1689,7 +1873,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "23",
           "directed": true,
           "metadata": {
@@ -1699,7 +1883,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "24",
           "directed": true,
           "metadata": {
@@ -1709,7 +1893,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "25",
           "directed": true,
           "metadata": {
@@ -1719,7 +1903,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "26",
           "directed": true,
           "metadata": {
@@ -1729,7 +1913,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "27",
           "directed": true,
           "metadata": {
@@ -1739,7 +1923,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "28",
           "directed": true,
           "metadata": {
@@ -1749,7 +1933,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "29",
           "directed": true,
           "metadata": {
@@ -1759,7 +1943,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "30",
           "directed": true,
           "metadata": {
@@ -1769,7 +1953,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "31",
           "directed": true,
           "metadata": {
@@ -1779,7 +1963,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "32",
           "directed": true,
           "metadata": {
@@ -1789,7 +1973,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "33",
           "directed": true,
           "metadata": {
@@ -1799,7 +1983,7 @@
           }
         },
         {
-          "source": "2",
+          "source": "1",
           "target": "34",
           "directed": true,
           "metadata": {
@@ -1819,7 +2003,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "36",
           "directed": true,
           "metadata": {
@@ -1829,7 +2013,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "37",
           "directed": true,
           "metadata": {
@@ -1839,7 +2023,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "1",
           "target": "38",
           "directed": true,
           "metadata": {
@@ -1849,7 +2033,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "39",
           "directed": true,
           "metadata": {
@@ -1859,7 +2043,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "40",
           "directed": true,
           "metadata": {
@@ -1869,7 +2053,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "41",
           "directed": true,
           "metadata": {
@@ -1879,7 +2063,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "42",
           "directed": true,
           "metadata": {
@@ -1889,7 +2073,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "43",
           "directed": true,
           "metadata": {
@@ -1899,7 +2083,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "44",
           "directed": true,
           "metadata": {
@@ -1909,7 +2093,7 @@
           }
         },
         {
-          "source": "35",
+          "source": "38",
           "target": "45",
           "directed": true,
           "metadata": {
@@ -1919,7 +2103,7 @@
           }
         },
         {
-          "source": "0",
+          "source": "38",
           "target": "46",
           "directed": true,
           "metadata": {
@@ -1929,7 +2113,7 @@
           }
         },
         {
-          "source": "46",
+          "source": "38",
           "target": "47",
           "directed": true,
           "metadata": {
@@ -1939,7 +2123,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "38",
           "target": "48",
           "directed": true,
           "metadata": {
@@ -1949,7 +2133,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "0",
           "target": "49",
           "directed": true,
           "metadata": {
@@ -1959,7 +2143,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "50",
           "directed": true,
           "metadata": {
@@ -1969,7 +2153,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "51",
           "directed": true,
           "metadata": {
@@ -1979,7 +2163,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "52",
           "directed": true,
           "metadata": {
@@ -1989,7 +2173,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "53",
           "directed": true,
           "metadata": {
@@ -1999,7 +2183,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "54",
           "directed": true,
           "metadata": {
@@ -2009,7 +2193,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "55",
           "directed": true,
           "metadata": {
@@ -2019,7 +2203,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "56",
           "directed": true,
           "metadata": {
@@ -2029,7 +2213,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "57",
           "directed": true,
           "metadata": {
@@ -2039,7 +2223,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "58",
           "directed": true,
           "metadata": {
@@ -2049,7 +2233,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "59",
           "directed": true,
           "metadata": {
@@ -2059,7 +2243,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "60",
           "directed": true,
           "metadata": {
@@ -2069,7 +2253,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "61",
           "directed": true,
           "metadata": {
@@ -2079,7 +2263,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "62",
           "directed": true,
           "metadata": {
@@ -2089,7 +2273,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "63",
           "directed": true,
           "metadata": {
@@ -2099,7 +2283,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "64",
           "directed": true,
           "metadata": {
@@ -2109,7 +2293,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "65",
           "directed": true,
           "metadata": {
@@ -2119,7 +2303,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "66",
           "directed": true,
           "metadata": {
@@ -2129,7 +2313,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "67",
           "directed": true,
           "metadata": {
@@ -2139,7 +2323,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "68",
           "directed": true,
           "metadata": {
@@ -2149,7 +2333,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "69",
           "directed": true,
           "metadata": {
@@ -2159,7 +2343,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "70",
           "directed": true,
           "metadata": {
@@ -2169,7 +2353,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "71",
           "directed": true,
           "metadata": {
@@ -2179,7 +2363,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "72",
           "directed": true,
           "metadata": {
@@ -2189,7 +2373,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "73",
           "directed": true,
           "metadata": {
@@ -2199,7 +2383,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "74",
           "directed": true,
           "metadata": {
@@ -2209,7 +2393,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "75",
           "directed": true,
           "metadata": {
@@ -2219,7 +2403,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "76",
           "directed": true,
           "metadata": {
@@ -2229,7 +2413,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "77",
           "directed": true,
           "metadata": {
@@ -2239,7 +2423,7 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "78",
           "directed": true,
           "metadata": {
@@ -2249,8 +2433,68 @@
           }
         },
         {
-          "source": "47",
+          "source": "49",
           "target": "79",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "80",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "81",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "82",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "83",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "84",
+          "directed": true,
+          "metadata": {
+            "name": {
+              "containment": "contains"
+            }
+          }
+        },
+        {
+          "source": "49",
+          "target": "85",
           "directed": true,
           "metadata": {
             "name": {

--- a/t/data/dws2jgf/rabbit-jobspec.json
+++ b/t/data/dws2jgf/rabbit-jobspec.json
@@ -1,39 +1,27 @@
 {
   "resources": [
     {
-      "type": "rack",
+      "type": "node",
       "count": 1,
+      "exclusive": true,
       "with": [
         {
-          "type": "node",
-          "count": 1,
-          "exclusive": true,
-          "with": [
-            {
-              "type": "slot",
-              "count": 1,
-              "with": [
-                {
-                  "type": "core",
-                  "count": 1
-                }
-              ],
-              "label": "task"
-            }
-          ]
-        },
-        {
-          "type": "rabbit",
+          "type": "slot",
           "count": 1,
           "with": [
             {
-              "type": "ssd",
-              "count": 2048,
-              "exclusive": true
+              "type": "core",
+              "count": 1
             }
-          ]
+          ],
+          "label": "task"
         }
       ]
+    },
+    {
+      "type": "ssd",
+      "count": 1,
+      "exclusive": true
     }
   ],
   "tasks": [

--- a/t/data/nnf-watch/rabbit-jobspec.json
+++ b/t/data/nnf-watch/rabbit-jobspec.json
@@ -1,39 +1,27 @@
 {
   "resources": [
     {
-      "type": "rack",
+      "type": "node",
       "count": 1,
+      "exclusive": true,
       "with": [
         {
-          "type": "node",
-          "count": 1,
-          "exclusive": true,
-          "with": [
-            {
-              "type": "slot",
-              "count": 1,
-              "with": [
-                {
-                  "type": "core",
-                  "count": 1
-                }
-              ],
-              "label": "task"
-            }
-          ]
-        },
-        {
-          "type": "rabbit",
+          "type": "slot",
           "count": 1,
           "with": [
             {
-              "type": "ssd",
-              "count": 2048,
-              "exclusive": true
+              "type": "core",
+              "count": 1
             }
-          ]
+          ],
+          "label": "task"
         }
       ]
+    },
+    {
+      "type": "ssd",
+      "count": 2048,
+      "exclusive": true
     }
   ],
   "tasks": [

--- a/t/python/t0001-directive-breakdown.py
+++ b/t/python/t0001-directive-breakdown.py
@@ -39,18 +39,15 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
-            rack = new_resources[0]
-            self.assertEqual(rack["type"], "rack")
-            self.assertEqual(rack["count"], nodecount)
-            self.assertEqual(len(rack["with"]), 2)
-            self.assertEqual(rack["with"][0]["type"], "node")
-            self.assertEqual(rack["with"][0]["count"], 1)
-            rabbit = rack["with"][1]
-            self.assertEqual(rabbit["type"], "rabbit")
-            self.assertEqual(rabbit["count"], 1)
-            self.assertEqual(len(rabbit["with"]), 1)
-            self.assertEqual(rabbit["with"][0]["type"], "ssd")
-            self.assertEqual(rabbit["with"][0]["count"], 10241 // nodecount)
+            slot = new_resources[0]
+            self.assertEqual(slot["type"], "slot")
+            self.assertEqual(slot["count"], nodecount)
+            self.assertEqual(len(slot["with"]), 2)
+            self.assertEqual(slot["with"][0]["type"], "node")
+            self.assertEqual(slot["with"][0]["count"], 1)
+            ssds = slot["with"][1]
+            self.assertEqual(ssds["type"], "ssd")
+            self.assertEqual(ssds["count"], 10241 // nodecount)
 
     @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_xfs10gb(self, patched_fetch):
@@ -60,18 +57,15 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
-            rack = new_resources[0]
-            self.assertEqual(rack["type"], "rack")
-            self.assertEqual(rack["count"], nodecount)
-            self.assertEqual(len(rack["with"]), 2)
-            self.assertEqual(rack["with"][0]["type"], "node")
-            self.assertEqual(rack["with"][0]["count"], 1)
-            rabbit = rack["with"][1]
-            self.assertEqual(rabbit["type"], "rabbit")
-            self.assertEqual(rabbit["count"], 1)
-            self.assertEqual(len(rabbit["with"]), 1)
-            self.assertEqual(rabbit["with"][0]["type"], "ssd")
-            self.assertEqual(rabbit["with"][0]["count"], 10)
+            slot = new_resources[0]
+            self.assertEqual(slot["type"], "slot")
+            self.assertEqual(slot["count"], nodecount)
+            self.assertEqual(len(slot["with"]), 2)
+            self.assertEqual(slot["with"][0]["type"], "node")
+            self.assertEqual(slot["with"][0]["count"], 1)
+            ssds = slot["with"][1]
+            self.assertEqual(ssds["type"], "ssd")
+            self.assertEqual(ssds["count"], 10)
 
     @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_xfs10gb_aggregation(self, patched_fetch):
@@ -83,18 +77,15 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
-            rack = new_resources[0]
-            self.assertEqual(rack["type"], "rack")
-            self.assertEqual(rack["count"], nodecount)
-            self.assertEqual(len(rack["with"]), 2)
-            self.assertEqual(rack["with"][0]["type"], "node")
-            self.assertEqual(rack["with"][0]["count"], 1)
-            rabbit = rack["with"][1]
-            self.assertEqual(rabbit["type"], "rabbit")
-            self.assertEqual(rabbit["count"], 1)
-            self.assertEqual(len(rabbit["with"]), 1)
-            self.assertEqual(rabbit["with"][0]["type"], "ssd")
-            self.assertEqual(rabbit["with"][0]["count"], 20)
+            slot = new_resources[0]
+            self.assertEqual(slot["type"], "slot")
+            self.assertEqual(slot["count"], nodecount)
+            self.assertEqual(len(slot["with"]), 2)
+            self.assertEqual(slot["with"][0]["type"], "node")
+            self.assertEqual(slot["with"][0]["count"], 1)
+            ssds = slot["with"][1]
+            self.assertEqual(ssds["type"], "ssd")
+            self.assertEqual(ssds["count"], 20)
 
     @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_combination_xfs_lustre(self, patched_fetch):
@@ -105,18 +96,15 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
         patched_fetch.assert_called_with(None, None)
         self.assertEqual(len(new_resources), 1)
-        rack = new_resources[0]
-        self.assertEqual(rack["type"], "rack")
-        self.assertEqual(rack["count"], 1)
-        self.assertEqual(len(rack["with"]), 2)
-        self.assertEqual(rack["with"][0]["type"], "node")
-        self.assertEqual(rack["with"][0]["count"], 1)
-        rabbit = rack["with"][1]
-        self.assertEqual(rabbit["type"], "rabbit")
-        self.assertEqual(rabbit["count"], 1)
-        self.assertEqual(len(rabbit["with"]), 1)
-        self.assertEqual(rabbit["with"][0]["type"], "ssd")
-        self.assertEqual(rabbit["with"][0]["count"], 10241 + 10)
+        slot = new_resources[0]
+        self.assertEqual(slot["type"], "slot")
+        self.assertEqual(slot["count"], 1)
+        self.assertEqual(len(slot["with"]), 2)
+        self.assertEqual(slot["with"][0]["type"], "node")
+        self.assertEqual(slot["with"][0]["count"], 1)
+        ssds = slot["with"][1]
+        self.assertEqual(ssds["type"], "ssd")
+        self.assertEqual(ssds["count"], 10241 + 10)
 
     @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
     def test_bad_resources(self, patched_fetch):
@@ -150,18 +138,15 @@ class TestDirectiveBreakdowns(unittest.TestCase):
                 new_resources = directivebreakdown.apply_breakdowns(None, None, resources, min_size)
                 patched_fetch.assert_called_with(None, None)
                 self.assertEqual(len(new_resources), 1)
-                rack = new_resources[0]
-                self.assertEqual(rack["type"], "rack")
-                self.assertEqual(rack["count"], nodecount)
-                self.assertEqual(len(rack["with"]), 2)
-                self.assertEqual(rack["with"][0]["type"], "node")
-                self.assertEqual(rack["with"][0]["count"], 1)
-                rabbit = rack["with"][1]
-                self.assertEqual(rabbit["type"], "rabbit")
-                self.assertEqual(rabbit["count"], 1)
-                self.assertEqual(len(rabbit["with"]), 1)
-                self.assertEqual(rabbit["with"][0]["type"], "ssd")
-                self.assertEqual(rabbit["with"][0]["count"], min_size)
+                slot = new_resources[0]
+                self.assertEqual(slot["type"], "slot")
+                self.assertEqual(slot["count"], nodecount)
+                self.assertEqual(len(slot["with"]), 2)
+                self.assertEqual(slot["with"][0]["type"], "node")
+                self.assertEqual(slot["with"][0]["count"], 1)
+                ssds = slot["with"][1]
+                self.assertEqual(ssds["type"], "ssd")
+                self.assertEqual(ssds["count"], min_size)
 
 
 unittest.main(testRunner=TAPTestRunner())

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -28,8 +28,9 @@ DATADIR=${SHARNESS_TEST_SRCDIR}/data/workflow-obj
 # 	flux jobtap load alloc-bypass.so
 # '
 
-test_expect_success 'job-manager: load dws-jobtap plugin' '
-	flux jobtap load ${PLUGINPATH}/dws-jobtap.so
+test_expect_success 'job-manager: load dws-jobtap and alloc-bypass plugin' '
+	flux jobtap load ${PLUGINPATH}/dws-jobtap.so &&
+	flux jobtap load alloc-bypass.so
 '
 
 test_expect_success 'exec dws service-providing script with bad arguments' '
@@ -203,6 +204,7 @@ test_expect_success 'dws service kills workflows in Error properly' '
 test_expect_success 'exec dws service-providing script with custom config path' '
 	flux cancel ${DWS_JOBID} &&
 	cp $REAL_HOME/.kube/config ./kubeconfig
+	R=$(flux R encode -r 0) &&
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
@@ -259,6 +261,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 		${jobid} prolog-start &&
 	flux job wait-event -vt 30 ${jobid} start &&
 	flux cancel ${DWS_JOBID} &&
+	R=$(flux R encode -r 0) &&
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -50,7 +50,7 @@ test_expect_success 'rabbits default to down and are not allocated' '
 
 test_expect_success 'exec Storage watching script' '
     jobid=$(flux submit \
-            --setattr=system.alloc-bypass.R="$(cat R.local)" --output=dws.out --error=dws.err \
+            --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws.out --error=dws.err \
             -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start
 '
@@ -133,7 +133,7 @@ test_expect_success 'test that flux drains Offline compute nodes' '
 test_expect_success 'exec Storage watching script with --disable-draining' '
     flux cancel ${jobid} &&
     jobid=$(flux submit \
-            --setattr=system.alloc-bypass.R="$(cat R.local)" --output=dws.out --error=dws.err \
+            --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws.out --error=dws.err \
             -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local \
             --disable-compute-node-draining) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -88,7 +88,7 @@ test_expect_success HAVE_JQ 'fluxion does not allocate a rack/rabbit job after a
 '
 
 test_expect_success HAVE_JQ 'fluxion allocates a rack/rabbit job when rabbit is up' '
-	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan0/rack0/rabbit-kind-worker2 up &&
+	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan0/rack0/ssd0 up &&
 	JOBID=$(flux job submit ${DATADIR}/rabbit-jobspec.json) &&
 	flux job wait-event -vt 2 -m status=0 ${JOBID} finish &&
 	flux job attach $JOBID &&


### PR DESCRIPTION
As noted [here](https://github.com/flux-framework/flux-sched/discussions/1189), the existing Fluxion graph layout imposes a serious limitation on scheduling: every node is forced to be on a different rack.

By changing the resource graph to remove intermediate "rabbit" vertices between "rack" and "ssd", this limitation can be worked around. It also opens up possibilities for better Fluxion scheduling of lustre-only rabbit jobs.