### PR TITLE
dws2jgf: change cluster-name logic

### DIFF
--- a/t/data/dws2jgf/expected-compute-01-nodws.jgf
+++ b/t/data/dws2jgf/expected-compute-01-nodws.jgf
@@ -23,8 +23,8 @@
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "ElCapitan",
-            "name": "ElCapitan0",
+            "basename": "compute",
+            "name": "compute0",
             "id": 0,
             "uniq_id": 0,
             "rank": -1,
@@ -33,7 +33,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0"
+              "containment": "/compute0"
             }
           }
         },
@@ -54,7 +54,7 @@
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack0"
+              "containment": "/compute0/rack0"
             }
           }
         },
@@ -72,7 +72,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd0"
+              "containment": "/compute0/rack0/ssd0"
             },
             "status": 1
           }
@@ -91,7 +91,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd1"
+              "containment": "/compute0/rack0/ssd1"
             },
             "status": 1
           }
@@ -110,7 +110,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd2"
+              "containment": "/compute0/rack0/ssd2"
             },
             "status": 1
           }
@@ -129,7 +129,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd3"
+              "containment": "/compute0/rack0/ssd3"
             },
             "status": 1
           }
@@ -148,7 +148,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd4"
+              "containment": "/compute0/rack0/ssd4"
             },
             "status": 1
           }
@@ -167,7 +167,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd5"
+              "containment": "/compute0/rack0/ssd5"
             },
             "status": 1
           }
@@ -186,7 +186,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd6"
+              "containment": "/compute0/rack0/ssd6"
             },
             "status": 1
           }
@@ -205,7 +205,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd7"
+              "containment": "/compute0/rack0/ssd7"
             },
             "status": 1
           }
@@ -224,7 +224,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd8"
+              "containment": "/compute0/rack0/ssd8"
             },
             "status": 1
           }
@@ -243,7 +243,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd9"
+              "containment": "/compute0/rack0/ssd9"
             },
             "status": 1
           }
@@ -262,7 +262,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd10"
+              "containment": "/compute0/rack0/ssd10"
             },
             "status": 1
           }
@@ -281,7 +281,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd11"
+              "containment": "/compute0/rack0/ssd11"
             },
             "status": 1
           }
@@ -300,7 +300,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd12"
+              "containment": "/compute0/rack0/ssd12"
             },
             "status": 1
           }
@@ -319,7 +319,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd13"
+              "containment": "/compute0/rack0/ssd13"
             },
             "status": 1
           }
@@ -338,7 +338,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd14"
+              "containment": "/compute0/rack0/ssd14"
             },
             "status": 1
           }
@@ -357,7 +357,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd15"
+              "containment": "/compute0/rack0/ssd15"
             },
             "status": 1
           }
@@ -376,7 +376,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd16"
+              "containment": "/compute0/rack0/ssd16"
             },
             "status": 1
           }
@@ -395,7 +395,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd17"
+              "containment": "/compute0/rack0/ssd17"
             },
             "status": 1
           }
@@ -414,7 +414,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd18"
+              "containment": "/compute0/rack0/ssd18"
             },
             "status": 1
           }
@@ -433,7 +433,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd19"
+              "containment": "/compute0/rack0/ssd19"
             },
             "status": 1
           }
@@ -452,7 +452,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd20"
+              "containment": "/compute0/rack0/ssd20"
             },
             "status": 1
           }
@@ -471,7 +471,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd21"
+              "containment": "/compute0/rack0/ssd21"
             },
             "status": 1
           }
@@ -490,7 +490,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd22"
+              "containment": "/compute0/rack0/ssd22"
             },
             "status": 1
           }
@@ -509,7 +509,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd23"
+              "containment": "/compute0/rack0/ssd23"
             },
             "status": 1
           }
@@ -528,7 +528,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd24"
+              "containment": "/compute0/rack0/ssd24"
             },
             "status": 1
           }
@@ -547,7 +547,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd25"
+              "containment": "/compute0/rack0/ssd25"
             },
             "status": 1
           }
