### PR TITLE
dws: change rabbit memo to hostlist

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -270,7 +270,7 @@ def setup_cb(handle, _t, msg, k8s_api):
         nodes_per_nnf[nnf_name] = nodes_per_nnf.get(nnf_name, 0) + 1
     handle.rpc(
         "job-manager.memo",
-        payload={"id": jobid, "memo": {"rabbits": list(nodes_per_nnf.keys())}},
+        payload={"id": jobid, "memo": {"rabbits": Hostlist(nodes_per_nnf.keys()).encode()}},
     ).then(log_rpc_response)
     k8s_api.patch_namespaced_custom_object(
         COMPUTE_CRD.group,

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -144,7 +144,8 @@ test_expect_success 'job submission with valid DW string works' '
 		${jobid} epilog-start &&
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 15 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean &&
+	flux jobs -n ${jobid} -o "{user.rabbits}" | flux hostlist -q -
 '
 
 test_expect_success 'job requesting copy-offload in DW string works' '
@@ -209,7 +210,8 @@ test_expect_success 'job submission with multiple valid DW strings on different 
 		${jobid} epilog-start &&
 	flux job wait-event -vt 45 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 15 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean &&
+	flux jobs -n ${jobid} -o "{user.rabbits}" | flux hostlist -q -
 '
 
 test_expect_success 'job submission with multiple valid DW strings on the same line works' '


### PR DESCRIPTION
Problem: the flux-coral2 script adds a memo to rabbit jobs with a JSON list of the rabbits used. This is inconvenient and can potentially become large.

Use a hostlist instead.