### PR TITLE
Enforce size constraints

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -603,6 +603,7 @@ static void resource_update_msg_cb (flux_t *h,
                              jobid,
                              "dws",
                              "Internal error: failed to update jobspec");
+        return;
     }
     if (flux_jobtap_dependency_remove (p, jobid, CREATE_DEP_NAME) < 0) {
         raise_job_exception (p,

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -574,16 +574,29 @@ static void resource_update_msg_cb (flux_t *h,
 {
     flux_plugin_t *p = (flux_plugin_t *)arg;
     json_int_t jobid;
-    json_t *resources = NULL;
-    json_t *jobspec;
+    json_t *resources = NULL, *errmsg, *jobspec;
     int copy_offload;
+    const char *errmsg_str;
 
-    if (flux_msg_unpack (msg, "{s:I, s:o, s:b}", "id", &jobid, "resources", &resources, "copy-offload", &copy_offload)
+    if (flux_msg_unpack (msg,
+                         "{s:I, s:o, s:b, s:o}",
+                         "id", &jobid,
+                         "resources", &resources,
+                         "copy-offload", &copy_offload,
+                         "errmsg", &errmsg)
         < 0) {
         flux_log_error (h, "received malformed dws.resource-update RPC");
         return;
     }
-    if (!(jobspec = flux_jobtap_job_aux_get (p, jobid, "dws_jobspec"))
+    if (!json_is_null (errmsg)) {
+        if (!(errmsg_str = json_string_value (errmsg))){
+            flux_log_error (h, "received malformed dws.resource-update RPC, errmsg must be string or JSON null");
+            errmsg_str = "<could not fetch error message>";
+        }
+        raise_job_exception (p, jobid, "dws", errmsg_str);
+        return;
+    }
+    else if (!(jobspec = flux_jobtap_job_aux_get (p, jobid, "dws_jobspec"))
         || json_object_set (jobspec, "resources", resources) < 0
         || flux_jobtap_job_aux_set (p, jobid, "flux::dws-copy-offload", copy_offload ? (void*) 1 : (void*) 0, NULL) < 0 ) {
         raise_job_exception (p,

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -26,7 +26,7 @@ def create_cb(fh, t, msg, arg):
         return
     fh.rpc(
         "job-manager.dws.resource-update",
-        payload={"id": msg.payload["jobid"], "resources": msg.payload["resources"], "copy-offload": False},
+        payload={"id": msg.payload["jobid"], "resources": msg.payload["resources"], "copy-offload": False, "errmsg": None},
     )
 
 def setup_cb(fh, t, msg, arg):

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -7,17 +7,18 @@ from flux.constants import FLUX_MSGTYPE_REQUEST
 from flux.future import Future
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--create-fail', action='store_true')
-parser.add_argument('--setup-fail', action='store_true')
-parser.add_argument('--setup-hang', action='store_true')
-parser.add_argument('--post-run-fail', action='store_true')
+parser.add_argument("--create-fail", action="store_true")
+parser.add_argument("--setup-fail", action="store_true")
+parser.add_argument("--setup-hang", action="store_true")
+parser.add_argument("--post-run-fail", action="store_true")
 
 args = parser.parse_args()
+
 
 def create_cb(fh, t, msg, arg):
     payload = {
         "success": not args.create_fail,
-        "errstr": "create RPC failed for test purposes"
+        "errstr": "create RPC failed for test purposes",
     }
     fh.respond(msg, payload)
     print(f"Responded to create request with {payload}")
@@ -26,25 +27,32 @@ def create_cb(fh, t, msg, arg):
         return
     fh.rpc(
         "job-manager.dws.resource-update",
-        payload={"id": msg.payload["jobid"], "resources": msg.payload["resources"], "copy-offload": False, "errmsg": None},
+        payload={
+            "id": msg.payload["jobid"],
+            "resources": msg.payload["resources"],
+            "copy-offload": False,
+            "errmsg": None,
+        },
     )
+
 
 def setup_cb(fh, t, msg, arg):
     if args.setup_hang:
         return
     payload = {"success": not args.setup_fail}
     if args.setup_fail:
-        payload['errstr'] = "setup RPC failed for test purposes"
+        payload["errstr"] = "setup RPC failed for test purposes"
     fh.respond(msg, payload)
     fh.rpc(
         "job-manager.dws.prolog-remove",
         payload={"id": msg.payload["jobid"], "variables": {}, "rabbits": {}},
     )
 
+
 def post_run_cb(fh, t, msg, arg):
     payload = {"success": not args.post_run_fail}
     if args.post_run_fail:
-        payload['errstr'] = "post_run RPC failed for test purposes"
+        payload["errstr"] = "post_run RPC failed for test purposes"
     fh.respond(msg, payload)
     if not args.post_run_fail:
         fh.rpc(
@@ -53,13 +61,16 @@ def post_run_cb(fh, t, msg, arg):
         )
     fh.reactor_stop()
 
+
 fh = flux.Flux()
 service_reg_fut = Future(fh.service_register("dws"))
 create_watcher = fh.msg_watcher_create(create_cb, FLUX_MSGTYPE_REQUEST, "dws.create")
 create_watcher.start()
 setup_watcher = fh.msg_watcher_create(setup_cb, FLUX_MSGTYPE_REQUEST, "dws.setup")
 setup_watcher.start()
-post_run_watcher = fh.msg_watcher_create(post_run_cb, FLUX_MSGTYPE_REQUEST, "dws.post_run")
+post_run_watcher = fh.msg_watcher_create(
+    post_run_cb, FLUX_MSGTYPE_REQUEST, "dws.post_run"
+)
 post_run_watcher.start()
 service_reg_fut.get()
 print("DWS service registered")

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -372,6 +372,7 @@ test_expect_success 'job submission with persistent DW string works' '
 '
 
 test_expect_success 'job submission with standalone MGT persistent DW string works' '
+	(kubectl delete nnfstorageprofiles -nnnf-system mypoolprofile || true) &&
 	kubectl get nnfstorageprofiles -nnnf-system default -ojson | \
 		jq ".data.lustreStorage.standaloneMgtPoolName = \"mypool\" |
 		.metadata.name = \"mypoolprofile\" | .data.default = false |


### PR DESCRIPTION
Problem: as rabbits enter more general use, there needs to be a way
to enforce crude limits on the size of file systems that users can
request.

Add command-line arguments to coral2_dws for accepting size limits
and logic to the directivebreakdown module for enforcing the limits.

The limits are enforced by adding an exception with a message while the job is held in DEPEND state.