@@ -566,7 +566,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd26"
+              "containment": "/compute0/rack0/ssd26"
             },
             "status": 1
           }
@@ -585,7 +585,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd27"
+              "containment": "/compute0/rack0/ssd27"
             },
             "status": 1
           }
@@ -604,7 +604,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd28"
+              "containment": "/compute0/rack0/ssd28"
             },
             "status": 1
           }
@@ -623,7 +623,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd29"
+              "containment": "/compute0/rack0/ssd29"
             },
             "status": 1
           }
@@ -642,7 +642,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd30"
+              "containment": "/compute0/rack0/ssd30"
             },
             "status": 1
           }
@@ -661,7 +661,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd31"
+              "containment": "/compute0/rack0/ssd31"
             },
             "status": 1
           }
@@ -680,7 +680,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd32"
+              "containment": "/compute0/rack0/ssd32"
             },
             "status": 1
           }
@@ -699,7 +699,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd33"
+              "containment": "/compute0/rack0/ssd33"
             },
             "status": 1
           }
@@ -718,7 +718,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd34"
+              "containment": "/compute0/rack0/ssd34"
             },
             "status": 1
           }
@@ -737,7 +737,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd35"
+              "containment": "/compute0/rack0/ssd35"
             },
             "status": 1
           }
@@ -756,7 +756,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01"
+              "containment": "/compute0/rack0/compute-01"
             }
           }
         },
@@ -774,7 +774,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core0"
+              "containment": "/compute0/rack0/compute-01/core0"
             }
           }
         },
@@ -792,7 +792,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core1"
+              "containment": "/compute0/rack0/compute-01/core1"
             }
           }
         },
@@ -810,7 +810,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core2"
+              "containment": "/compute0/rack0/compute-01/core2"
             }
           }
         },
@@ -828,7 +828,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core3"
+              "containment": "/compute0/rack0/compute-01/core3"
             }
           }
         },
@@ -846,7 +846,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core4"
+              "containment": "/compute0/rack0/compute-01/core4"
             }
           }
         },
@@ -864,7 +864,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02"
+              "containment": "/compute0/rack0/compute-02"
             }
           }
         },
@@ -882,7 +882,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core0"
+              "containment": "/compute0/rack0/compute-02/core0"
             }
           }
         },
@@ -900,7 +900,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core1"
+              "containment": "/compute0/rack0/compute-02/core1"
             }
           }
         },
@@ -918,7 +918,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core2"
+              "containment": "/compute0/rack0/compute-02/core2"
             }
           }
         },
@@ -936,7 +936,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core3"
+              "containment": "/compute0/rack0/compute-02/core3"
             }
           }
         },
@@ -954,7 +954,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core4"
+              "containment": "/compute0/rack0/compute-02/core4"
             }
           }
         },
@@ -972,7 +972,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03"
+              "containment": "/compute0/rack0/compute-03"
             }
           }
         },
@@ -990,7 +990,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core0"
+              "containment": "/compute0/rack0/compute-03/core0"
             }
           }
         },
@@ -1008,7 +1008,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core1"
+              "containment": "/compute0/rack0/compute-03/core1"
             }
           }
         },
@@ -1026,7 +1026,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core2"
+              "containment": "/compute0/rack0/compute-03/core2"
             }
           }
         },
@@ -1044,7 +1044,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core3"
+              "containment": "/compute0/rack0/compute-03/core3"
             }
           }
         },
@@ -1062,7 +1062,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core4"
+              "containment": "/compute0/rack0/compute-03/core4"
             }
           }
         },
@@ -1083,7 +1083,7 @@
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack1"
+              "containment": "/compute0/rack1"
             }
           }
         },
@@ -1101,7 +1101,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd0"
+              "containment": "/compute0/rack1/ssd0"
             },
             "status": 1
           }
@@ -1120,7 +1120,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd1"
+              "containment": "/compute0/rack1/ssd1"
             },
             "status": 1
           }
