### PR TITLE
dws: Fix NnfDataMovement logging

### DIFF
--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -36,10 +36,3 @@ SERVER_CRD = CRD(
     namespace="default",
     plural="servers",
 )
-
-DATAMOVEMENT_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
-    plural="nnfdatamovements",
-)


### PR DESCRIPTION
Problem: No NnfDataMovement resources are found when dumping to the
journal. The current implementation is only looking at the default
namespace instead of all namespaces. Additionally, the output is valid
json.

- Changed the api call to use `list_cluster_custom_object` to retrieve
  objects from all namespaces
- Deleted `DATAMOVEMENT_CRD` since namespace cannot be used for
  `list_cluster_custom_object`
- Moved NnfDatamovement retrieval to before the transition to
  `TearDown`. Otherwise these will start to be removed.