### PR TITLE
dws: add marker for prolog to enable the nnf-dm daemon

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -457,7 +457,11 @@ def _workflow_state_change_cb_inner(
                 "resources"
             ]
         if not disable_fluxion:
-            resources = directivebreakdown.apply_breakdowns(
+            resources, copy_offload = directivebreakdown.apply_breakdowns(
+                k8s_api, workflow, resources, _MIN_ALLOCATION_SIZE
+            )
+        else:
+            _, copy_offload = directivebreakdown.apply_breakdowns(
                 k8s_api, workflow, resources, _MIN_ALLOCATION_SIZE
             )
         handle.rpc(
@@ -465,6 +469,7 @@ def _workflow_state_change_cb_inner(
             payload={
                 "id": jobid,
                 "resources": resources,
+                "copy-offload": copy_offload,
             },
         ).then(log_rpc_response)
     elif state_complete(workflow, "Setup"):

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -78,8 +78,11 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
         }
     ]
     allocation_applied = False
+    copy_offload = False
     # update ssd_resources to the right number
     for breakdown in breakdown_list:
+        if "copy-offload" in breakdown["status"].get("requiredDaemons", []):
+            copy_offload = True
         if breakdown["kind"] != "DirectiveBreakdown":
             raise ValueError(f"unsupported breakdown kind {breakdown['kind']!r}")
         if not breakdown["status"]["ready"]:
@@ -89,8 +92,8 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
                 _apply_allocation(allocation, ssd_resources, nodecount, min_size)
                 allocation_applied = True
     if not allocation_applied:
-        return old_resources
-    return new_resources
+        return (old_resources, copy_offload)
+    return (new_resources, copy_offload)
 
 
 def fetch_breakdowns(k8s_api, workflow):

--- a/t/data/breakdown/lustre10tb_daemon.yaml
+++ b/t/data/breakdown/lustre10tb_daemon.yaml
@@ -1,0 +1,25 @@
+version: v1
+kind: DirectiveBreakdown
+metadata:
+  name: job456-0
+spec:
+  dwRecord:
+    dwDirectiveIndex: 0
+    dwDirective: jobdw type=lustre capacity=10TB name=lus-name
+  lifetime: job
+  name: my-lustre-storage
+status:
+  ready: true
+  requiredDaemons: copy-offload
+  servers:
+    kind: Servers
+    name: job456-0
+    namespace: default
+  storage:
+    allocationSets:
+    - allocationStrategy: AllocateAcrossServers
+      minimumCapacity: 2000000000
+      label: mgtmdt
+    - allocationStrategy: AllocateAcrossServers
+      minimumCapacity: 10995116277760
+      label: ost

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -26,7 +26,7 @@ def create_cb(fh, t, msg, arg):
         return
     fh.rpc(
         "job-manager.dws.resource-update",
-        payload={"id": msg.payload["jobid"], "resources": msg.payload["resources"]},
+        payload={"id": msg.payload["jobid"], "resources": msg.payload["resources"], "copy-offload": False},
     )
 
 def setup_cb(fh, t, msg, arg):

--- a/t/python/t0001-directive-breakdown.py
+++ b/t/python/t0001-directive-breakdown.py
@@ -36,7 +36,27 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "lustre10tb.yaml")
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+            new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+            self.assertFalse(copy_offload)
+            patched_fetch.assert_called_with(None, None)
+            self.assertEqual(len(new_resources), 1)
+            slot = new_resources[0]
+            self.assertEqual(slot["type"], "slot")
+            self.assertEqual(slot["count"], nodecount)
+            self.assertEqual(len(slot["with"]), 2)
+            self.assertEqual(slot["with"][0]["type"], "node")
+            self.assertEqual(slot["with"][0]["count"], 1)
+            ssds = slot["with"][1]
+            self.assertEqual(ssds["type"], "ssd")
+            self.assertEqual(ssds["count"], 10241 // nodecount)
+
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
+    def test_lustre10tb_daemon(self, patched_fetch):
+        patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "lustre10tb_daemon.yaml")
+        for nodecount in (4, 6, 8):
+            resources = [{"type": "node", "count": nodecount}]
+            new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+            self.assertTrue(copy_offload)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
             slot = new_resources[0]
