### PR TITLE
dws: increase timeout of shell plugin

### DIFF
--- a/src/shell/plugins/dws_environment.c
+++ b/src/shell/plugins/dws_environment.c
@@ -93,7 +93,7 @@ static int read_future (flux_shell_t *shell, flux_future_t *fut)
     json_t *env, *rabbit_mapping;
     const char *name, *event = NULL;
 
-    while (flux_future_wait_for (fut, 2.0) == 0
+    while (flux_future_wait_for (fut, 30.0) == 0
            && flux_job_event_watch_get (fut, &event) == 0) {
         if (!(o = eventlog_entry_decode (event))) {
             shell_log_errno ("Error decoding eventlog entry");


### PR DESCRIPTION
Problem: as described in issue #192, on large, busy systems with lots of jobs, the dws_environment shell plugin's two-second timeout to fetch the first eventlog entry is too short and occasionally times out.

In Mark Grondona's tests to reproduce the issue, all succeeded within five seconds. However, to be safe, increase the timeout to thirty seconds.

Fixes #192.