@@ -1139,7 +1139,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd2"
+              "containment": "/compute0/rack1/ssd2"
             },
             "status": 1
           }
@@ -1158,7 +1158,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd3"
+              "containment": "/compute0/rack1/ssd3"
             },
             "status": 1
           }
@@ -1177,7 +1177,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd4"
+              "containment": "/compute0/rack1/ssd4"
             },
             "status": 1
           }
@@ -1196,7 +1196,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd5"
+              "containment": "/compute0/rack1/ssd5"
             },
             "status": 1
           }
@@ -1215,7 +1215,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd6"
+              "containment": "/compute0/rack1/ssd6"
             },
             "status": 1
           }
@@ -1234,7 +1234,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd7"
+              "containment": "/compute0/rack1/ssd7"
             },
             "status": 1
           }
@@ -1253,7 +1253,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd8"
+              "containment": "/compute0/rack1/ssd8"
             },
             "status": 1
           }
@@ -1272,7 +1272,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd9"
+              "containment": "/compute0/rack1/ssd9"
             },
             "status": 1
           }
@@ -1291,7 +1291,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd10"
+              "containment": "/compute0/rack1/ssd10"
             },
             "status": 1
           }
@@ -1310,7 +1310,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd11"
+              "containment": "/compute0/rack1/ssd11"
             },
             "status": 1
           }
@@ -1329,7 +1329,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd12"
+              "containment": "/compute0/rack1/ssd12"
             },
             "status": 1
           }
@@ -1348,7 +1348,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd13"
+              "containment": "/compute0/rack1/ssd13"
             },
             "status": 1
           }
@@ -1367,7 +1367,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd14"
+              "containment": "/compute0/rack1/ssd14"
             },
             "status": 1
           }
@@ -1386,7 +1386,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd15"
+              "containment": "/compute0/rack1/ssd15"
             },
             "status": 1
           }
@@ -1405,7 +1405,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd16"
+              "containment": "/compute0/rack1/ssd16"
             },
             "status": 1
           }
@@ -1424,7 +1424,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd17"
+              "containment": "/compute0/rack1/ssd17"
             },
             "status": 1
           }
@@ -1443,7 +1443,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd18"
+              "containment": "/compute0/rack1/ssd18"
             },
             "status": 1
           }
@@ -1462,7 +1462,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd19"
+              "containment": "/compute0/rack1/ssd19"
             },
             "status": 1
           }
@@ -1481,7 +1481,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd20"
+              "containment": "/compute0/rack1/ssd20"
             },
             "status": 1
           }
@@ -1500,7 +1500,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd21"
+              "containment": "/compute0/rack1/ssd21"
             },
             "status": 1
           }
@@ -1519,7 +1519,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd22"
+              "containment": "/compute0/rack1/ssd22"
             },
             "status": 1
           }
@@ -1538,7 +1538,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd23"
+              "containment": "/compute0/rack1/ssd23"
             },
             "status": 1
           }
@@ -1557,7 +1557,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd24"
+              "containment": "/compute0/rack1/ssd24"
             },
             "status": 1
           }
@@ -1576,7 +1576,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd25"
+              "containment": "/compute0/rack1/ssd25"
             },
             "status": 1
           }
@@ -1595,7 +1595,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd26"
+              "containment": "/compute0/rack1/ssd26"
             },
             "status": 1
           }
@@ -1614,7 +1614,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd27"
+              "containment": "/compute0/rack1/ssd27"
             },
             "status": 1
           }
@@ -1633,7 +1633,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd28"
+              "containment": "/compute0/rack1/ssd28"
             },
             "status": 1
           }
@@ -1652,7 +1652,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd29"
+              "containment": "/compute0/rack1/ssd29"
             },
             "status": 1
           }
@@ -1671,7 +1671,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd30"
+              "containment": "/compute0/rack1/ssd30"
             },
             "status": 1
           }
@@ -1690,7 +1690,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd31"
+              "containment": "/compute0/rack1/ssd31"
             },
             "status": 1
           }