@@ -54,8 +74,9 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "xfs10gb.yaml")
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+            new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
             patched_fetch.assert_called_with(None, None)
+            self.assertFalse(copy_offload)
             self.assertEqual(len(new_resources), 1)
             slot = new_resources[0]
             self.assertEqual(slot["type"], "slot")
@@ -74,9 +95,10 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         )
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+            new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
+            self.assertFalse(copy_offload)
             slot = new_resources[0]
             self.assertEqual(slot["type"], "slot")
             self.assertEqual(slot["count"], nodecount)
@@ -93,7 +115,28 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             YAMLDIR / "xfs10gb.yaml", YAMLDIR / "lustre10tb.yaml"
         )
         resources = [{"type": "node", "count": 1, "with": [{"type": "slot"}]}]
-        new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+        new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+        self.assertFalse(copy_offload)
+        patched_fetch.assert_called_with(None, None)
+        self.assertEqual(len(new_resources), 1)
+        slot = new_resources[0]
+        self.assertEqual(slot["type"], "slot")
+        self.assertEqual(slot["count"], 1)
+        self.assertEqual(len(slot["with"]), 2)
+        self.assertEqual(slot["with"][0]["type"], "node")
+        self.assertEqual(slot["with"][0]["count"], 1)
+        ssds = slot["with"][1]
+        self.assertEqual(ssds["type"], "ssd")
+        self.assertEqual(ssds["count"], 10241 + 10)
+
+    @unittest.mock.patch("flux_k8s.directivebreakdown.fetch_breakdowns")
+    def test_combination_xfs_lustre_daemon(self, patched_fetch):
+        patched_fetch.return_value = read_yaml_breakdown(
+            YAMLDIR / "xfs10gb.yaml", YAMLDIR / "lustre10tb_daemon.yaml"
+        )
+        resources = [{"type": "node", "count": 1, "with": [{"type": "slot"}]}]
+        new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, 1)
+        self.assertTrue(copy_offload)
         patched_fetch.assert_called_with(None, None)
         self.assertEqual(len(new_resources), 1)
         slot = new_resources[0]
@@ -135,7 +178,8 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         for nodecount in (4, 6, 8):
             for min_size in (11, 15, 170):
                 resources = [{"type": "node", "count": nodecount}]
-                new_resources = directivebreakdown.apply_breakdowns(None, None, resources, min_size)
+                new_resources, copy_offload = directivebreakdown.apply_breakdowns(None, None, resources, min_size)
+                self.assertFalse(copy_offload)
                 patched_fetch.assert_called_with(None, None)
                 self.assertEqual(len(new_resources), 1)
                 slot = new_resources[0]

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -137,6 +137,36 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event.json &&
+	jq -e .context.variables env-event.json && jq -e .context.rabbits env-event.json &&
+	jq -e ".context.copy_offload == false" env-event.json &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+
+test_expect_success 'job requesting copy-offload in DW string works' '
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1
+			requires=copy-offload" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-remove &&
+	flux job wait-event -t 10 -m rabbit_workflow=fluxjob-$(flux job id ${jobid}) \
+		${jobid} memo &&
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event2.json &&
+	jq -e .context.variables env-event2.json && jq -e .context.rabbits env-event2.json &&
+	jq -e ".context.copy_offload == true" env-event2.json &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \


### PR DESCRIPTION
Problem: There is no marker that a job needs the nnf data movement
daemon to be running during its duration. Without a marker, an
administrative prolog cannot tell whether to start the daemon.

Add a boolean to the dws-environment event that indicates whether
the nnf-dm daemon is needed. The administrative prolog can watch for
this event and its context.

Fixes #167.

@grondo, what would be the best way for a shell script (the administrative prolog) to watch for the boolean? It is already watching for the `dws_environment` event, but now it also needs to know whether the `copy-offload` entry in the context is true or false.