### PR TITLE
Kvs workflow timings

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -147,11 +147,36 @@ def remove_finalizer(workflow_name, k8s_api, workflow):
         )
 
 
+def save_elapsed_time_to_kvs(handle, jobid, workflow):
+    """Save the elapsedTime field to a job's KVS, ignoring errors."""
+    try:
+        timing = workflow["status"]["elapsedTimeLastState"]
+        state = workflow["status"]["state"].lower()
+    except KeyError:
+        return
+    try:
+        kvsdir = flux.job.job_kvs(handle, jobid)
+        kvsdir[f"rabbit_{state}_timing"] = timing
+        kvsdir.commit()
+    except Exception:
+        LOGGER.exception(
+            "Failed to update KVS for job %s: workflow is", jobid, workflow
+        )
+
+
 def save_workflow_to_kvs(handle, jobid, workflow):
     """Save a workflow to a job's KVS, ignoring errors."""
     try:
+        timing = workflow["status"]["elapsedTimeLastState"]
+        state = workflow["status"]["state"].lower()
+    except KeyError:
+        timing = None
+        state = None
+    try:
         kvsdir = flux.job.job_kvs(handle, jobid)
         kvsdir["rabbit_workflow"] = workflow
+        if timing is not None and state is not None:
+            kvsdir[f"rabbit_{state}_timing"] = timing
         kvsdir.commit()
     except Exception:
         LOGGER.exception(
@@ -455,9 +480,11 @@ def _workflow_state_change_cb_inner(
     elif state_complete(workflow, "Setup"):
         # move workflow to next stage, DataIn
         move_workflow_desiredstate(winfo.name, "DataIn", k8s_api)
+        save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "DataIn"):
         # move workflow to next stage, PreRun
         move_workflow_desiredstate(winfo.name, "PreRun", k8s_api)
+        save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "PreRun"):
         # tell DWS jobtap plugin that the job can start
         if winfo.rabbits is not None:
@@ -474,9 +501,11 @@ def _workflow_state_change_cb_inner(
                 },
             },
         ).then(log_rpc_response)
+        save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "PostRun"):
         # move workflow to next stage, DataOut
         move_workflow_desiredstate(winfo.name, "DataOut", k8s_api)
+        save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "DataOut"):
         # move workflow to next stage, teardown
         move_workflow_to_teardown(handle, winfo, k8s_api, workflow)

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -150,7 +150,13 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job info ${jobid} rabbit_workflow | \
 		jq -e ".metadata.name == \"fluxjob-$(flux job id ${jobid})\"" &&
 	flux job info ${jobid} rabbit_workflow | jq -e ".spec.wlmID == \"flux\"" &&
-	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\""
+	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\"" &&
+	flux job info ${jobid} rabbit_proposal_timing &&
+	flux job info ${jobid} rabbit_setup_timing &&
+	flux job info ${jobid} rabbit_datain_timing &&
+	flux job info ${jobid} rabbit_prerun_timing &&
+	flux job info ${jobid} rabbit_postrun_timing &&
+	flux job info ${jobid} rabbit_dataout_timing
 '
 
 test_expect_success 'job requesting copy-offload in DW string works' '
@@ -182,7 +188,13 @@ test_expect_success 'job requesting copy-offload in DW string works' '
 	flux job info ${jobid} rabbit_workflow | \
 		jq -e ".metadata.name == \"fluxjob-$(flux job id ${jobid})\"" &&
 	flux job info ${jobid} rabbit_workflow | jq -e ".spec.wlmID == \"flux\"" &&
-	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\""
+	flux job info ${jobid} rabbit_workflow | jq -e ".kind == \"Workflow\"" &&
+	flux job info ${jobid} rabbit_proposal_timing &&
+	flux job info ${jobid} rabbit_setup_timing &&
+	flux job info ${jobid} rabbit_datain_timing &&
+	flux job info ${jobid} rabbit_prerun_timing &&
+	flux job info ${jobid} rabbit_postrun_timing &&
+	flux job info ${jobid} rabbit_dataout_timing
 '
 
 test_expect_success 'job requesting too much storage is rejected' '


### PR DESCRIPTION
Two changes:

1) Save workflows to the KVS after the completion of every state except Teardown. So now you don't need to wait for the job to complete to look at your workflow
2) Save the `.status.elapsedTimeLastState` field of workflows to the KVS after the completion of every state except Teardown. The timing goes under the `rabbit_{state}_timing` key so to get the timing for DataIn, you could run `flux job info $JOBID rabbit_DataIn_timing`.