@@ -1709,7 +1709,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd32"
+              "containment": "/compute0/rack1/ssd32"
             },
             "status": 1
           }
@@ -1728,7 +1728,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd33"
+              "containment": "/compute0/rack1/ssd33"
             },
             "status": 1
           }
@@ -1747,7 +1747,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd34"
+              "containment": "/compute0/rack1/ssd34"
             },
             "status": 1
           }
@@ -1766,7 +1766,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd35"
+              "containment": "/compute0/rack1/ssd35"
             },
             "status": 1
           }
@@ -1785,7 +1785,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04"
+              "containment": "/compute0/rack1/compute-04"
             }
           }
         },
@@ -1803,7 +1803,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core0"
+              "containment": "/compute0/rack1/compute-04/core0"
             }
           }
         },
@@ -1821,7 +1821,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core1"
+              "containment": "/compute0/rack1/compute-04/core1"
             }
           }
         },
@@ -1839,7 +1839,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core2"
+              "containment": "/compute0/rack1/compute-04/core2"
             }
           }
         },
@@ -1857,7 +1857,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core3"
+              "containment": "/compute0/rack1/compute-04/core3"
             }
           }
         },
@@ -1875,7 +1875,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core4"
+              "containment": "/compute0/rack1/compute-04/core4"
             }
           }
         },
@@ -1893,7 +1893,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0"
+              "containment": "/compute0/nodws0"
             }
           }
         },
@@ -1911,7 +1911,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0/core0"
+              "containment": "/compute0/nodws0/core0"
             }
           }
         },
@@ -1929,7 +1929,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0/core1"
+              "containment": "/compute0/nodws0/core1"
             }
           }
         },
@@ -1947,7 +1947,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0/core2"
+              "containment": "/compute0/nodws0/core2"
             }
           }
         },
@@ -1965,7 +1965,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0/core3"
+              "containment": "/compute0/nodws0/core3"
             }
           }
         },
@@ -1983,7 +1983,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws0/core4"
+              "containment": "/compute0/nodws0/core4"
             }
           }
         },
@@ -2001,7 +2001,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1"
+              "containment": "/compute0/nodws1"
             }
           }
         },
@@ -2019,7 +2019,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1/core0"
+              "containment": "/compute0/nodws1/core0"
             }
           }
         },
@@ -2037,7 +2037,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1/core1"
+              "containment": "/compute0/nodws1/core1"
             }
           }
         },
@@ -2055,7 +2055,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1/core2"
+              "containment": "/compute0/nodws1/core2"
             }
           }
         },
@@ -2073,7 +2073,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1/core3"
+              "containment": "/compute0/nodws1/core3"
             }
           }
         },
@@ -2091,7 +2091,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws1/core4"
+              "containment": "/compute0/nodws1/core4"
             }
           }
         },
@@ -2109,7 +2109,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2"
+              "containment": "/compute0/nodws2"
             }
           }
         },
@@ -2127,7 +2127,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2/core0"
+              "containment": "/compute0/nodws2/core0"
             }
           }
         },
@@ -2145,7 +2145,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2/core1"
+              "containment": "/compute0/nodws2/core1"
             }
           }
         },
@@ -2163,7 +2163,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2/core2"
+              "containment": "/compute0/nodws2/core2"
             }
           }
         },
@@ -2181,7 +2181,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2/core3"
+              "containment": "/compute0/nodws2/core3"
             }
           }
         },
@@ -2199,7 +2199,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws2/core4"
+              "containment": "/compute0/nodws2/core4"
             }
           }
         },
@@ -2217,7 +2217,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3"
+              "containment": "/compute0/nodws3"
             }
           }
         },
@@ -2235,7 +2235,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3/core0"
+              "containment": "/compute0/nodws3/core0"
             }
           }
         },
@@ -2253,7 +2253,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3/core1"
+              "containment": "/compute0/nodws3/core1"
             }
           }
         },
@@ -2271,7 +2271,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3/core2"
+              "containment": "/compute0/nodws3/core2"
             }
           }
         },
