### PR TITLE
dws: saving workflows to KVS

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -793,11 +793,16 @@ def raise_self_exception(handle):
     testing purposes.
     Once https://github.com/flux-framework/flux-core/issues/3821 is
     implemented/closed, this can be replaced with that solution.
+
+    Also, remove FLUX_KVS_NAMESPACE from the environment, because otherwise
+    KVS lookups will look relative to that namespace, changing the behavior
+    relative to when the script runs as a service.
     """
     try:
         jobid = id_parse(os.environ["FLUX_JOB_ID"])
     except KeyError:
         return
+    del os.environ["FLUX_KVS_NAMESPACE"]
     Future(handle.job_raise(jobid, "exception", 7, "dws watchers setup")).get()
 
 

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -756,9 +756,9 @@ def setup_parsing():
 def config_logging(args):
     """Configure logging for the script."""
     log_level = logging.WARNING
-    if args.verbose > 1:
+    if args.verbose > 0:
         log_level = logging.INFO
-    if args.verbose > 2:
+    if args.verbose > 1:
         log_level = logging.DEBUG
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(message)s",

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -173,7 +173,7 @@ def move_workflow_to_teardown(handle, winfo, k8s_api, workflow=None):
         },
     )
     winfo.toredown = True
-    if LOGGER.isEnabledFor(logging.DEBUG):
+    if LOGGER.isEnabledFor(logging.INFO):
         try:
             api_response = k8s_api.list_namespaced_custom_object(
                 *DATAMOVEMENT_CRD,
@@ -183,14 +183,14 @@ def move_workflow_to_teardown(handle, winfo, k8s_api, workflow=None):
                 ),
             )
         except Exception as exc:
-            LOGGER.debug(
+            LOGGER.info(
                 "Failed to fetch nnfdatamovement crds for workflow '%s': %s",
                 winfo.name,
                 exc,
             )
         else:
             for crd in api_response["items"]:
-                LOGGER.debug(
+                LOGGER.info(
                     "Found nnfdatamovement crd for workflow '%s': %s", winfo.name, crd
                 )
 
@@ -488,7 +488,7 @@ def _workflow_state_change_cb_inner(
             move_workflow_to_teardown(handle, winfo, k8s_api, workflow)
     elif workflow["status"].get("status") == "TransientCondition":
         # a potentially fatal error has occurred, but may resolve itself
-        LOGGER.warning(
+        LOGGER.info(
             "Workflow '%s' has TransientCondition set, message is '%s', workflow is %s",
             winfo.name,
             workflow["status"].get("message", ""),

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -473,7 +473,6 @@ def _workflow_state_change_cb_inner(
         move_workflow_to_teardown(handle, winfo, k8s_api, workflow)
     if workflow["status"].get("status") == "Error":
         # a fatal error has occurred in the workflows, raise a job exception
-        LOGGER.info("workflow '%s' hit an error: %s", winfo.name, workflow)
         handle.job_raise(
             jobid,
             "exception",
@@ -664,11 +663,6 @@ def kill_workflows_in_tc(_reactor, watcher, _r, tc_timeout):
     # iterate over it.
     for winfo in WORKFLOWS_IN_TC.copy():
         if curr_time - winfo.transient_condition.last_time > tc_timeout:
-            LOGGER.info(
-                "Workflow '%s' was in TransientCondition too long: %s",
-                winfo.name,
-                winfo.transient_condition.workflow,
-            )
             watcher.flux_handle.job_raise(
                 winfo.jobid,
                 "exception",

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -148,11 +148,18 @@ def remove_finalizer(workflow_name, k8s_api, workflow):
         )
 
 
-def move_workflow_to_teardown(winfo, k8s_api, workflow=None):
+def move_workflow_to_teardown(handle, winfo, k8s_api, workflow=None):
     """Helper function for moving a workflow to Teardown."""
     if workflow is None:
         workflow = k8s_api.get_namespaced_custom_object(*WORKFLOW_CRD, winfo.name)
-    LOGGER.debug("Moving workflow %s to Teardown, dump is %s", winfo.name, workflow)
+    try:
+        kvsdir = flux.job.job_kvs(handle, winfo.jobid)
+        kvsdir["rabbit_workflow"] = workflow
+        kvsdir.commit()
+    except Exception:
+        LOGGER.exception(
+            "Failed to update KVS for job %s: workflow is", winfo.jobid, workflow
+        )
     try:
         workflow["metadata"]["finalizers"].remove(_FINALIZER)
     except ValueError:
@@ -270,7 +277,10 @@ def setup_cb(handle, _t, msg, k8s_api):
         nodes_per_nnf[nnf_name] = nodes_per_nnf.get(nnf_name, 0) + 1
     handle.rpc(
         "job-manager.memo",
-        payload={"id": jobid, "memo": {"rabbits": Hostlist(nodes_per_nnf.keys()).encode()}},
+        payload={
+            "id": jobid,
+            "memo": {"rabbits": Hostlist(nodes_per_nnf.keys()).encode()},
+        },
     ).then(log_rpc_response)
     k8s_api.patch_namespaced_custom_object(
         COMPUTE_CRD.group,
@@ -322,7 +332,7 @@ def post_run_cb(handle, _t, msg, k8s_api):
     if not run_started:
         # the job hit an exception before beginning to run; transition
         # the workflow immediately to 'teardown'
-        move_workflow_to_teardown(winfo, k8s_api)
+        move_workflow_to_teardown(handle, winfo, k8s_api)
     else:
         move_workflow_desiredstate(winfo.name, "PostRun", k8s_api)
 
@@ -368,7 +378,7 @@ def workflow_state_change_cb(event, handle, k8s_api, disable_fluxion):
             jobid,
         )
         try:
-            move_workflow_to_teardown(winfo, k8s_api, workflow)
+            move_workflow_to_teardown(handle, winfo, k8s_api, workflow)
         except ApiException:
             LOGGER.exception(
                 "Failed to move workflow '%s' with jobid %s to 'teardown' "
@@ -460,7 +470,7 @@ def _workflow_state_change_cb_inner(
         move_workflow_desiredstate(winfo.name, "DataOut", k8s_api)
     elif state_complete(workflow, "DataOut"):
         # move workflow to next stage, teardown
-        move_workflow_to_teardown(winfo, k8s_api, workflow)
+        move_workflow_to_teardown(handle, winfo, k8s_api, workflow)
     if workflow["status"].get("status") == "Error":
         # a fatal error has occurred in the workflows, raise a job exception
         LOGGER.info("workflow '%s' hit an error: %s", winfo.name, workflow)
@@ -476,7 +486,7 @@ def _workflow_state_change_cb_inner(
         # workflow is in PostRun or DataOut, the exception won't affect the dws-epilog
         # action holding the job, so the workflow should be moved to Teardown now.
         if workflow["spec"]["desiredState"] in ("PostRun", "DataOut"):
-            move_workflow_to_teardown(winfo, k8s_api, workflow)
+            move_workflow_to_teardown(handle, winfo, k8s_api, workflow)
     elif workflow["status"].get("status") == "TransientCondition":
         # a potentially fatal error has occurred, but may resolve itself
         LOGGER.warning(

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -145,7 +145,12 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
 	flux job wait-event -vt 15 ${jobid} clean &&
-	flux jobs -n ${jobid} -o "{user.rabbits}" | flux hostlist -q -
+	flux jobs -n ${jobid} -o "{user.rabbits}" | flux hostlist -q - &&
+	flux job info ${jobid} rabbit_workflow &&
+	flux job info ${jobid} rabbit_workflow | \
+		jq -e ".metadata.name == \"fluxjob-$(flux job id ${jobid})\"" &&
+	flux job info ${jobid} rabbit_workflow | jq -e ".spec.wlmID == \"flux\"" &&
+	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\""
 '
 
 test_expect_success 'job requesting copy-offload in DW string works' '
@@ -172,7 +177,12 @@ test_expect_success 'job requesting copy-offload in DW string works' '
 		${jobid} epilog-start &&
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
 		${jobid} epilog-finish &&
-	flux job wait-event -vt 15 ${jobid} clean
+	flux job wait-event -vt 15 ${jobid} clean &&
+	flux job info ${jobid} rabbit_workflow &&
+	flux job info ${jobid} rabbit_workflow | \
+		jq -e ".metadata.name == \"fluxjob-$(flux job id ${jobid})\"" &&
+	flux job info ${jobid} rabbit_workflow | jq -e ".spec.wlmID == \"flux\"" &&
+	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\""
 '
 
 test_expect_success 'job requesting too much storage is rejected' '


### PR DESCRIPTION
Problem: HPE and others working with k8s workflows have been
frustrated that k8s resources disappear shortly after their
associated flux job moves to cleanup, and have requested that
Flux save some of the resources.

Save workflow resources to jobs' KVS. More resources may be needed
in the future, but start small to reduce KVS pressure.

See also #180 .