### PR TITLE
dws: dump datamovements to logs

### DIFF
--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -36,3 +36,10 @@ SERVER_CRD = CRD(
     namespace="default",
     plural="servers",
 )
+
+DATAMOVEMENT_CRD = CRD(
+    group="dataworkflowservices.github.io",
+    version="v1alpha2",
+    namespace="default",
+    plural="nnfdatamovements",
+)

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -49,7 +49,7 @@ test_expect_success 'exec dws service-providing script with fluxion scheduling d
             --setattr=system.alloc-bypass.R="$R" \
             -o per-resource.type=node --output=dws-fluxion-disabled.out \
             --error=dws-fluxion-disabled.err python ${DWS_MODULE_PATH} -e1 \
-            -v --disable-fluxion) &&
+            -vvv --disable-fluxion) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start &&
     flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
     ${RPC} "dws.create"
@@ -102,7 +102,7 @@ test_expect_success 'exec dws service-providing script' '
 	DWS_JOBID=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws1.out --error=dws1.err \
-	        python ${DWS_MODULE_PATH} -e1 -v -rR.local) &&
+	        python ${DWS_MODULE_PATH} -e1 -vvv -rR.local) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start
 '
 
@@ -271,7 +271,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v -rR.local) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '
@@ -328,7 +328,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -v -rR.local) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
 	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&


### PR DESCRIPTION
Problem: my HPE overlords want the coral2-dws service to log `nnfdatamovements`.