@@ -2289,7 +2289,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3/core3"
+              "containment": "/compute0/nodws3/core3"
             }
           }
         },
@@ -2307,7 +2307,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws3/core4"
+              "containment": "/compute0/nodws3/core4"
             }
           }
         },
@@ -2325,7 +2325,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4"
+              "containment": "/compute0/nodws4"
             }
           }
         },
@@ -2343,7 +2343,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4/core0"
+              "containment": "/compute0/nodws4/core0"
             }
           }
         },
@@ -2361,7 +2361,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4/core1"
+              "containment": "/compute0/nodws4/core1"
             }
           }
         },
@@ -2379,7 +2379,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4/core2"
+              "containment": "/compute0/nodws4/core2"
             }
           }
         },
@@ -2397,7 +2397,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4/core3"
+              "containment": "/compute0/nodws4/core3"
             }
           }
         },
@@ -2415,7 +2415,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws4/core4"
+              "containment": "/compute0/nodws4/core4"
             }
           }
         },
@@ -2433,7 +2433,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5"
+              "containment": "/compute0/nodws5"
             }
           }
         },
@@ -2451,7 +2451,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5/core0"
+              "containment": "/compute0/nodws5/core0"
             }
           }
         },
@@ -2469,7 +2469,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5/core1"
+              "containment": "/compute0/nodws5/core1"
             }
           }
         },
@@ -2487,7 +2487,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5/core2"
+              "containment": "/compute0/nodws5/core2"
             }
           }
         },
@@ -2505,7 +2505,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5/core3"
+              "containment": "/compute0/nodws5/core3"
             }
           }
         },
@@ -2523,7 +2523,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/nodws5/core4"
+              "containment": "/compute0/nodws5/core4"
             }
           }
         }

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -26,8 +26,8 @@
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "ElCapitan",
-            "name": "ElCapitan0",
+            "basename": "compute",
+            "name": "compute0",
             "id": 0,
             "uniq_id": 0,
             "rank": -1,
@@ -36,7 +36,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0"
+              "containment": "/compute0"
             }
           }
         },
@@ -57,7 +57,7 @@
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack0"
+              "containment": "/compute0/rack0"
             }
           }
         },
@@ -75,7 +75,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd0"
+              "containment": "/compute0/rack0/ssd0"
             },
             "status": 1
           }
@@ -94,7 +94,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd1"
+              "containment": "/compute0/rack0/ssd1"
             },
             "status": 1
           }
@@ -113,7 +113,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd2"
+              "containment": "/compute0/rack0/ssd2"
             },
             "status": 1
           }
@@ -132,7 +132,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd3"
+              "containment": "/compute0/rack0/ssd3"
             },
             "status": 1
           }
@@ -151,7 +151,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd4"
+              "containment": "/compute0/rack0/ssd4"
             },
             "status": 1
           }
@@ -170,7 +170,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd5"
+              "containment": "/compute0/rack0/ssd5"
             },
             "status": 1
           }
@@ -189,7 +189,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd6"
+              "containment": "/compute0/rack0/ssd6"
             },
             "status": 1
           }
@@ -208,7 +208,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd7"
+              "containment": "/compute0/rack0/ssd7"
             },
             "status": 1
           }
@@ -227,7 +227,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd8"
+              "containment": "/compute0/rack0/ssd8"
             },
             "status": 1
           }
@@ -246,7 +246,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd9"
+              "containment": "/compute0/rack0/ssd9"
             },
             "status": 1
           }
@@ -265,7 +265,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd10"
+              "containment": "/compute0/rack0/ssd10"
             },
             "status": 1
           }
@@ -284,7 +284,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd11"
+              "containment": "/compute0/rack0/ssd11"
             },
             "status": 1
           }
@@ -303,7 +303,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd12"
+              "containment": "/compute0/rack0/ssd12"
             },
             "status": 1
           }
@@ -322,7 +322,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd13"
+              "containment": "/compute0/rack0/ssd13"
             },
             "status": 1
           }
