### PR TITLE
Event watch cancel

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -160,7 +160,7 @@ def save_elapsed_time_to_kvs(handle, jobid, workflow):
         kvsdir.commit()
     except Exception:
         LOGGER.exception(
-            "Failed to update KVS for job %s: workflow is", jobid, workflow
+            "Failed to update KVS for job %s: workflow is %s", jobid, workflow
         )
 
 
@@ -180,7 +180,7 @@ def save_workflow_to_kvs(handle, jobid, workflow):
         kvsdir.commit()
     except Exception:
         LOGGER.exception(
-            "Failed to update KVS for job %s: workflow is", jobid, workflow
+            "Failed to update KVS for job %s: workflow is %s", jobid, workflow
         )
 
 

--- a/src/shell/plugins/dws_environment.c
+++ b/src/shell/plugins/dws_environment.c
@@ -171,9 +171,12 @@ static int dws_environment_init (flux_plugin_t *p,
     }
     if (read_future (shell, fut) < 0) {
         shell_log_error ("Error reading DW environment from eventlog");
+        flux_job_event_watch_cancel (fut);
         flux_future_destroy (fut);
         return -1;
     }
+    if ((flux_job_event_watch_cancel (fut)) < 0)
+        shell_log_error ("flux_job_event_watch_cancel");
     flux_future_destroy (fut);
     return 0;
 }

--- a/src/shell/plugins/dws_environment.c
+++ b/src/shell/plugins/dws_environment.c
@@ -104,7 +104,13 @@ static int read_future (flux_shell_t *shell, flux_future_t *fut)
             json_decref (o);
             return -1;
         }
-        if (!strcmp (name, "dws_environment")) {
+        if (!strcmp (name, "start")) {
+            //  'start' event with no dws_environment event.
+            shell_log_error ("'start' event found before 'dws_environment'");
+            json_decref (o);
+            return -1;
+        }
+        else if (!strcmp (name, "dws_environment")) {
             if (json_unpack (context,
                              "{s:o, s:o}",
                              "variables",
@@ -130,7 +136,7 @@ static int read_future (flux_shell_t *shell, flux_future_t *fut)
             json_decref (o);
         }
     }
-    shell_log_error ("No 'dws_environment' event posted");
+    shell_log_error ("No 'dws_environment' event posted within timeout");
     return -1;
 }
 


### PR DESCRIPTION
Problem: as described in issue https://github.com/flux-framework/flux-coral2/issues/195, the dws_environment shell
plugin should call flux_job_event_watch_cancel after finding the
dws_environment event, otherwise the watch will stay active in
the job-info service, which will continue to send responses as new
events appear in the eventlog until the shell exits and a
disconnect message is sent.

Call flux_job_event_watch_cancel.

Fixes #195.