### PR TITLE
dws: change exception import path

### DIFF
--- a/src/python/flux_k8s/watch.py
+++ b/src/python/flux_k8s/watch.py
@@ -5,8 +5,6 @@ from flux.constants import FLUX_MSGTYPE_REQUEST
 import kubernetes as k8s
 from kubernetes.client.rest import ApiException
 
-from flux.core.watchers import fd_handler_wrapper
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/python/flux_k8s/watch.py
+++ b/src/python/flux_k8s/watch.py
@@ -3,8 +3,7 @@ import logging
 
 from flux.constants import FLUX_MSGTYPE_REQUEST
 import kubernetes as k8s
-from kubernetes.client.exceptions import ApiException
-
+from kubernetes.client.rest import ApiException
 
 from flux.core.watchers import fd_handler_wrapper
 


### PR DESCRIPTION
Problem: some older versions of kubernetes do not have a 'kubernetes.client.exceptions' module which 'watch.py' attempts to import from.

Add a try/except around the import, and if the import fails, create a dummy exception with the same name.