@@ -341,7 +341,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd14"
+              "containment": "/compute0/rack0/ssd14"
             },
             "status": 1
           }
@@ -360,7 +360,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd15"
+              "containment": "/compute0/rack0/ssd15"
             },
             "status": 1
           }
@@ -379,7 +379,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd16"
+              "containment": "/compute0/rack0/ssd16"
             },
             "status": 1
           }
@@ -398,7 +398,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd17"
+              "containment": "/compute0/rack0/ssd17"
             },
             "status": 1
           }
@@ -417,7 +417,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd18"
+              "containment": "/compute0/rack0/ssd18"
             },
             "status": 1
           }
@@ -436,7 +436,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd19"
+              "containment": "/compute0/rack0/ssd19"
             },
             "status": 1
           }
@@ -455,7 +455,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd20"
+              "containment": "/compute0/rack0/ssd20"
             },
             "status": 1
           }
@@ -474,7 +474,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd21"
+              "containment": "/compute0/rack0/ssd21"
             },
             "status": 1
           }
@@ -493,7 +493,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd22"
+              "containment": "/compute0/rack0/ssd22"
             },
             "status": 1
           }
@@ -512,7 +512,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd23"
+              "containment": "/compute0/rack0/ssd23"
             },
             "status": 1
           }
@@ -531,7 +531,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd24"
+              "containment": "/compute0/rack0/ssd24"
             },
             "status": 1
           }
@@ -550,7 +550,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd25"
+              "containment": "/compute0/rack0/ssd25"
             },
             "status": 1
           }
@@ -569,7 +569,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd26"
+              "containment": "/compute0/rack0/ssd26"
             },
             "status": 1
           }
@@ -588,7 +588,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd27"
+              "containment": "/compute0/rack0/ssd27"
             },
             "status": 1
           }
@@ -607,7 +607,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd28"
+              "containment": "/compute0/rack0/ssd28"
             },
             "status": 1
           }
@@ -626,7 +626,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd29"
+              "containment": "/compute0/rack0/ssd29"
             },
             "status": 1
           }
@@ -645,7 +645,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd30"
+              "containment": "/compute0/rack0/ssd30"
             },
             "status": 1
           }
@@ -664,7 +664,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd31"
+              "containment": "/compute0/rack0/ssd31"
             },
             "status": 1
           }
@@ -683,7 +683,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd32"
+              "containment": "/compute0/rack0/ssd32"
             },
             "status": 1
           }
@@ -702,7 +702,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd33"
+              "containment": "/compute0/rack0/ssd33"
             },
             "status": 1
           }
@@ -721,7 +721,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd34"
+              "containment": "/compute0/rack0/ssd34"
             },
             "status": 1
           }
@@ -740,7 +740,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd35"
+              "containment": "/compute0/rack0/ssd35"
             },
             "status": 1
           }
@@ -761,7 +761,7 @@
               "pdebug": ""
             },
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01"
+              "containment": "/compute0/rack0/compute-01"
             }
           }
         },
@@ -779,7 +779,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core0"
+              "containment": "/compute0/rack0/compute-01/core0"
             }
           }
         },
@@ -797,7 +797,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core1"
+              "containment": "/compute0/rack0/compute-01/core1"
             }
           }
         },
@@ -815,7 +815,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core2"
+              "containment": "/compute0/rack0/compute-01/core2"
             }
           }
         },
@@ -833,7 +833,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core3"
+              "containment": "/compute0/rack0/compute-01/core3"
             }
           }
         },
@@ -851,7 +851,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core4"
+              "containment": "/compute0/rack0/compute-01/core4"
             }
           }
         },
@@ -869,7 +869,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core5"
+              "containment": "/compute0/rack0/compute-01/core5"
             }
           }
         },
@@ -887,7 +887,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core6"
+              "containment": "/compute0/rack0/compute-01/core6"
             }
           }
         },
@@ -905,7 +905,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core7"
+              "containment": "/compute0/rack0/compute-01/core7"
             }
           }
         },
