### PR TITLE
dws: save workflow teardown timings to KVS

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -448,6 +448,7 @@ def _workflow_state_change_cb_inner(
         handle.rpc("job-manager.dws.epilog-remove", payload={"id": jobid}).then(
             log_rpc_response
         )
+        save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif winfo.toredown:
         # in the event of an exception, the workflow will skip to 'teardown'.
         # Without this early 'return', this function may try to

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -156,7 +156,8 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job info ${jobid} rabbit_datain_timing &&
 	flux job info ${jobid} rabbit_prerun_timing &&
 	flux job info ${jobid} rabbit_postrun_timing &&
-	flux job info ${jobid} rabbit_dataout_timing
+	flux job info ${jobid} rabbit_dataout_timing &&
+	flux job info ${jobid} rabbit_teardown_timing
 '
 
 test_expect_success 'job requesting copy-offload in DW string works' '
@@ -194,7 +195,8 @@ test_expect_success 'job requesting copy-offload in DW string works' '
 	flux job info ${jobid} rabbit_datain_timing &&
 	flux job info ${jobid} rabbit_prerun_timing &&
 	flux job info ${jobid} rabbit_postrun_timing &&
-	flux job info ${jobid} rabbit_dataout_timing
+	flux job info ${jobid} rabbit_dataout_timing &&
+	flux job info ${jobid} rabbit_teardown_timing
 '
 
 test_expect_success 'job requesting too much storage is rejected' '


### PR DESCRIPTION
Problem: starting in #187, the elapsed time for every state except Teardown is saved to a job's KVS. There is no reason for this exclusion, and the teardown timing may be useful or interesting.

Save the timing to the KVS and add a brief check for the entry in tests.