### PR TITLE
dws: crudely enforce mdt count constraints

### DIFF
--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -1,3 +1,5 @@
+"""Module defining functions related to DirectiveBreakdown resources."""
+
 import enum
 import copy
 import functools
@@ -7,6 +9,8 @@ from flux_k8s.crd import DIRECTIVEBREAKDOWN_CRD
 
 
 class AllocationStrategy(enum.Enum):
+    """Enum defining different AllocationStrategies."""
+
     PER_COMPUTE = "AllocatePerCompute"
     SINGLE_SERVER = "AllocateSingleServer"
     ACROSS_SERVERS = "AllocateAcrossServers"
@@ -17,6 +21,7 @@ LUSTRE_TYPES = ("ost", "mdt", "mgt", "mgtmdt")
 
 
 def build_allocation_sets(breakdown_alloc_sets, nodes_per_nnf, hlist, min_alloc_size):
+    """Build the allocationSet for a Server based on its DirectiveBreakdown."""
     allocation_sets = []
     for alloc_set in breakdown_alloc_sets:
         storage_field = []
@@ -61,7 +66,6 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
     """Apply all of the directive breakdown information to a jobspec's `resources`."""
     resources = copy.deepcopy(old_resources)
     breakdown_list = list(fetch_breakdowns(k8s_api, workflow))
-    per_compute_total = 0  # total bytes of per-compute storage
     if not resources:
         raise ValueError("jobspec resources empty")
     if len(resources) > 1 or resources[0]["type"] != "node":
@@ -106,7 +110,7 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
 def fetch_breakdowns(k8s_api, workflow):
     """Fetch all of the directive breakdowns associated with a workflow."""
     if not workflow["status"].get("directiveBreakdowns"):
-        return []  # destroy_persistent DW directives have no breakdowns
+        return  # destroy_persistent DW directives have no breakdowns
     for breakdown in workflow["status"]["directiveBreakdowns"]:
         yield k8s_api.get_namespaced_custom_object(
             DIRECTIVEBREAKDOWN_CRD.group,

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -14,42 +14,6 @@ PER_COMPUTE_TYPES = ("xfs", "gfs2", "raw")
 LUSTRE_TYPES = ("ost", "mdt", "mgt", "mgtmdt")
 
 
-def build_allocation_sets(allocation_sets, local_allocations, nodes_per_nnf):
-    ret = []
-    for allocation in allocation_sets:
-        alloc_entry = {
-            "allocationSize": 0,
-            "label": allocation["label"],
-            "storage": [],
-        }
-        max_alloc_size = 0
-        # build the storage field of alloc_entry
-        for nnf_name in local_allocations:
-            if allocation["label"] in PER_COMPUTE_TYPES:
-                alloc_size = int(
-                    local_allocations[nnf_name]
-                    * allocation["percentage_of_total"]
-                    / nodes_per_nnf[nnf_name]
-                )
-                if alloc_size < allocation["minimumCapacity"]:
-                    raise RuntimeError(
-                        "Expected an allocation size of at least "
-                        f"{allocation['minimumCapacity']}, got {alloc_size}"
-                    )
-                if max_alloc_size == 0:
-                    max_alloc_size = alloc_size
-                else:
-                    max_alloc_size = min(max_alloc_size, alloc_size)
-                alloc_entry["storage"].append(
-                    {"allocationCount": nodes_per_nnf[nnf_name], "name": nnf_name}
-                )
-            else:
-                raise ValueError(f"{allocation['label']} not currently supported")
-        alloc_entry["allocationSize"] = max_alloc_size
-        ret.append(alloc_entry)
-    return ret
-
-
 def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
     """Apply all of the directive breakdown information to a jobspec's `resources`."""
     resources = copy.deepcopy(old_resources)


### PR DESCRIPTION
Problem: as described in #171, creating many MDTs is a bad
for performance, and usually goes against what is explicitly
required by directivebreakdown resources. However, there is not
yet a good way to get Fluxion to handle MDT allocation.

Bypass Fluxion allocation completely, and tell DWS to create
exactly the number of allocations requested in the
.constraints.count field (which is usually found on MDTs).

Place the allocations on the rabbits which have the most compute
nodes allocated to the job.

This is intended to be only a temporary solution, since it
adds a new potential problem, in that some rabbit storage is
used which is not tracked by Fluxion. This could lead to
overallocation of resources, causing jobs to fail with errors.
However, this seems unlikely to occur in practice, since MDTs
are small and Fluxion always gives jobs more storage than they
asked for, so there should usually be some spare storage.