@@ -923,7 +923,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core8"
+              "containment": "/compute0/rack0/compute-01/core8"
             }
           }
         },
@@ -941,7 +941,7 @@
             "size": 1,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core9"
+              "containment": "/compute0/rack0/compute-01/core9"
             }
           }
         },
@@ -962,7 +962,7 @@
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack1"
+              "containment": "/compute0/rack1"
             }
           }
         },
@@ -980,7 +980,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd0"
+              "containment": "/compute0/rack1/ssd0"
             },
             "status": 1
           }
@@ -999,7 +999,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd1"
+              "containment": "/compute0/rack1/ssd1"
             },
             "status": 1
           }
@@ -1018,7 +1018,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd2"
+              "containment": "/compute0/rack1/ssd2"
             },
             "status": 1
           }
@@ -1037,7 +1037,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd3"
+              "containment": "/compute0/rack1/ssd3"
             },
             "status": 1
           }
@@ -1056,7 +1056,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd4"
+              "containment": "/compute0/rack1/ssd4"
             },
             "status": 1
           }
@@ -1075,7 +1075,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd5"
+              "containment": "/compute0/rack1/ssd5"
             },
             "status": 1
           }
@@ -1094,7 +1094,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd6"
+              "containment": "/compute0/rack1/ssd6"
             },
             "status": 1
           }
@@ -1113,7 +1113,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd7"
+              "containment": "/compute0/rack1/ssd7"
             },
             "status": 1
           }
@@ -1132,7 +1132,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd8"
+              "containment": "/compute0/rack1/ssd8"
             },
             "status": 1
           }
@@ -1151,7 +1151,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd9"
+              "containment": "/compute0/rack1/ssd9"
             },
             "status": 1
           }
@@ -1170,7 +1170,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd10"
+              "containment": "/compute0/rack1/ssd10"
             },
             "status": 1
           }
@@ -1189,7 +1189,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd11"
+              "containment": "/compute0/rack1/ssd11"
             },
             "status": 1
           }
@@ -1208,7 +1208,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd12"
+              "containment": "/compute0/rack1/ssd12"
             },
             "status": 1
           }
@@ -1227,7 +1227,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd13"
+              "containment": "/compute0/rack1/ssd13"
             },
             "status": 1
           }
@@ -1246,7 +1246,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd14"
+              "containment": "/compute0/rack1/ssd14"
             },
             "status": 1
           }
@@ -1265,7 +1265,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd15"
+              "containment": "/compute0/rack1/ssd15"
             },
             "status": 1
           }
@@ -1284,7 +1284,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd16"
+              "containment": "/compute0/rack1/ssd16"
             },
             "status": 1
           }
@@ -1303,7 +1303,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd17"
+              "containment": "/compute0/rack1/ssd17"
             },
             "status": 1
           }
@@ -1322,7 +1322,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd18"
+              "containment": "/compute0/rack1/ssd18"
             },
             "status": 1
           }
@@ -1341,7 +1341,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd19"
+              "containment": "/compute0/rack1/ssd19"
             },
             "status": 1
           }
@@ -1360,7 +1360,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd20"
+              "containment": "/compute0/rack1/ssd20"
             },
             "status": 1
           }
@@ -1379,7 +1379,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd21"
+              "containment": "/compute0/rack1/ssd21"
             },
             "status": 1
           }
@@ -1398,7 +1398,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd22"
+              "containment": "/compute0/rack1/ssd22"
             },
             "status": 1
           }
@@ -1417,7 +1417,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd23"
+              "containment": "/compute0/rack1/ssd23"
             },
             "status": 1
           }
@@ -1436,7 +1436,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd24"
+              "containment": "/compute0/rack1/ssd24"
             },
             "status": 1
           }
@@ -1455,7 +1455,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd25"
+              "containment": "/compute0/rack1/ssd25"
             },
             "status": 1
           }
@@ -1474,7 +1474,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd26"
+              "containment": "/compute0/rack1/ssd26"
             },
             "status": 1
           }
@@ -1493,7 +1493,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd27"
+              "containment": "/compute0/rack1/ssd27"
             },
             "status": 1
           }
@@ -1512,7 +1512,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd28"
+              "containment": "/compute0/rack1/ssd28"
             },
             "status": 1
           }
@@ -1531,7 +1531,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd29"
+              "containment": "/compute0/rack1/ssd29"
             },
             "status": 1
           }
@@ -1550,7 +1550,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd30"
+              "containment": "/compute0/rack1/ssd30"
             },
             "status": 1
           }
@@ -1569,7 +1569,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd31"
+              "containment": "/compute0/rack1/ssd31"
             },
             "status": 1
           }
@@ -1588,7 +1588,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd32"
+              "containment": "/compute0/rack1/ssd32"
             },
             "status": 1
           }
@@ -1607,7 +1607,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd33"
+              "containment": "/compute0/rack1/ssd33"
             },
             "status": 1
           }
@@ -1626,7 +1626,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd34"
+              "containment": "/compute0/rack1/ssd34"
             },
             "status": 1
           }
@@ -1645,7 +1645,7 @@
             "size": 1024,
             "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd35"
+              "containment": "/compute0/rack1/ssd35"
             },
             "status": 1
           }

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -29,18 +29,19 @@ test_expect_success HAVE_JQ 'smoke test to ensure the storage resources are expe
 	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[1].name == \"compute-02\"" &&
 	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[2].name == \"compute-03\"" &&
 	kubectl get storages kind-worker3 -ojson | jq -e ".status.access.computes | length == 1" &&
-	kubectl get storages kind-worker3 -ojson | jq -e ".status.access.computes[0].name == \"compute-04\""
+	kubectl get storages kind-worker3 -ojson | jq -e ".status.access.computes[0].name == \"compute-04\"" &&
+	test $(hostname) = compute-01
 '
 
 test_expect_success HAVE_JQ 'flux-dws2jgf.py outputs expected JGF for single compute node' '
-	flux R encode -Hcompute-01 | flux python ${CMD} --no-validate | \
-	jq . > actual-compute-01.jgf &&
+	flux R encode -Hcompute-01 | flux python ${CMD} --no-validate --cluster-name=ElCapitan \
+	| jq . > actual-compute-01.jgf &&
 	test_cmp ${DATADIR}/expected-compute-01.jgf actual-compute-01.jgf
 '
 
 test_expect_success HAVE_JQ 'flux-dws2jgf.py outputs expected JGF for multiple compute nodes' '
-	flux R encode -Hcompute-[01-04] -c0-4 | flux python ${CMD} --no-validate | \
-	jq . > actual-compute-01-04.jgf &&
+	flux R encode -Hcompute-[01-04] -c0-4 | flux python ${CMD} --no-validate --cluster-name=ElCapitan \
+	| jq . > actual-compute-01-04.jgf &&
 	test_cmp ${DATADIR}/expected-compute-01-04.jgf actual-compute-01-04.jgf
 '
 
@@ -69,7 +70,7 @@ test_expect_success HAVE_JQ 'fluxion rejects a rack/rabbit job when no rabbits a
 
 test_expect_success HAVE_JQ 'fluxion can be loaded with output of dws2jgf' '
 	flux run -n1 hostname &&
-	flux R encode -l | flux python ${CMD} --no-validate | jq . > R.local &&
+	flux R encode -l | flux python ${CMD} --no-validate --cluster-name=ElCapitan | jq . > R.local &&
 	flux kvs put resource.R="$(cat R.local)" &&
 	flux module list &&
 	flux module remove -f sched-fluxion-qmanager &&


### PR DESCRIPTION
Problem: at the moment admins should supply the name of the cluster through a command-line argument when running dws2jgf. But they will probably run it from the management node of a cluster, and most LC clusters have nodes with names like 'nameXXXXX' for XXXXX some decimal number.

Simplify things for them by making the cluster name in the resource graph default to the hostname stripped of numerals.