### PR TITLE
dws2jgf: drop defaults for jgf simplification

### DIFF
--- a/t/data/dws2jgf/expected-compute-01-04.jgf
+++ b/t/data/dws2jgf/expected-compute-01-04.jgf
@@ -17,23 +17,15 @@
   },
   "scheduling": {
     "graph": {
-      "directed": true,
+      "directed": false,
       "nodes": [
         {
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "ElCapitan",
-            "name": "ElCapitan0",
-            "id": 0,
-            "uniq_id": 0,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
+            "name": "ElCapitan",
             "paths": {
-              "containment": "/ElCapitan0"
+              "containment": "/ElCapitan"
             }
           }
         },
@@ -41,20 +33,13 @@
           "id": "1",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack0",
             "id": 0,
-            "uniq_id": 1,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack0"
+              "containment": "/ElCapitan/rack0"
             }
           }
         },
@@ -62,17 +47,10 @@
           "id": "2",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 2,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd0"
+              "containment": "/ElCapitan/rack0/ssd0"
             },
             "status": 1
           }
@@ -81,17 +59,10 @@
           "id": "3",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 3,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd1"
+              "containment": "/ElCapitan/rack0/ssd1"
             },
             "status": 1
           }
@@ -100,17 +71,10 @@
           "id": "4",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 4,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd2"
+              "containment": "/ElCapitan/rack0/ssd2"
             },
             "status": 1
           }
@@ -119,17 +83,10 @@
           "id": "5",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 5,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd3"
+              "containment": "/ElCapitan/rack0/ssd3"
             },
             "status": 1
           }
@@ -138,17 +95,10 @@
           "id": "6",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 6,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd4"
+              "containment": "/ElCapitan/rack0/ssd4"
             },
             "status": 1
           }
@@ -157,17 +107,10 @@
           "id": "7",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 7,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd5"
+              "containment": "/ElCapitan/rack0/ssd5"
             },
             "status": 1
           }
@@ -176,17 +119,10 @@
           "id": "8",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 8,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd6"
+              "containment": "/ElCapitan/rack0/ssd6"
             },
             "status": 1
           }
@@ -195,17 +131,10 @@
           "id": "9",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 9,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd7"
+              "containment": "/ElCapitan/rack0/ssd7"
             },
             "status": 1
           }
@@ -214,17 +143,10 @@
           "id": "10",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 10,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd8"
+              "containment": "/ElCapitan/rack0/ssd8"
             },
             "status": 1
           }
@@ -233,17 +155,10 @@
           "id": "11",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 11,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd9"
+              "containment": "/ElCapitan/rack0/ssd9"
             },
             "status": 1
           }
@@ -252,17 +167,10 @@
           "id": "12",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 12,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd10"
+              "containment": "/ElCapitan/rack0/ssd10"
             },
             "status": 1
           }
@@ -271,17 +179,10 @@
           "id": "13",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 13,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd11"
+              "containment": "/ElCapitan/rack0/ssd11"
             },
             "status": 1
           }
@@ -290,17 +191,10 @@
           "id": "14",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 14,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd12"
+              "containment": "/ElCapitan/rack0/ssd12"
             },
             "status": 1
           }
@@ -309,17 +203,10 @@
           "id": "15",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 15,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd13"
+              "containment": "/ElCapitan/rack0/ssd13"
             },
             "status": 1
           }
@@ -328,17 +215,10 @@
           "id": "16",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 16,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd14"
+              "containment": "/ElCapitan/rack0/ssd14"
             },
             "status": 1
           }
@@ -347,17 +227,10 @@
           "id": "17",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 17,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd15"
+              "containment": "/ElCapitan/rack0/ssd15"
             },
             "status": 1
           }
@@ -366,17 +239,10 @@
           "id": "18",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 18,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd16"
+              "containment": "/ElCapitan/rack0/ssd16"
             },
             "status": 1
           }
@@ -385,17 +251,10 @@
           "id": "19",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 19,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd17"
+              "containment": "/ElCapitan/rack0/ssd17"
             },
             "status": 1
           }
@@ -404,17 +263,10 @@
           "id": "20",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 20,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd18"
+              "containment": "/ElCapitan/rack0/ssd18"
             },
             "status": 1
           }
@@ -423,17 +275,10 @@
           "id": "21",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 21,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd19"
+              "containment": "/ElCapitan/rack0/ssd19"
             },
             "status": 1
           }
@@ -442,17 +287,10 @@
           "id": "22",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 22,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd20"
+              "containment": "/ElCapitan/rack0/ssd20"
             },
             "status": 1
           }
@@ -461,17 +299,10 @@
           "id": "23",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 23,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd21"
+              "containment": "/ElCapitan/rack0/ssd21"
             },
             "status": 1
           }
@@ -480,17 +311,10 @@
           "id": "24",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 24,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd22"
+              "containment": "/ElCapitan/rack0/ssd22"
             },
             "status": 1
           }
@@ -499,17 +323,10 @@
           "id": "25",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 25,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd23"
+              "containment": "/ElCapitan/rack0/ssd23"
             },
             "status": 1
           }
@@ -518,17 +335,10 @@
           "id": "26",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 26,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd24"
+              "containment": "/ElCapitan/rack0/ssd24"
             },
             "status": 1
           }
@@ -537,17 +347,10 @@
           "id": "27",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 27,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd25"
+              "containment": "/ElCapitan/rack0/ssd25"
             },
             "status": 1
           }
@@ -556,17 +359,10 @@
           "id": "28",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 28,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd26"
+              "containment": "/ElCapitan/rack0/ssd26"
             },
             "status": 1
           }
@@ -575,17 +371,10 @@
           "id": "29",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 29,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd27"
+              "containment": "/ElCapitan/rack0/ssd27"
             },
             "status": 1
           }
@@ -594,17 +383,10 @@
           "id": "30",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 30,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd28"
+              "containment": "/ElCapitan/rack0/ssd28"
             },
             "status": 1
           }
@@ -613,17 +395,10 @@
           "id": "31",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 31,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd29"
+              "containment": "/ElCapitan/rack0/ssd29"
             },
             "status": 1
           }
@@ -632,17 +407,10 @@
           "id": "32",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 32,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd30"
+              "containment": "/ElCapitan/rack0/ssd30"
             },
             "status": 1
           }
@@ -651,17 +419,10 @@
           "id": "33",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 33,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd31"
+              "containment": "/ElCapitan/rack0/ssd31"
             },
             "status": 1
           }
@@ -670,17 +431,10 @@
           "id": "34",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 34,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd32"
+              "containment": "/ElCapitan/rack0/ssd32"
             },
             "status": 1
           }
@@ -689,17 +443,10 @@
           "id": "35",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 35,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd33"
+              "containment": "/ElCapitan/rack0/ssd33"
             },
             "status": 1
           }
@@ -708,17 +455,10 @@
           "id": "36",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 36,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd34"
+              "containment": "/ElCapitan/rack0/ssd34"
             },
             "status": 1
           }
@@ -727,17 +467,10 @@
           "id": "37",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 37,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd35"
+              "containment": "/ElCapitan/rack0/ssd35"
             },
             "status": 1
           }
@@ -746,17 +479,10 @@
           "id": "38",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-01",
-            "id": 1,
-            "uniq_id": 38,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01"
+              "containment": "/ElCapitan/rack0/compute-01"
             }
           }
         },
@@ -764,17 +490,10 @@
           "id": "39",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 39,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core0"
+              "containment": "/ElCapitan/rack0/compute-01/core0"
             }
           }
         },
@@ -782,17 +501,10 @@
           "id": "40",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 40,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core1"
+              "containment": "/ElCapitan/rack0/compute-01/core1"
             }
           }
         },
@@ -800,17 +512,10 @@
           "id": "41",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 41,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core2"
+              "containment": "/ElCapitan/rack0/compute-01/core2"
             }
           }
         },
@@ -818,17 +523,10 @@
           "id": "42",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 42,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core3"
+              "containment": "/ElCapitan/rack0/compute-01/core3"
             }
           }
         },
@@ -836,17 +534,10 @@
           "id": "43",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 43,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core4"
+              "containment": "/ElCapitan/rack0/compute-01/core4"
             }
           }
         },
@@ -854,17 +545,10 @@
           "id": "44",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-02",
-            "id": 2,
-            "uniq_id": 44,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02"
+              "containment": "/ElCapitan/rack0/compute-02"
             }
           }
         },
@@ -872,17 +556,10 @@
           "id": "45",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 45,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core0"
+              "containment": "/ElCapitan/rack0/compute-02/core0"
             }
           }
         },
@@ -890,17 +567,10 @@
           "id": "46",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 46,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core1"
+              "containment": "/ElCapitan/rack0/compute-02/core1"
             }
           }
         },
@@ -908,17 +578,10 @@
           "id": "47",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 47,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core2"
+              "containment": "/ElCapitan/rack0/compute-02/core2"
             }
           }
         },
@@ -926,17 +589,10 @@
           "id": "48",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 48,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core3"
+              "containment": "/ElCapitan/rack0/compute-02/core3"
             }
           }
         },
@@ -944,17 +600,10 @@
           "id": "49",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 49,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-02/core4"
+              "containment": "/ElCapitan/rack0/compute-02/core4"
             }
           }
         },
@@ -962,17 +611,10 @@
           "id": "50",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-03",
-            "id": 3,
-            "uniq_id": 50,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03"
+              "containment": "/ElCapitan/rack0/compute-03"
             }
           }
         },
@@ -980,17 +622,10 @@
           "id": "51",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 51,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core0"
+              "containment": "/ElCapitan/rack0/compute-03/core0"
             }
           }
         },
@@ -998,17 +633,10 @@
           "id": "52",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 52,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core1"
+              "containment": "/ElCapitan/rack0/compute-03/core1"
             }
           }
         },
@@ -1016,17 +644,10 @@
           "id": "53",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 53,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core2"
+              "containment": "/ElCapitan/rack0/compute-03/core2"
             }
           }
         },
@@ -1034,17 +655,10 @@
           "id": "54",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 54,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core3"
+              "containment": "/ElCapitan/rack0/compute-03/core3"
             }
           }
         },
@@ -1052,17 +666,10 @@
           "id": "55",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 55,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-03/core4"
+              "containment": "/ElCapitan/rack0/compute-03/core4"
             }
           }
         },
@@ -1070,20 +677,13 @@
           "id": "56",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack1",
             "id": 1,
-            "uniq_id": 56,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack1"
+              "containment": "/ElCapitan/rack1"
             }
           }
         },
@@ -1091,17 +691,10 @@
           "id": "57",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 57,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd0"
+              "containment": "/ElCapitan/rack1/ssd0"
             },
             "status": 1
           }
@@ -1110,17 +703,10 @@
           "id": "58",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 58,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd1"
+              "containment": "/ElCapitan/rack1/ssd1"
             },
             "status": 1
           }
@@ -1129,17 +715,10 @@
           "id": "59",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 59,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd2"
+              "containment": "/ElCapitan/rack1/ssd2"
             },
             "status": 1
           }
@@ -1148,17 +727,10 @@
           "id": "60",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 60,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd3"
+              "containment": "/ElCapitan/rack1/ssd3"
             },
             "status": 1
           }
@@ -1167,17 +739,10 @@
           "id": "61",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 61,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd4"
+              "containment": "/ElCapitan/rack1/ssd4"
             },
             "status": 1
           }
@@ -1186,17 +751,10 @@
           "id": "62",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 62,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd5"
+              "containment": "/ElCapitan/rack1/ssd5"
             },
             "status": 1
           }
@@ -1205,17 +763,10 @@
           "id": "63",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 63,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd6"
+              "containment": "/ElCapitan/rack1/ssd6"
             },
             "status": 1
           }
@@ -1224,17 +775,10 @@
           "id": "64",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 64,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd7"
+              "containment": "/ElCapitan/rack1/ssd7"
             },
             "status": 1
           }
@@ -1243,17 +787,10 @@
           "id": "65",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 65,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd8"
+              "containment": "/ElCapitan/rack1/ssd8"
             },
             "status": 1
           }
@@ -1262,17 +799,10 @@
           "id": "66",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 66,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd9"
+              "containment": "/ElCapitan/rack1/ssd9"
             },
             "status": 1
           }
@@ -1281,17 +811,10 @@
           "id": "67",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 67,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd10"
+              "containment": "/ElCapitan/rack1/ssd10"
             },
             "status": 1
           }
@@ -1300,17 +823,10 @@
           "id": "68",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 68,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd11"
+              "containment": "/ElCapitan/rack1/ssd11"
             },
             "status": 1
           }
@@ -1319,17 +835,10 @@
           "id": "69",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 69,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd12"
+              "containment": "/ElCapitan/rack1/ssd12"
             },
             "status": 1
           }
@@ -1338,17 +847,10 @@
           "id": "70",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 70,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd13"
+              "containment": "/ElCapitan/rack1/ssd13"
             },
             "status": 1
           }
@@ -1357,17 +859,10 @@
           "id": "71",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 71,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd14"
+              "containment": "/ElCapitan/rack1/ssd14"
             },
             "status": 1
           }
@@ -1376,17 +871,10 @@
           "id": "72",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 72,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd15"
+              "containment": "/ElCapitan/rack1/ssd15"
             },
             "status": 1
           }
@@ -1395,17 +883,10 @@
           "id": "73",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 73,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd16"
+              "containment": "/ElCapitan/rack1/ssd16"
             },
             "status": 1
           }
@@ -1414,17 +895,10 @@
           "id": "74",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 74,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd17"
+              "containment": "/ElCapitan/rack1/ssd17"
             },
             "status": 1
           }
@@ -1433,17 +907,10 @@
           "id": "75",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 75,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd18"
+              "containment": "/ElCapitan/rack1/ssd18"
             },
             "status": 1
           }
@@ -1452,17 +919,10 @@
           "id": "76",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 76,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd19"
+              "containment": "/ElCapitan/rack1/ssd19"
             },
             "status": 1
           }
@@ -1471,17 +931,10 @@
           "id": "77",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 77,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd20"
+              "containment": "/ElCapitan/rack1/ssd20"
             },
             "status": 1
           }
@@ -1490,17 +943,10 @@
           "id": "78",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 78,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd21"
+              "containment": "/ElCapitan/rack1/ssd21"
             },
             "status": 1
           }
@@ -1509,17 +955,10 @@
           "id": "79",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 79,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd22"
+              "containment": "/ElCapitan/rack1/ssd22"
             },
             "status": 1
           }
@@ -1528,17 +967,10 @@
           "id": "80",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 80,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd23"
+              "containment": "/ElCapitan/rack1/ssd23"
             },
             "status": 1
           }
@@ -1547,17 +979,10 @@
           "id": "81",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 81,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd24"
+              "containment": "/ElCapitan/rack1/ssd24"
             },
             "status": 1
           }
@@ -1566,17 +991,10 @@
           "id": "82",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 82,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd25"
+              "containment": "/ElCapitan/rack1/ssd25"
             },
             "status": 1
           }
@@ -1585,17 +1003,10 @@
           "id": "83",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 83,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd26"
+              "containment": "/ElCapitan/rack1/ssd26"
             },
             "status": 1
           }
@@ -1604,17 +1015,10 @@
           "id": "84",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 84,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd27"
+              "containment": "/ElCapitan/rack1/ssd27"
             },
             "status": 1
           }
@@ -1623,17 +1027,10 @@
           "id": "85",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 85,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd28"
+              "containment": "/ElCapitan/rack1/ssd28"
             },
             "status": 1
           }
@@ -1642,17 +1039,10 @@
           "id": "86",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 86,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd29"
+              "containment": "/ElCapitan/rack1/ssd29"
             },
             "status": 1
           }
@@ -1661,17 +1051,10 @@
           "id": "87",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 87,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd30"
+              "containment": "/ElCapitan/rack1/ssd30"
             },
             "status": 1
           }
@@ -1680,17 +1063,10 @@
           "id": "88",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 88,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd31"
+              "containment": "/ElCapitan/rack1/ssd31"
             },
             "status": 1
           }
@@ -1699,17 +1075,10 @@
           "id": "89",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 89,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd32"
+              "containment": "/ElCapitan/rack1/ssd32"
             },
             "status": 1
           }
@@ -1718,17 +1087,10 @@
           "id": "90",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 90,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd33"
+              "containment": "/ElCapitan/rack1/ssd33"
             },
             "status": 1
           }
@@ -1737,17 +1099,10 @@
           "id": "91",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 91,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd34"
+              "containment": "/ElCapitan/rack1/ssd34"
             },
             "status": 1
           }
@@ -1756,17 +1111,10 @@
           "id": "92",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 92,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd35"
+              "containment": "/ElCapitan/rack1/ssd35"
             },
             "status": 1
           }
@@ -1775,17 +1123,10 @@
           "id": "93",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-04",
-            "id": 4,
-            "uniq_id": 93,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04"
+              "containment": "/ElCapitan/rack1/compute-04"
             }
           }
         },
@@ -1793,17 +1134,10 @@
           "id": "94",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 94,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core0"
+              "containment": "/ElCapitan/rack1/compute-04/core0"
             }
           }
         },
@@ -1811,17 +1145,10 @@
           "id": "95",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 95,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core1"
+              "containment": "/ElCapitan/rack1/compute-04/core1"
             }
           }
         },
@@ -1829,17 +1156,10 @@
           "id": "96",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 96,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core2"
+              "containment": "/ElCapitan/rack1/compute-04/core2"
             }
           }
         },
@@ -1847,17 +1167,10 @@
           "id": "97",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 97,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core3"
+              "containment": "/ElCapitan/rack1/compute-04/core3"
             }
           }
         },
@@ -1865,17 +1178,10 @@
           "id": "98",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 98,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/compute-04/core4"
+              "containment": "/ElCapitan/rack1/compute-04/core4"
             }
           }
         }
@@ -1883,787 +1189,395 @@
       "edges": [
         {
           "source": "0",
-          "target": "1",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "1"
         },
         {
           "source": "1",
-          "target": "2",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "2"
         },
         {
           "source": "1",
-          "target": "3",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "3"
         },
         {
           "source": "1",
-          "target": "4",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "4"
         },
         {
           "source": "1",
-          "target": "5",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "5"
         },
         {
           "source": "1",
-          "target": "6",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "6"
         },
         {
           "source": "1",
-          "target": "7",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "7"
         },
         {
           "source": "1",
-          "target": "8",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "8"
         },
         {
           "source": "1",
-          "target": "9",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "9"
         },
         {
           "source": "1",
-          "target": "10",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "10"
         },
         {
           "source": "1",
-          "target": "11",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "11"
         },
         {
           "source": "1",
-          "target": "12",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "12"
         },
         {
           "source": "1",
-          "target": "13",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "13"
         },
         {
           "source": "1",
-          "target": "14",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "14"
         },
         {
           "source": "1",
-          "target": "15",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "15"
         },
         {
           "source": "1",
-          "target": "16",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "16"
         },
         {
           "source": "1",
-          "target": "17",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "17"
         },
         {
           "source": "1",
-          "target": "18",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "18"
         },
         {
           "source": "1",
-          "target": "19",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "19"
         },
         {
           "source": "1",
-          "target": "20",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "20"
         },
         {
           "source": "1",
-          "target": "21",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "21"
         },
         {
           "source": "1",
-          "target": "22",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "22"
         },
         {
           "source": "1",
-          "target": "23",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "23"
         },
         {
           "source": "1",
-          "target": "24",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "24"
         },
         {
           "source": "1",
-          "target": "25",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "25"
         },
         {
           "source": "1",
-          "target": "26",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "26"
         },
         {
           "source": "1",
-          "target": "27",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "27"
         },
         {
           "source": "1",
-          "target": "28",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "28"
         },
         {
           "source": "1",
-          "target": "29",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "29"
         },
         {
           "source": "1",
-          "target": "30",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "30"
         },
         {
           "source": "1",
-          "target": "31",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "31"
         },
         {
           "source": "1",
-          "target": "32",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "32"
         },
         {
           "source": "1",
-          "target": "33",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "33"
         },
         {
           "source": "1",
-          "target": "34",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "34"
         },
         {
           "source": "1",
-          "target": "35",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "35"
         },
         {
           "source": "1",
-          "target": "36",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "36"
         },
         {
           "source": "1",
-          "target": "37",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "37"
         },
         {
           "source": "1",
-          "target": "38",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "38"
         },
         {
           "source": "38",
-          "target": "39",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "39"
         },
         {
           "source": "38",
-          "target": "40",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "40"
         },
         {
           "source": "38",
-          "target": "41",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "41"
         },
         {
           "source": "38",
-          "target": "42",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "42"
         },
         {
           "source": "38",
-          "target": "43",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "43"
         },
         {
           "source": "1",
-          "target": "44",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "44"
         },
         {
           "source": "44",
-          "target": "45",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "45"
         },
         {
           "source": "44",
-          "target": "46",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "46"
         },
         {
           "source": "44",
-          "target": "47",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "47"
         },
         {
           "source": "44",
-          "target": "48",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "48"
         },
         {
           "source": "44",
-          "target": "49",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "49"
         },
         {
           "source": "1",
-          "target": "50",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "50"
         },
         {
           "source": "50",
-          "target": "51",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "51"
         },
         {
           "source": "50",
-          "target": "52",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "52"
         },
         {
           "source": "50",
-          "target": "53",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "53"
         },
         {
           "source": "50",
-          "target": "54",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "54"
         },
         {
           "source": "50",
-          "target": "55",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "55"
         },
         {
           "source": "0",
-          "target": "56",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "56"
         },
         {
           "source": "56",
-          "target": "57",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "57"
         },
         {
           "source": "56",
-          "target": "58",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "58"
         },
         {
           "source": "56",
-          "target": "59",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "59"
         },
         {
           "source": "56",
-          "target": "60",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "60"
         },
         {
           "source": "56",
-          "target": "61",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "61"
         },
         {
           "source": "56",
-          "target": "62",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "62"
         },
         {
           "source": "56",
-          "target": "63",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "63"
         },
         {
           "source": "56",
-          "target": "64",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "64"
         },
         {
           "source": "56",
-          "target": "65",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "65"
         },
         {
           "source": "56",
-          "target": "66",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "66"
         },
         {
           "source": "56",
-          "target": "67",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "67"
         },
         {
           "source": "56",
-          "target": "68",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "68"
         },
         {
           "source": "56",
-          "target": "69",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "69"
         },
         {
           "source": "56",
-          "target": "70",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "70"
         },
         {
           "source": "56",
-          "target": "71",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "71"
         },
         {
           "source": "56",
-          "target": "72",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "72"
         },
         {
           "source": "56",
-          "target": "73",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "73"
         },
         {
           "source": "56",
-          "target": "74",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "74"
         },
         {
           "source": "56",
-          "target": "75",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "75"
         },
         {
           "source": "56",
-          "target": "76",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "76"
         },
         {
           "source": "56",
-          "target": "77",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "77"
         },
         {
           "source": "56",
-          "target": "78",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "78"
         },
         {
           "source": "56",
-          "target": "79",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "79"
         },
         {
           "source": "56",
-          "target": "80",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "80"
         },
         {
           "source": "56",
-          "target": "81",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "81"
         },
         {
           "source": "56",
-          "target": "82",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "82"
         },
         {
           "source": "56",
-          "target": "83",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "83"
         },
         {
           "source": "56",
-          "target": "84",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "84"
         },
         {
           "source": "56",
-          "target": "85",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "85"
         },
         {
           "source": "56",
-          "target": "86",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "86"
         },
         {
           "source": "56",
-          "target": "87",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "87"
         },
         {
           "source": "56",
-          "target": "88",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "88"
         },
         {
           "source": "56",
-          "target": "89",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "89"
         },
         {
           "source": "56",
-          "target": "90",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "90"
         },
         {
           "source": "56",
-          "target": "91",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "91"
         },
         {
           "source": "56",
-          "target": "92",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "92"
         },
         {
           "source": "56",
-          "target": "93",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "93"
         },
         {
           "source": "93",
-          "target": "94",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "94"
         },
         {
           "source": "93",
-          "target": "95",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "95"
         },
         {
           "source": "93",
-          "target": "96",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "96"
         },
         {
           "source": "93",
-          "target": "97",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "97"
         },
         {
           "source": "93",
-          "target": "98",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "98"
         }
       ]
     }

--- a/t/data/dws2jgf/expected-compute-01-nodws.jgf
+++ b/t/data/dws2jgf/expected-compute-01-nodws.jgf
@@ -17,23 +17,15 @@
   },
   "scheduling": {
     "graph": {
-      "directed": true,
+      "directed": false,
       "nodes": [
         {
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "compute",
-            "name": "compute0",
-            "id": 0,
-            "uniq_id": 0,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
+            "name": "compute",
             "paths": {
-              "containment": "/compute0"
+              "containment": "/compute"
             }
           }
         },
@@ -41,20 +33,13 @@
           "id": "1",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack0",
             "id": 0,
-            "uniq_id": 1,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute0/rack0"
+              "containment": "/compute/rack0"
             }
           }
         },
@@ -62,17 +47,10 @@
           "id": "2",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 2,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd0"
+              "containment": "/compute/rack0/ssd0"
             },
             "status": 1
           }
@@ -81,17 +59,10 @@
           "id": "3",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 3,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd1"
+              "containment": "/compute/rack0/ssd1"
             },
             "status": 1
           }
@@ -100,17 +71,10 @@
           "id": "4",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 4,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd2"
+              "containment": "/compute/rack0/ssd2"
             },
             "status": 1
           }
@@ -119,17 +83,10 @@
           "id": "5",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 5,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd3"
+              "containment": "/compute/rack0/ssd3"
             },
             "status": 1
           }
@@ -138,17 +95,10 @@
           "id": "6",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 6,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd4"
+              "containment": "/compute/rack0/ssd4"
             },
             "status": 1
           }
@@ -157,17 +107,10 @@
           "id": "7",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 7,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd5"
+              "containment": "/compute/rack0/ssd5"
             },
             "status": 1
           }
@@ -176,17 +119,10 @@
           "id": "8",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 8,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd6"
+              "containment": "/compute/rack0/ssd6"
             },
             "status": 1
           }
@@ -195,17 +131,10 @@
           "id": "9",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 9,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd7"
+              "containment": "/compute/rack0/ssd7"
             },
             "status": 1
           }
@@ -214,17 +143,10 @@
           "id": "10",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 10,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd8"
+              "containment": "/compute/rack0/ssd8"
             },
             "status": 1
           }
@@ -233,17 +155,10 @@
           "id": "11",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 11,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd9"
+              "containment": "/compute/rack0/ssd9"
             },
             "status": 1
           }
@@ -252,17 +167,10 @@
           "id": "12",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 12,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd10"
+              "containment": "/compute/rack0/ssd10"
             },
             "status": 1
           }
@@ -271,17 +179,10 @@
           "id": "13",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 13,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd11"
+              "containment": "/compute/rack0/ssd11"
             },
             "status": 1
           }
@@ -290,17 +191,10 @@
           "id": "14",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 14,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd12"
+              "containment": "/compute/rack0/ssd12"
             },
             "status": 1
           }
@@ -309,17 +203,10 @@
           "id": "15",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 15,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd13"
+              "containment": "/compute/rack0/ssd13"
             },
             "status": 1
           }
@@ -328,17 +215,10 @@
           "id": "16",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 16,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd14"
+              "containment": "/compute/rack0/ssd14"
             },
             "status": 1
           }
@@ -347,17 +227,10 @@
           "id": "17",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 17,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd15"
+              "containment": "/compute/rack0/ssd15"
             },
             "status": 1
           }
@@ -366,17 +239,10 @@
           "id": "18",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 18,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd16"
+              "containment": "/compute/rack0/ssd16"
             },
             "status": 1
           }
@@ -385,17 +251,10 @@
           "id": "19",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 19,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd17"
+              "containment": "/compute/rack0/ssd17"
             },
             "status": 1
           }
@@ -404,17 +263,10 @@
           "id": "20",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 20,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd18"
+              "containment": "/compute/rack0/ssd18"
             },
             "status": 1
           }
@@ -423,17 +275,10 @@
           "id": "21",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 21,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd19"
+              "containment": "/compute/rack0/ssd19"
             },
             "status": 1
           }
@@ -442,17 +287,10 @@
           "id": "22",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 22,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd20"
+              "containment": "/compute/rack0/ssd20"
             },
             "status": 1
           }
@@ -461,17 +299,10 @@
           "id": "23",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 23,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd21"
+              "containment": "/compute/rack0/ssd21"
             },
             "status": 1
           }
@@ -480,17 +311,10 @@
           "id": "24",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 24,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd22"
+              "containment": "/compute/rack0/ssd22"
             },
             "status": 1
           }
@@ -499,17 +323,10 @@
           "id": "25",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 25,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd23"
+              "containment": "/compute/rack0/ssd23"
             },
             "status": 1
           }
@@ -518,17 +335,10 @@
           "id": "26",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 26,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd24"
+              "containment": "/compute/rack0/ssd24"
             },
             "status": 1
           }
@@ -537,17 +347,10 @@
           "id": "27",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 27,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd25"
+              "containment": "/compute/rack0/ssd25"
             },
             "status": 1
           }
@@ -556,17 +359,10 @@
           "id": "28",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 28,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd26"
+              "containment": "/compute/rack0/ssd26"
             },
             "status": 1
           }
@@ -575,17 +371,10 @@
           "id": "29",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 29,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd27"
+              "containment": "/compute/rack0/ssd27"
             },
             "status": 1
           }
@@ -594,17 +383,10 @@
           "id": "30",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 30,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd28"
+              "containment": "/compute/rack0/ssd28"
             },
             "status": 1
           }
@@ -613,17 +395,10 @@
           "id": "31",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 31,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd29"
+              "containment": "/compute/rack0/ssd29"
             },
             "status": 1
           }
@@ -632,17 +407,10 @@
           "id": "32",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 32,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd30"
+              "containment": "/compute/rack0/ssd30"
             },
             "status": 1
           }
@@ -651,17 +419,10 @@
           "id": "33",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 33,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd31"
+              "containment": "/compute/rack0/ssd31"
             },
             "status": 1
           }
@@ -670,17 +431,10 @@
           "id": "34",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 34,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd32"
+              "containment": "/compute/rack0/ssd32"
             },
             "status": 1
           }
@@ -689,17 +443,10 @@
           "id": "35",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 35,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd33"
+              "containment": "/compute/rack0/ssd33"
             },
             "status": 1
           }
@@ -708,17 +455,10 @@
           "id": "36",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 36,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd34"
+              "containment": "/compute/rack0/ssd34"
             },
             "status": 1
           }
@@ -727,17 +467,10 @@
           "id": "37",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 37,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd35"
+              "containment": "/compute/rack0/ssd35"
             },
             "status": 1
           }
@@ -746,17 +479,10 @@
           "id": "38",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-01",
-            "id": 1,
-            "uniq_id": 38,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01"
+              "containment": "/compute/rack0/compute-01"
             }
           }
         },
@@ -764,17 +490,10 @@
           "id": "39",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 39,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core0"
+              "containment": "/compute/rack0/compute-01/core0"
             }
           }
         },
@@ -782,17 +501,10 @@
           "id": "40",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 40,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core1"
+              "containment": "/compute/rack0/compute-01/core1"
             }
           }
         },
@@ -800,17 +512,10 @@
           "id": "41",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 41,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core2"
+              "containment": "/compute/rack0/compute-01/core2"
             }
           }
         },
@@ -818,17 +523,10 @@
           "id": "42",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 42,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core3"
+              "containment": "/compute/rack0/compute-01/core3"
             }
           }
         },
@@ -836,17 +534,10 @@
           "id": "43",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 43,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core4"
+              "containment": "/compute/rack0/compute-01/core4"
             }
           }
         },
@@ -854,17 +545,10 @@
           "id": "44",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-02",
-            "id": 2,
-            "uniq_id": 44,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02"
+              "containment": "/compute/rack0/compute-02"
             }
           }
         },
@@ -872,17 +556,10 @@
           "id": "45",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 45,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02/core0"
+              "containment": "/compute/rack0/compute-02/core0"
             }
           }
         },
@@ -890,17 +567,10 @@
           "id": "46",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 46,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02/core1"
+              "containment": "/compute/rack0/compute-02/core1"
             }
           }
         },
@@ -908,17 +578,10 @@
           "id": "47",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 47,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02/core2"
+              "containment": "/compute/rack0/compute-02/core2"
             }
           }
         },
@@ -926,17 +589,10 @@
           "id": "48",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 48,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02/core3"
+              "containment": "/compute/rack0/compute-02/core3"
             }
           }
         },
@@ -944,17 +600,10 @@
           "id": "49",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 49,
             "rank": 1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-02/core4"
+              "containment": "/compute/rack0/compute-02/core4"
             }
           }
         },
@@ -962,17 +611,10 @@
           "id": "50",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-03",
-            "id": 3,
-            "uniq_id": 50,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03"
+              "containment": "/compute/rack0/compute-03"
             }
           }
         },
@@ -980,17 +622,10 @@
           "id": "51",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 51,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03/core0"
+              "containment": "/compute/rack0/compute-03/core0"
             }
           }
         },
@@ -998,17 +633,10 @@
           "id": "52",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 52,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03/core1"
+              "containment": "/compute/rack0/compute-03/core1"
             }
           }
         },
@@ -1016,17 +644,10 @@
           "id": "53",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 53,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03/core2"
+              "containment": "/compute/rack0/compute-03/core2"
             }
           }
         },
@@ -1034,17 +655,10 @@
           "id": "54",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 54,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03/core3"
+              "containment": "/compute/rack0/compute-03/core3"
             }
           }
         },
@@ -1052,17 +666,10 @@
           "id": "55",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 55,
             "rank": 2,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-03/core4"
+              "containment": "/compute/rack0/compute-03/core4"
             }
           }
         },
@@ -1070,20 +677,13 @@
           "id": "56",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack1",
             "id": 1,
-            "uniq_id": 56,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute0/rack1"
+              "containment": "/compute/rack1"
             }
           }
         },
@@ -1091,17 +691,10 @@
           "id": "57",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 57,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd0"
+              "containment": "/compute/rack1/ssd0"
             },
             "status": 1
           }
@@ -1110,17 +703,10 @@
           "id": "58",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 58,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd1"
+              "containment": "/compute/rack1/ssd1"
             },
             "status": 1
           }
@@ -1129,17 +715,10 @@
           "id": "59",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 59,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd2"
+              "containment": "/compute/rack1/ssd2"
             },
             "status": 1
           }
@@ -1148,17 +727,10 @@
           "id": "60",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 60,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd3"
+              "containment": "/compute/rack1/ssd3"
             },
             "status": 1
           }
@@ -1167,17 +739,10 @@
           "id": "61",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 61,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd4"
+              "containment": "/compute/rack1/ssd4"
             },
             "status": 1
           }
@@ -1186,17 +751,10 @@
           "id": "62",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 62,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd5"
+              "containment": "/compute/rack1/ssd5"
             },
             "status": 1
           }
@@ -1205,17 +763,10 @@
           "id": "63",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 63,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd6"
+              "containment": "/compute/rack1/ssd6"
             },
             "status": 1
           }
@@ -1224,17 +775,10 @@
           "id": "64",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 64,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd7"
+              "containment": "/compute/rack1/ssd7"
             },
             "status": 1
           }
@@ -1243,17 +787,10 @@
           "id": "65",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 65,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd8"
+              "containment": "/compute/rack1/ssd8"
             },
             "status": 1
           }
@@ -1262,17 +799,10 @@
           "id": "66",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 66,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd9"
+              "containment": "/compute/rack1/ssd9"
             },
             "status": 1
           }
@@ -1281,17 +811,10 @@
           "id": "67",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 67,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd10"
+              "containment": "/compute/rack1/ssd10"
             },
             "status": 1
           }
@@ -1300,17 +823,10 @@
           "id": "68",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 68,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd11"
+              "containment": "/compute/rack1/ssd11"
             },
             "status": 1
           }
@@ -1319,17 +835,10 @@
           "id": "69",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 69,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd12"
+              "containment": "/compute/rack1/ssd12"
             },
             "status": 1
           }
@@ -1338,17 +847,10 @@
           "id": "70",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 70,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd13"
+              "containment": "/compute/rack1/ssd13"
             },
             "status": 1
           }
@@ -1357,17 +859,10 @@
           "id": "71",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 71,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd14"
+              "containment": "/compute/rack1/ssd14"
             },
             "status": 1
           }
@@ -1376,17 +871,10 @@
           "id": "72",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 72,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd15"
+              "containment": "/compute/rack1/ssd15"
             },
             "status": 1
           }
@@ -1395,17 +883,10 @@
           "id": "73",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 73,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd16"
+              "containment": "/compute/rack1/ssd16"
             },
             "status": 1
           }
@@ -1414,17 +895,10 @@
           "id": "74",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 74,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd17"
+              "containment": "/compute/rack1/ssd17"
             },
             "status": 1
           }
@@ -1433,17 +907,10 @@
           "id": "75",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 75,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd18"
+              "containment": "/compute/rack1/ssd18"
             },
             "status": 1
           }
@@ -1452,17 +919,10 @@
           "id": "76",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 76,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd19"
+              "containment": "/compute/rack1/ssd19"
             },
             "status": 1
           }
@@ -1471,17 +931,10 @@
           "id": "77",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 77,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd20"
+              "containment": "/compute/rack1/ssd20"
             },
             "status": 1
           }
@@ -1490,17 +943,10 @@
           "id": "78",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 78,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd21"
+              "containment": "/compute/rack1/ssd21"
             },
             "status": 1
           }
@@ -1509,17 +955,10 @@
           "id": "79",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 79,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd22"
+              "containment": "/compute/rack1/ssd22"
             },
             "status": 1
           }
@@ -1528,17 +967,10 @@
           "id": "80",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 80,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd23"
+              "containment": "/compute/rack1/ssd23"
             },
             "status": 1
           }
@@ -1547,17 +979,10 @@
           "id": "81",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 81,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd24"
+              "containment": "/compute/rack1/ssd24"
             },
             "status": 1
           }
@@ -1566,17 +991,10 @@
           "id": "82",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 82,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd25"
+              "containment": "/compute/rack1/ssd25"
             },
             "status": 1
           }
@@ -1585,17 +1003,10 @@
           "id": "83",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 83,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd26"
+              "containment": "/compute/rack1/ssd26"
             },
             "status": 1
           }
@@ -1604,17 +1015,10 @@
           "id": "84",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 84,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd27"
+              "containment": "/compute/rack1/ssd27"
             },
             "status": 1
           }
@@ -1623,17 +1027,10 @@
           "id": "85",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 85,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd28"
+              "containment": "/compute/rack1/ssd28"
             },
             "status": 1
           }
@@ -1642,17 +1039,10 @@
           "id": "86",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 86,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd29"
+              "containment": "/compute/rack1/ssd29"
             },
             "status": 1
           }
@@ -1661,17 +1051,10 @@
           "id": "87",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 87,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd30"
+              "containment": "/compute/rack1/ssd30"
             },
             "status": 1
           }
@@ -1680,17 +1063,10 @@
           "id": "88",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 88,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd31"
+              "containment": "/compute/rack1/ssd31"
             },
             "status": 1
           }
@@ -1699,17 +1075,10 @@
           "id": "89",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 89,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd32"
+              "containment": "/compute/rack1/ssd32"
             },
             "status": 1
           }
@@ -1718,17 +1087,10 @@
           "id": "90",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 90,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd33"
+              "containment": "/compute/rack1/ssd33"
             },
             "status": 1
           }
@@ -1737,17 +1099,10 @@
           "id": "91",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 91,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd34"
+              "containment": "/compute/rack1/ssd34"
             },
             "status": 1
           }
@@ -1756,17 +1111,10 @@
           "id": "92",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 92,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd35"
+              "containment": "/compute/rack1/ssd35"
             },
             "status": 1
           }
@@ -1775,17 +1123,10 @@
           "id": "93",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-04",
-            "id": 4,
-            "uniq_id": 93,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04"
+              "containment": "/compute/rack1/compute-04"
             }
           }
         },
@@ -1793,17 +1134,10 @@
           "id": "94",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 94,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04/core0"
+              "containment": "/compute/rack1/compute-04/core0"
             }
           }
         },
@@ -1811,17 +1145,10 @@
           "id": "95",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 95,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04/core1"
+              "containment": "/compute/rack1/compute-04/core1"
             }
           }
         },
@@ -1829,17 +1156,10 @@
           "id": "96",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 96,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04/core2"
+              "containment": "/compute/rack1/compute-04/core2"
             }
           }
         },
@@ -1847,17 +1167,10 @@
           "id": "97",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 97,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04/core3"
+              "containment": "/compute/rack1/compute-04/core3"
             }
           }
         },
@@ -1865,17 +1178,10 @@
           "id": "98",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 98,
             "rank": 3,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/compute-04/core4"
+              "containment": "/compute/rack1/compute-04/core4"
             }
           }
         },
@@ -1883,17 +1189,10 @@
           "id": "99",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws0",
-            "id": 0,
-            "uniq_id": 99,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0"
+              "containment": "/compute/nodws0"
             }
           }
         },
@@ -1901,17 +1200,10 @@
           "id": "100",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 100,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0/core0"
+              "containment": "/compute/nodws0/core0"
             }
           }
         },
@@ -1919,17 +1211,10 @@
           "id": "101",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 101,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0/core1"
+              "containment": "/compute/nodws0/core1"
             }
           }
         },
@@ -1937,17 +1222,10 @@
           "id": "102",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 102,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0/core2"
+              "containment": "/compute/nodws0/core2"
             }
           }
         },
@@ -1955,17 +1233,10 @@
           "id": "103",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 103,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0/core3"
+              "containment": "/compute/nodws0/core3"
             }
           }
         },
@@ -1973,17 +1244,10 @@
           "id": "104",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 104,
             "rank": 4,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws0/core4"
+              "containment": "/compute/nodws0/core4"
             }
           }
         },
@@ -1991,17 +1255,10 @@
           "id": "105",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws1",
-            "id": 1,
-            "uniq_id": 105,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1"
+              "containment": "/compute/nodws1"
             }
           }
         },
@@ -2009,17 +1266,10 @@
           "id": "106",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 106,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1/core0"
+              "containment": "/compute/nodws1/core0"
             }
           }
         },
@@ -2027,17 +1277,10 @@
           "id": "107",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 107,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1/core1"
+              "containment": "/compute/nodws1/core1"
             }
           }
         },
@@ -2045,17 +1288,10 @@
           "id": "108",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 108,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1/core2"
+              "containment": "/compute/nodws1/core2"
             }
           }
         },
@@ -2063,17 +1299,10 @@
           "id": "109",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 109,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1/core3"
+              "containment": "/compute/nodws1/core3"
             }
           }
         },
@@ -2081,17 +1310,10 @@
           "id": "110",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 110,
             "rank": 5,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws1/core4"
+              "containment": "/compute/nodws1/core4"
             }
           }
         },
@@ -2099,17 +1321,10 @@
           "id": "111",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws2",
-            "id": 2,
-            "uniq_id": 111,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2"
+              "containment": "/compute/nodws2"
             }
           }
         },
@@ -2117,17 +1332,10 @@
           "id": "112",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 112,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2/core0"
+              "containment": "/compute/nodws2/core0"
             }
           }
         },
@@ -2135,17 +1343,10 @@
           "id": "113",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 113,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2/core1"
+              "containment": "/compute/nodws2/core1"
             }
           }
         },
@@ -2153,17 +1354,10 @@
           "id": "114",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 114,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2/core2"
+              "containment": "/compute/nodws2/core2"
             }
           }
         },
@@ -2171,17 +1365,10 @@
           "id": "115",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 115,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2/core3"
+              "containment": "/compute/nodws2/core3"
             }
           }
         },
@@ -2189,17 +1376,10 @@
           "id": "116",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 116,
             "rank": 6,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws2/core4"
+              "containment": "/compute/nodws2/core4"
             }
           }
         },
@@ -2207,17 +1387,10 @@
           "id": "117",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws3",
-            "id": 3,
-            "uniq_id": 117,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3"
+              "containment": "/compute/nodws3"
             }
           }
         },
@@ -2225,17 +1398,10 @@
           "id": "118",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 118,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3/core0"
+              "containment": "/compute/nodws3/core0"
             }
           }
         },
@@ -2243,17 +1409,10 @@
           "id": "119",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 119,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3/core1"
+              "containment": "/compute/nodws3/core1"
             }
           }
         },
@@ -2261,17 +1420,10 @@
           "id": "120",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 120,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3/core2"
+              "containment": "/compute/nodws3/core2"
             }
           }
         },
@@ -2279,17 +1431,10 @@
           "id": "121",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 121,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3/core3"
+              "containment": "/compute/nodws3/core3"
             }
           }
         },
@@ -2297,17 +1442,10 @@
           "id": "122",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 122,
             "rank": 7,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws3/core4"
+              "containment": "/compute/nodws3/core4"
             }
           }
         },
@@ -2315,17 +1453,10 @@
           "id": "123",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws4",
-            "id": 4,
-            "uniq_id": 123,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4"
+              "containment": "/compute/nodws4"
             }
           }
         },
@@ -2333,17 +1464,10 @@
           "id": "124",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 124,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4/core0"
+              "containment": "/compute/nodws4/core0"
             }
           }
         },
@@ -2351,17 +1475,10 @@
           "id": "125",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 125,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4/core1"
+              "containment": "/compute/nodws4/core1"
             }
           }
         },
@@ -2369,17 +1486,10 @@
           "id": "126",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 126,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4/core2"
+              "containment": "/compute/nodws4/core2"
             }
           }
         },
@@ -2387,17 +1497,10 @@
           "id": "127",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 127,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4/core3"
+              "containment": "/compute/nodws4/core3"
             }
           }
         },
@@ -2405,17 +1508,10 @@
           "id": "128",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 128,
             "rank": 8,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws4/core4"
+              "containment": "/compute/nodws4/core4"
             }
           }
         },
@@ -2423,17 +1519,10 @@
           "id": "129",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "nodws5",
-            "id": 5,
-            "uniq_id": 129,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5"
+              "containment": "/compute/nodws5"
             }
           }
         },
@@ -2441,17 +1530,10 @@
           "id": "130",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 130,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5/core0"
+              "containment": "/compute/nodws5/core0"
             }
           }
         },
@@ -2459,17 +1541,10 @@
           "id": "131",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 131,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5/core1"
+              "containment": "/compute/nodws5/core1"
             }
           }
         },
@@ -2477,17 +1552,10 @@
           "id": "132",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 132,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5/core2"
+              "containment": "/compute/nodws5/core2"
             }
           }
         },
@@ -2495,17 +1563,10 @@
           "id": "133",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 133,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5/core3"
+              "containment": "/compute/nodws5/core3"
             }
           }
         },
@@ -2513,17 +1574,10 @@
           "id": "134",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 134,
             "rank": 9,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/nodws5/core4"
+              "containment": "/compute/nodws5/core4"
             }
           }
         }
@@ -2531,1075 +1585,539 @@
       "edges": [
         {
           "source": "0",
-          "target": "1",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "1"
         },
         {
           "source": "1",
-          "target": "2",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "2"
         },
         {
           "source": "1",
-          "target": "3",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "3"
         },
         {
           "source": "1",
-          "target": "4",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "4"
         },
         {
           "source": "1",
-          "target": "5",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "5"
         },
         {
           "source": "1",
-          "target": "6",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "6"
         },
         {
           "source": "1",
-          "target": "7",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "7"
         },
         {
           "source": "1",
-          "target": "8",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "8"
         },
         {
           "source": "1",
-          "target": "9",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "9"
         },
         {
           "source": "1",
-          "target": "10",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "10"
         },
         {
           "source": "1",
-          "target": "11",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "11"
         },
         {
           "source": "1",
-          "target": "12",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "12"
         },
         {
           "source": "1",
-          "target": "13",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "13"
         },
         {
           "source": "1",
-          "target": "14",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "14"
         },
         {
           "source": "1",
-          "target": "15",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "15"
         },
         {
           "source": "1",
-          "target": "16",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "16"
         },
         {
           "source": "1",
-          "target": "17",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "17"
         },
         {
           "source": "1",
-          "target": "18",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "18"
         },
         {
           "source": "1",
-          "target": "19",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "19"
         },
         {
           "source": "1",
-          "target": "20",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "20"
         },
         {
           "source": "1",
-          "target": "21",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "21"
         },
         {
           "source": "1",
-          "target": "22",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "22"
         },
         {
           "source": "1",
-          "target": "23",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "23"
         },
         {
           "source": "1",
-          "target": "24",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "24"
         },
         {
           "source": "1",
-          "target": "25",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "25"
         },
         {
           "source": "1",
-          "target": "26",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "26"
         },
         {
           "source": "1",
-          "target": "27",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "27"
         },
         {
           "source": "1",
-          "target": "28",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "28"
         },
         {
           "source": "1",
-          "target": "29",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "29"
         },
         {
           "source": "1",
-          "target": "30",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "30"
         },
         {
           "source": "1",
-          "target": "31",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "31"
         },
         {
           "source": "1",
-          "target": "32",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "32"
         },
         {
           "source": "1",
-          "target": "33",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "33"
         },
         {
           "source": "1",
-          "target": "34",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "34"
         },
         {
           "source": "1",
-          "target": "35",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "35"
         },
         {
           "source": "1",
-          "target": "36",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "36"
         },
         {
           "source": "1",
-          "target": "37",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "37"
         },
         {
           "source": "1",
-          "target": "38",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "38"
         },
         {
           "source": "38",
-          "target": "39",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "39"
         },
         {
           "source": "38",
-          "target": "40",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "40"
         },
         {
           "source": "38",
-          "target": "41",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "41"
         },
         {
           "source": "38",
-          "target": "42",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "42"
         },
         {
           "source": "38",
-          "target": "43",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "43"
         },
         {
           "source": "1",
-          "target": "44",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "44"
         },
         {
           "source": "44",
-          "target": "45",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "45"
         },
         {
           "source": "44",
-          "target": "46",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "46"
         },
         {
           "source": "44",
-          "target": "47",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "47"
         },
         {
           "source": "44",
-          "target": "48",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "48"
         },
         {
           "source": "44",
-          "target": "49",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "49"
         },
         {
           "source": "1",
-          "target": "50",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "50"
         },
         {
           "source": "50",
-          "target": "51",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "51"
         },
         {
           "source": "50",
-          "target": "52",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "52"
         },
         {
           "source": "50",
-          "target": "53",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "53"
         },
         {
           "source": "50",
-          "target": "54",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "54"
         },
         {
           "source": "50",
-          "target": "55",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "55"
         },
         {
           "source": "0",
-          "target": "56",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "56"
         },
         {
           "source": "56",
-          "target": "57",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "57"
         },
         {
           "source": "56",
-          "target": "58",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "58"
         },
         {
           "source": "56",
-          "target": "59",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "59"
         },
         {
           "source": "56",
-          "target": "60",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "60"
         },
         {
           "source": "56",
-          "target": "61",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "61"
         },
         {
           "source": "56",
-          "target": "62",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "62"
         },
         {
           "source": "56",
-          "target": "63",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "63"
         },
         {
           "source": "56",
-          "target": "64",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "64"
         },
         {
           "source": "56",
-          "target": "65",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "65"
         },
         {
           "source": "56",
-          "target": "66",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "66"
         },
         {
           "source": "56",
-          "target": "67",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "67"
         },
         {
           "source": "56",
-          "target": "68",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "68"
         },
         {
           "source": "56",
-          "target": "69",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "69"
         },
         {
           "source": "56",
-          "target": "70",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "70"
         },
         {
           "source": "56",
-          "target": "71",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "71"
         },
         {
           "source": "56",
-          "target": "72",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "72"
         },
         {
           "source": "56",
-          "target": "73",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "73"
         },
         {
           "source": "56",
-          "target": "74",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "74"
         },
         {
           "source": "56",
-          "target": "75",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "75"
         },
         {
           "source": "56",
-          "target": "76",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "76"
         },
         {
           "source": "56",
-          "target": "77",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "77"
         },
         {
           "source": "56",
-          "target": "78",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "78"
         },
         {
           "source": "56",
-          "target": "79",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "79"
         },
         {
           "source": "56",
-          "target": "80",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "80"
         },
         {
           "source": "56",
-          "target": "81",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "81"
         },
         {
           "source": "56",
-          "target": "82",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "82"
         },
         {
           "source": "56",
-          "target": "83",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "83"
         },
         {
           "source": "56",
-          "target": "84",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "84"
         },
         {
           "source": "56",
-          "target": "85",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "85"
         },
         {
           "source": "56",
-          "target": "86",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "86"
         },
         {
           "source": "56",
-          "target": "87",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "87"
         },
         {
           "source": "56",
-          "target": "88",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "88"
         },
         {
           "source": "56",
-          "target": "89",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "89"
         },
         {
           "source": "56",
-          "target": "90",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "90"
         },
         {
           "source": "56",
-          "target": "91",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "91"
         },
         {
           "source": "56",
-          "target": "92",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "92"
         },
         {
           "source": "56",
-          "target": "93",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "93"
         },
         {
           "source": "93",
-          "target": "94",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "94"
         },
         {
           "source": "93",
-          "target": "95",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "95"
         },
         {
           "source": "93",
-          "target": "96",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "96"
         },
         {
           "source": "93",
-          "target": "97",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "97"
         },
         {
           "source": "93",
-          "target": "98",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "98"
         },
         {
           "source": "0",
-          "target": "99",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "99"
         },
         {
           "source": "99",
-          "target": "100",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "100"
         },
         {
           "source": "99",
-          "target": "101",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "101"
         },
         {
           "source": "99",
-          "target": "102",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "102"
         },
         {
           "source": "99",
-          "target": "103",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "103"
         },
         {
           "source": "99",
-          "target": "104",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "104"
         },
         {
           "source": "0",
-          "target": "105",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "105"
         },
         {
           "source": "105",
-          "target": "106",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "106"
         },
         {
           "source": "105",
-          "target": "107",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "107"
         },
         {
           "source": "105",
-          "target": "108",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "108"
         },
         {
           "source": "105",
-          "target": "109",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "109"
         },
         {
           "source": "105",
-          "target": "110",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "110"
         },
         {
           "source": "0",
-          "target": "111",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "111"
         },
         {
           "source": "111",
-          "target": "112",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "112"
         },
         {
           "source": "111",
-          "target": "113",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "113"
         },
         {
           "source": "111",
-          "target": "114",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "114"
         },
         {
           "source": "111",
-          "target": "115",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "115"
         },
         {
           "source": "111",
-          "target": "116",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "116"
         },
         {
           "source": "0",
-          "target": "117",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "117"
         },
         {
           "source": "117",
-          "target": "118",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "118"
         },
         {
           "source": "117",
-          "target": "119",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "119"
         },
         {
           "source": "117",
-          "target": "120",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "120"
         },
         {
           "source": "117",
-          "target": "121",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "121"
         },
         {
           "source": "117",
-          "target": "122",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "122"
         },
         {
           "source": "0",
-          "target": "123",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "123"
         },
         {
           "source": "123",
-          "target": "124",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "124"
         },
         {
           "source": "123",
-          "target": "125",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "125"
         },
         {
           "source": "123",
-          "target": "126",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "126"
         },
         {
           "source": "123",
-          "target": "127",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "127"
         },
         {
           "source": "123",
-          "target": "128",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "128"
         },
         {
           "source": "0",
-          "target": "129",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "129"
         },
         {
           "source": "129",
-          "target": "130",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "130"
         },
         {
           "source": "129",
-          "target": "131",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "131"
         },
         {
           "source": "129",
-          "target": "132",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "132"
         },
         {
           "source": "129",
-          "target": "133",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "133"
         },
         {
           "source": "129",
-          "target": "134",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "134"
         }
       ]
     }

--- a/t/data/dws2jgf/expected-compute-01.jgf
+++ b/t/data/dws2jgf/expected-compute-01.jgf
@@ -17,23 +17,15 @@
   },
   "scheduling": {
     "graph": {
-      "directed": true,
+      "directed": false,
       "nodes": [
         {
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "ElCapitan",
-            "name": "ElCapitan0",
-            "id": 0,
-            "uniq_id": 0,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
+            "name": "ElCapitan",
             "paths": {
-              "containment": "/ElCapitan0"
+              "containment": "/ElCapitan"
             }
           }
         },
@@ -41,20 +33,13 @@
           "id": "1",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack0",
             "id": 0,
-            "uniq_id": 1,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack0"
+              "containment": "/ElCapitan/rack0"
             }
           }
         },
@@ -62,17 +47,10 @@
           "id": "2",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 2,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd0"
+              "containment": "/ElCapitan/rack0/ssd0"
             },
             "status": 1
           }
@@ -81,17 +59,10 @@
           "id": "3",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 3,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd1"
+              "containment": "/ElCapitan/rack0/ssd1"
             },
             "status": 1
           }
@@ -100,17 +71,10 @@
           "id": "4",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 4,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd2"
+              "containment": "/ElCapitan/rack0/ssd2"
             },
             "status": 1
           }
@@ -119,17 +83,10 @@
           "id": "5",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 5,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd3"
+              "containment": "/ElCapitan/rack0/ssd3"
             },
             "status": 1
           }
@@ -138,17 +95,10 @@
           "id": "6",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 6,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd4"
+              "containment": "/ElCapitan/rack0/ssd4"
             },
             "status": 1
           }
@@ -157,17 +107,10 @@
           "id": "7",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 7,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd5"
+              "containment": "/ElCapitan/rack0/ssd5"
             },
             "status": 1
           }
@@ -176,17 +119,10 @@
           "id": "8",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 8,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd6"
+              "containment": "/ElCapitan/rack0/ssd6"
             },
             "status": 1
           }
@@ -195,17 +131,10 @@
           "id": "9",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 9,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd7"
+              "containment": "/ElCapitan/rack0/ssd7"
             },
             "status": 1
           }
@@ -214,17 +143,10 @@
           "id": "10",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 10,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd8"
+              "containment": "/ElCapitan/rack0/ssd8"
             },
             "status": 1
           }
@@ -233,17 +155,10 @@
           "id": "11",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 11,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd9"
+              "containment": "/ElCapitan/rack0/ssd9"
             },
             "status": 1
           }
@@ -252,17 +167,10 @@
           "id": "12",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 12,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd10"
+              "containment": "/ElCapitan/rack0/ssd10"
             },
             "status": 1
           }
@@ -271,17 +179,10 @@
           "id": "13",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 13,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd11"
+              "containment": "/ElCapitan/rack0/ssd11"
             },
             "status": 1
           }
@@ -290,17 +191,10 @@
           "id": "14",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 14,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd12"
+              "containment": "/ElCapitan/rack0/ssd12"
             },
             "status": 1
           }
@@ -309,17 +203,10 @@
           "id": "15",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 15,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd13"
+              "containment": "/ElCapitan/rack0/ssd13"
             },
             "status": 1
           }
@@ -328,17 +215,10 @@
           "id": "16",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 16,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd14"
+              "containment": "/ElCapitan/rack0/ssd14"
             },
             "status": 1
           }
@@ -347,17 +227,10 @@
           "id": "17",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 17,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd15"
+              "containment": "/ElCapitan/rack0/ssd15"
             },
             "status": 1
           }
@@ -366,17 +239,10 @@
           "id": "18",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 18,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd16"
+              "containment": "/ElCapitan/rack0/ssd16"
             },
             "status": 1
           }
@@ -385,17 +251,10 @@
           "id": "19",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 19,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd17"
+              "containment": "/ElCapitan/rack0/ssd17"
             },
             "status": 1
           }
@@ -404,17 +263,10 @@
           "id": "20",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 20,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd18"
+              "containment": "/ElCapitan/rack0/ssd18"
             },
             "status": 1
           }
@@ -423,17 +275,10 @@
           "id": "21",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 21,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd19"
+              "containment": "/ElCapitan/rack0/ssd19"
             },
             "status": 1
           }
@@ -442,17 +287,10 @@
           "id": "22",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 22,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd20"
+              "containment": "/ElCapitan/rack0/ssd20"
             },
             "status": 1
           }
@@ -461,17 +299,10 @@
           "id": "23",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 23,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd21"
+              "containment": "/ElCapitan/rack0/ssd21"
             },
             "status": 1
           }
@@ -480,17 +311,10 @@
           "id": "24",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 24,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd22"
+              "containment": "/ElCapitan/rack0/ssd22"
             },
             "status": 1
           }
@@ -499,17 +323,10 @@
           "id": "25",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 25,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd23"
+              "containment": "/ElCapitan/rack0/ssd23"
             },
             "status": 1
           }
@@ -518,17 +335,10 @@
           "id": "26",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 26,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd24"
+              "containment": "/ElCapitan/rack0/ssd24"
             },
             "status": 1
           }
@@ -537,17 +347,10 @@
           "id": "27",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 27,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd25"
+              "containment": "/ElCapitan/rack0/ssd25"
             },
             "status": 1
           }
@@ -556,17 +359,10 @@
           "id": "28",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 28,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd26"
+              "containment": "/ElCapitan/rack0/ssd26"
             },
             "status": 1
           }
@@ -575,17 +371,10 @@
           "id": "29",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 29,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd27"
+              "containment": "/ElCapitan/rack0/ssd27"
             },
             "status": 1
           }
@@ -594,17 +383,10 @@
           "id": "30",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 30,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd28"
+              "containment": "/ElCapitan/rack0/ssd28"
             },
             "status": 1
           }
@@ -613,17 +395,10 @@
           "id": "31",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 31,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd29"
+              "containment": "/ElCapitan/rack0/ssd29"
             },
             "status": 1
           }
@@ -632,17 +407,10 @@
           "id": "32",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 32,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd30"
+              "containment": "/ElCapitan/rack0/ssd30"
             },
             "status": 1
           }
@@ -651,17 +419,10 @@
           "id": "33",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 33,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd31"
+              "containment": "/ElCapitan/rack0/ssd31"
             },
             "status": 1
           }
@@ -670,17 +431,10 @@
           "id": "34",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 34,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd32"
+              "containment": "/ElCapitan/rack0/ssd32"
             },
             "status": 1
           }
@@ -689,17 +443,10 @@
           "id": "35",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 35,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd33"
+              "containment": "/ElCapitan/rack0/ssd33"
             },
             "status": 1
           }
@@ -708,17 +455,10 @@
           "id": "36",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 36,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd34"
+              "containment": "/ElCapitan/rack0/ssd34"
             },
             "status": 1
           }
@@ -727,17 +467,10 @@
           "id": "37",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 37,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/ssd35"
+              "containment": "/ElCapitan/rack0/ssd35"
             },
             "status": 1
           }
@@ -746,17 +479,10 @@
           "id": "38",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-01",
-            "id": 1,
-            "uniq_id": 38,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01"
+              "containment": "/ElCapitan/rack0/compute-01"
             }
           }
         },
@@ -764,17 +490,10 @@
           "id": "39",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 39,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack0/compute-01/core0"
+              "containment": "/ElCapitan/rack0/compute-01/core0"
             }
           }
         },
@@ -782,20 +501,13 @@
           "id": "40",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack1",
             "id": 1,
-            "uniq_id": 40,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan0/rack1"
+              "containment": "/ElCapitan/rack1"
             }
           }
         },
@@ -803,17 +515,10 @@
           "id": "41",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 41,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd0"
+              "containment": "/ElCapitan/rack1/ssd0"
             },
             "status": 1
           }
@@ -822,17 +527,10 @@
           "id": "42",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 42,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd1"
+              "containment": "/ElCapitan/rack1/ssd1"
             },
             "status": 1
           }
@@ -841,17 +539,10 @@
           "id": "43",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 43,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd2"
+              "containment": "/ElCapitan/rack1/ssd2"
             },
             "status": 1
           }
@@ -860,17 +551,10 @@
           "id": "44",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 44,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd3"
+              "containment": "/ElCapitan/rack1/ssd3"
             },
             "status": 1
           }
@@ -879,17 +563,10 @@
           "id": "45",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 45,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd4"
+              "containment": "/ElCapitan/rack1/ssd4"
             },
             "status": 1
           }
@@ -898,17 +575,10 @@
           "id": "46",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 46,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd5"
+              "containment": "/ElCapitan/rack1/ssd5"
             },
             "status": 1
           }
@@ -917,17 +587,10 @@
           "id": "47",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 47,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd6"
+              "containment": "/ElCapitan/rack1/ssd6"
             },
             "status": 1
           }
@@ -936,17 +599,10 @@
           "id": "48",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 48,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd7"
+              "containment": "/ElCapitan/rack1/ssd7"
             },
             "status": 1
           }
@@ -955,17 +611,10 @@
           "id": "49",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 49,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd8"
+              "containment": "/ElCapitan/rack1/ssd8"
             },
             "status": 1
           }
@@ -974,17 +623,10 @@
           "id": "50",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 50,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd9"
+              "containment": "/ElCapitan/rack1/ssd9"
             },
             "status": 1
           }
@@ -993,17 +635,10 @@
           "id": "51",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 51,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd10"
+              "containment": "/ElCapitan/rack1/ssd10"
             },
             "status": 1
           }
@@ -1012,17 +647,10 @@
           "id": "52",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 52,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd11"
+              "containment": "/ElCapitan/rack1/ssd11"
             },
             "status": 1
           }
@@ -1031,17 +659,10 @@
           "id": "53",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 53,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd12"
+              "containment": "/ElCapitan/rack1/ssd12"
             },
             "status": 1
           }
@@ -1050,17 +671,10 @@
           "id": "54",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 54,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd13"
+              "containment": "/ElCapitan/rack1/ssd13"
             },
             "status": 1
           }
@@ -1069,17 +683,10 @@
           "id": "55",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 55,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd14"
+              "containment": "/ElCapitan/rack1/ssd14"
             },
             "status": 1
           }
@@ -1088,17 +695,10 @@
           "id": "56",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 56,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd15"
+              "containment": "/ElCapitan/rack1/ssd15"
             },
             "status": 1
           }
@@ -1107,17 +707,10 @@
           "id": "57",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 57,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd16"
+              "containment": "/ElCapitan/rack1/ssd16"
             },
             "status": 1
           }
@@ -1126,17 +719,10 @@
           "id": "58",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 58,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd17"
+              "containment": "/ElCapitan/rack1/ssd17"
             },
             "status": 1
           }
@@ -1145,17 +731,10 @@
           "id": "59",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 59,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd18"
+              "containment": "/ElCapitan/rack1/ssd18"
             },
             "status": 1
           }
@@ -1164,17 +743,10 @@
           "id": "60",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 60,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd19"
+              "containment": "/ElCapitan/rack1/ssd19"
             },
             "status": 1
           }
@@ -1183,17 +755,10 @@
           "id": "61",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 61,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd20"
+              "containment": "/ElCapitan/rack1/ssd20"
             },
             "status": 1
           }
@@ -1202,17 +767,10 @@
           "id": "62",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 62,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd21"
+              "containment": "/ElCapitan/rack1/ssd21"
             },
             "status": 1
           }
@@ -1221,17 +779,10 @@
           "id": "63",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 63,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd22"
+              "containment": "/ElCapitan/rack1/ssd22"
             },
             "status": 1
           }
@@ -1240,17 +791,10 @@
           "id": "64",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 64,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd23"
+              "containment": "/ElCapitan/rack1/ssd23"
             },
             "status": 1
           }
@@ -1259,17 +803,10 @@
           "id": "65",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 65,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd24"
+              "containment": "/ElCapitan/rack1/ssd24"
             },
             "status": 1
           }
@@ -1278,17 +815,10 @@
           "id": "66",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 66,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd25"
+              "containment": "/ElCapitan/rack1/ssd25"
             },
             "status": 1
           }
@@ -1297,17 +827,10 @@
           "id": "67",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 67,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd26"
+              "containment": "/ElCapitan/rack1/ssd26"
             },
             "status": 1
           }
@@ -1316,17 +839,10 @@
           "id": "68",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 68,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd27"
+              "containment": "/ElCapitan/rack1/ssd27"
             },
             "status": 1
           }
@@ -1335,17 +851,10 @@
           "id": "69",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 69,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd28"
+              "containment": "/ElCapitan/rack1/ssd28"
             },
             "status": 1
           }
@@ -1354,17 +863,10 @@
           "id": "70",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 70,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd29"
+              "containment": "/ElCapitan/rack1/ssd29"
             },
             "status": 1
           }
@@ -1373,17 +875,10 @@
           "id": "71",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 71,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd30"
+              "containment": "/ElCapitan/rack1/ssd30"
             },
             "status": 1
           }
@@ -1392,17 +887,10 @@
           "id": "72",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 72,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd31"
+              "containment": "/ElCapitan/rack1/ssd31"
             },
             "status": 1
           }
@@ -1411,17 +899,10 @@
           "id": "73",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 73,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd32"
+              "containment": "/ElCapitan/rack1/ssd32"
             },
             "status": 1
           }
@@ -1430,17 +911,10 @@
           "id": "74",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 74,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd33"
+              "containment": "/ElCapitan/rack1/ssd33"
             },
             "status": 1
           }
@@ -1449,17 +923,10 @@
           "id": "75",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 75,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd34"
+              "containment": "/ElCapitan/rack1/ssd34"
             },
             "status": 1
           }
@@ -1468,17 +935,10 @@
           "id": "76",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 76,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/ElCapitan0/rack1/ssd35"
+              "containment": "/ElCapitan/rack1/ssd35"
             },
             "status": 1
           }
@@ -1487,611 +947,307 @@
       "edges": [
         {
           "source": "0",
-          "target": "1",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "1"
         },
         {
           "source": "1",
-          "target": "2",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "2"
         },
         {
           "source": "1",
-          "target": "3",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "3"
         },
         {
           "source": "1",
-          "target": "4",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "4"
         },
         {
           "source": "1",
-          "target": "5",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "5"
         },
         {
           "source": "1",
-          "target": "6",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "6"
         },
         {
           "source": "1",
-          "target": "7",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "7"
         },
         {
           "source": "1",
-          "target": "8",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "8"
         },
         {
           "source": "1",
-          "target": "9",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "9"
         },
         {
           "source": "1",
-          "target": "10",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "10"
         },
         {
           "source": "1",
-          "target": "11",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "11"
         },
         {
           "source": "1",
-          "target": "12",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "12"
         },
         {
           "source": "1",
-          "target": "13",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "13"
         },
         {
           "source": "1",
-          "target": "14",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "14"
         },
         {
           "source": "1",
-          "target": "15",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "15"
         },
         {
           "source": "1",
-          "target": "16",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "16"
         },
         {
           "source": "1",
-          "target": "17",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "17"
         },
         {
           "source": "1",
-          "target": "18",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "18"
         },
         {
           "source": "1",
-          "target": "19",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "19"
         },
         {
           "source": "1",
-          "target": "20",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "20"
         },
         {
           "source": "1",
-          "target": "21",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "21"
         },
         {
           "source": "1",
-          "target": "22",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "22"
         },
         {
           "source": "1",
-          "target": "23",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "23"
         },
         {
           "source": "1",
-          "target": "24",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "24"
         },
         {
           "source": "1",
-          "target": "25",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "25"
         },
         {
           "source": "1",
-          "target": "26",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "26"
         },
         {
           "source": "1",
-          "target": "27",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "27"
         },
         {
           "source": "1",
-          "target": "28",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "28"
         },
         {
           "source": "1",
-          "target": "29",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "29"
         },
         {
           "source": "1",
-          "target": "30",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "30"
         },
         {
           "source": "1",
-          "target": "31",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "31"
         },
         {
           "source": "1",
-          "target": "32",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "32"
         },
         {
           "source": "1",
-          "target": "33",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "33"
         },
         {
           "source": "1",
-          "target": "34",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "34"
         },
         {
           "source": "1",
-          "target": "35",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "35"
         },
         {
           "source": "1",
-          "target": "36",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "36"
         },
         {
           "source": "1",
-          "target": "37",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "37"
         },
         {
           "source": "1",
-          "target": "38",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "38"
         },
         {
           "source": "38",
-          "target": "39",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "39"
         },
         {
           "source": "0",
-          "target": "40",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "40"
         },
         {
           "source": "40",
-          "target": "41",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "41"
         },
         {
           "source": "40",
-          "target": "42",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "42"
         },
         {
           "source": "40",
-          "target": "43",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "43"
         },
         {
           "source": "40",
-          "target": "44",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "44"
         },
         {
           "source": "40",
-          "target": "45",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "45"
         },
         {
           "source": "40",
-          "target": "46",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "46"
         },
         {
           "source": "40",
-          "target": "47",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "47"
         },
         {
           "source": "40",
-          "target": "48",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "48"
         },
         {
           "source": "40",
-          "target": "49",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "49"
         },
         {
           "source": "40",
-          "target": "50",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "50"
         },
         {
           "source": "40",
-          "target": "51",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "51"
         },
         {
           "source": "40",
-          "target": "52",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "52"
         },
         {
           "source": "40",
-          "target": "53",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "53"
         },
         {
           "source": "40",
-          "target": "54",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "54"
         },
         {
           "source": "40",
-          "target": "55",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "55"
         },
         {
           "source": "40",
-          "target": "56",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "56"
         },
         {
           "source": "40",
-          "target": "57",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "57"
         },
         {
           "source": "40",
-          "target": "58",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "58"
         },
         {
           "source": "40",
-          "target": "59",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "59"
         },
         {
           "source": "40",
-          "target": "60",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "60"
         },
         {
           "source": "40",
-          "target": "61",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "61"
         },
         {
           "source": "40",
-          "target": "62",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "62"
         },
         {
           "source": "40",
-          "target": "63",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "63"
         },
         {
           "source": "40",
-          "target": "64",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "64"
         },
         {
           "source": "40",
-          "target": "65",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "65"
         },
         {
           "source": "40",
-          "target": "66",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "66"
         },
         {
           "source": "40",
-          "target": "67",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "67"
         },
         {
           "source": "40",
-          "target": "68",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "68"
         },
         {
           "source": "40",
-          "target": "69",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "69"
         },
         {
           "source": "40",
-          "target": "70",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "70"
         },
         {
           "source": "40",
-          "target": "71",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "71"
         },
         {
           "source": "40",
-          "target": "72",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "72"
         },
         {
           "source": "40",
-          "target": "73",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "73"
         },
         {
           "source": "40",
-          "target": "74",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "74"
         },
         {
           "source": "40",
-          "target": "75",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "75"
         },
         {
           "source": "40",
-          "target": "76",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "76"
         }
       ]
     }

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -20,23 +20,15 @@
   },
   "scheduling": {
     "graph": {
-      "directed": true,
+      "directed": false,
       "nodes": [
         {
           "id": "0",
           "metadata": {
             "type": "cluster",
-            "basename": "compute",
-            "name": "compute0",
-            "id": 0,
-            "uniq_id": 0,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
+            "name": "compute",
             "paths": {
-              "containment": "/compute0"
+              "containment": "/compute"
             }
           }
         },
@@ -44,20 +36,13 @@
           "id": "1",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack0",
             "id": 0,
-            "uniq_id": 1,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute0/rack0"
+              "containment": "/compute/rack0"
             }
           }
         },
@@ -65,17 +50,10 @@
           "id": "2",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 2,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd0"
+              "containment": "/compute/rack0/ssd0"
             },
             "status": 1
           }
@@ -84,17 +62,10 @@
           "id": "3",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 3,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd1"
+              "containment": "/compute/rack0/ssd1"
             },
             "status": 1
           }
@@ -103,17 +74,10 @@
           "id": "4",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 4,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd2"
+              "containment": "/compute/rack0/ssd2"
             },
             "status": 1
           }
@@ -122,17 +86,10 @@
           "id": "5",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 5,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd3"
+              "containment": "/compute/rack0/ssd3"
             },
             "status": 1
           }
@@ -141,17 +98,10 @@
           "id": "6",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 6,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd4"
+              "containment": "/compute/rack0/ssd4"
             },
             "status": 1
           }
@@ -160,17 +110,10 @@
           "id": "7",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 7,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd5"
+              "containment": "/compute/rack0/ssd5"
             },
             "status": 1
           }
@@ -179,17 +122,10 @@
           "id": "8",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 8,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd6"
+              "containment": "/compute/rack0/ssd6"
             },
             "status": 1
           }
@@ -198,17 +134,10 @@
           "id": "9",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 9,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd7"
+              "containment": "/compute/rack0/ssd7"
             },
             "status": 1
           }
@@ -217,17 +146,10 @@
           "id": "10",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 10,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd8"
+              "containment": "/compute/rack0/ssd8"
             },
             "status": 1
           }
@@ -236,17 +158,10 @@
           "id": "11",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 11,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd9"
+              "containment": "/compute/rack0/ssd9"
             },
             "status": 1
           }
@@ -255,17 +170,10 @@
           "id": "12",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 12,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd10"
+              "containment": "/compute/rack0/ssd10"
             },
             "status": 1
           }
@@ -274,17 +182,10 @@
           "id": "13",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 13,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd11"
+              "containment": "/compute/rack0/ssd11"
             },
             "status": 1
           }
@@ -293,17 +194,10 @@
           "id": "14",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 14,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd12"
+              "containment": "/compute/rack0/ssd12"
             },
             "status": 1
           }
@@ -312,17 +206,10 @@
           "id": "15",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 15,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd13"
+              "containment": "/compute/rack0/ssd13"
             },
             "status": 1
           }
@@ -331,17 +218,10 @@
           "id": "16",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 16,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd14"
+              "containment": "/compute/rack0/ssd14"
             },
             "status": 1
           }
@@ -350,17 +230,10 @@
           "id": "17",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 17,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd15"
+              "containment": "/compute/rack0/ssd15"
             },
             "status": 1
           }
@@ -369,17 +242,10 @@
           "id": "18",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 18,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd16"
+              "containment": "/compute/rack0/ssd16"
             },
             "status": 1
           }
@@ -388,17 +254,10 @@
           "id": "19",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 19,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd17"
+              "containment": "/compute/rack0/ssd17"
             },
             "status": 1
           }
@@ -407,17 +266,10 @@
           "id": "20",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 20,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd18"
+              "containment": "/compute/rack0/ssd18"
             },
             "status": 1
           }
@@ -426,17 +278,10 @@
           "id": "21",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 21,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd19"
+              "containment": "/compute/rack0/ssd19"
             },
             "status": 1
           }
@@ -445,17 +290,10 @@
           "id": "22",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 22,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd20"
+              "containment": "/compute/rack0/ssd20"
             },
             "status": 1
           }
@@ -464,17 +302,10 @@
           "id": "23",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 23,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd21"
+              "containment": "/compute/rack0/ssd21"
             },
             "status": 1
           }
@@ -483,17 +314,10 @@
           "id": "24",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 24,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd22"
+              "containment": "/compute/rack0/ssd22"
             },
             "status": 1
           }
@@ -502,17 +326,10 @@
           "id": "25",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 25,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd23"
+              "containment": "/compute/rack0/ssd23"
             },
             "status": 1
           }
@@ -521,17 +338,10 @@
           "id": "26",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 26,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd24"
+              "containment": "/compute/rack0/ssd24"
             },
             "status": 1
           }
@@ -540,17 +350,10 @@
           "id": "27",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 27,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd25"
+              "containment": "/compute/rack0/ssd25"
             },
             "status": 1
           }
@@ -559,17 +362,10 @@
           "id": "28",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 28,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd26"
+              "containment": "/compute/rack0/ssd26"
             },
             "status": 1
           }
@@ -578,17 +374,10 @@
           "id": "29",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 29,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd27"
+              "containment": "/compute/rack0/ssd27"
             },
             "status": 1
           }
@@ -597,17 +386,10 @@
           "id": "30",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 30,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd28"
+              "containment": "/compute/rack0/ssd28"
             },
             "status": 1
           }
@@ -616,17 +398,10 @@
           "id": "31",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 31,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd29"
+              "containment": "/compute/rack0/ssd29"
             },
             "status": 1
           }
@@ -635,17 +410,10 @@
           "id": "32",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 32,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd30"
+              "containment": "/compute/rack0/ssd30"
             },
             "status": 1
           }
@@ -654,17 +422,10 @@
           "id": "33",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 33,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd31"
+              "containment": "/compute/rack0/ssd31"
             },
             "status": 1
           }
@@ -673,17 +434,10 @@
           "id": "34",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 34,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd32"
+              "containment": "/compute/rack0/ssd32"
             },
             "status": 1
           }
@@ -692,17 +446,10 @@
           "id": "35",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 35,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd33"
+              "containment": "/compute/rack0/ssd33"
             },
             "status": 1
           }
@@ -711,17 +458,10 @@
           "id": "36",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 36,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd34"
+              "containment": "/compute/rack0/ssd34"
             },
             "status": 1
           }
@@ -730,17 +470,10 @@
           "id": "37",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 37,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/ssd35"
+              "containment": "/compute/rack0/ssd35"
             },
             "status": 1
           }
@@ -749,19 +482,13 @@
           "id": "38",
           "metadata": {
             "type": "node",
-            "basename": "node",
             "name": "compute-01",
-            "id": 1,
-            "uniq_id": 38,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "pdebug": ""
             },
             "paths": {
-              "containment": "/compute0/rack0/compute-01"
+              "containment": "/compute/rack0/compute-01"
             }
           }
         },
@@ -769,17 +496,10 @@
           "id": "39",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core0",
             "id": 0,
-            "uniq_id": 39,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core0"
+              "containment": "/compute/rack0/compute-01/core0"
             }
           }
         },
@@ -787,17 +507,10 @@
           "id": "40",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core1",
             "id": 1,
-            "uniq_id": 40,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core1"
+              "containment": "/compute/rack0/compute-01/core1"
             }
           }
         },
@@ -805,17 +518,10 @@
           "id": "41",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core2",
             "id": 2,
-            "uniq_id": 41,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core2"
+              "containment": "/compute/rack0/compute-01/core2"
             }
           }
         },
@@ -823,17 +529,10 @@
           "id": "42",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core3",
             "id": 3,
-            "uniq_id": 42,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core3"
+              "containment": "/compute/rack0/compute-01/core3"
             }
           }
         },
@@ -841,17 +540,10 @@
           "id": "43",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core4",
             "id": 4,
-            "uniq_id": 43,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core4"
+              "containment": "/compute/rack0/compute-01/core4"
             }
           }
         },
@@ -859,17 +551,10 @@
           "id": "44",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core5",
             "id": 5,
-            "uniq_id": 44,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core5"
+              "containment": "/compute/rack0/compute-01/core5"
             }
           }
         },
@@ -877,17 +562,10 @@
           "id": "45",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core6",
             "id": 6,
-            "uniq_id": 45,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core6"
+              "containment": "/compute/rack0/compute-01/core6"
             }
           }
         },
@@ -895,17 +573,10 @@
           "id": "46",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core7",
             "id": 7,
-            "uniq_id": 46,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core7"
+              "containment": "/compute/rack0/compute-01/core7"
             }
           }
         },
@@ -913,17 +584,10 @@
           "id": "47",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core8",
             "id": 8,
-            "uniq_id": 47,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core8"
+              "containment": "/compute/rack0/compute-01/core8"
             }
           }
         },
@@ -931,17 +595,10 @@
           "id": "48",
           "metadata": {
             "type": "core",
-            "basename": "core",
-            "name": "core9",
             "id": 9,
-            "uniq_id": 48,
             "rank": 0,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack0/compute-01/core9"
+              "containment": "/compute/rack0/compute-01/core9"
             }
           }
         },
@@ -949,20 +606,13 @@
           "id": "49",
           "metadata": {
             "type": "rack",
-            "basename": "rack",
-            "name": "rack1",
             "id": 1,
-            "uniq_id": 49,
-            "rank": -1,
-            "exclusive": true,
-            "unit": "",
-            "size": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute0/rack1"
+              "containment": "/compute/rack1"
             }
           }
         },
@@ -970,17 +620,10 @@
           "id": "50",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd0",
-            "id": 0,
-            "uniq_id": 50,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd0"
+              "containment": "/compute/rack1/ssd0"
             },
             "status": 1
           }
@@ -989,17 +632,10 @@
           "id": "51",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd1",
-            "id": 1,
-            "uniq_id": 51,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd1"
+              "containment": "/compute/rack1/ssd1"
             },
             "status": 1
           }
@@ -1008,17 +644,10 @@
           "id": "52",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd2",
-            "id": 2,
-            "uniq_id": 52,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd2"
+              "containment": "/compute/rack1/ssd2"
             },
             "status": 1
           }
@@ -1027,17 +656,10 @@
           "id": "53",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd3",
-            "id": 3,
-            "uniq_id": 53,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd3"
+              "containment": "/compute/rack1/ssd3"
             },
             "status": 1
           }
@@ -1046,17 +668,10 @@
           "id": "54",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd4",
-            "id": 4,
-            "uniq_id": 54,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd4"
+              "containment": "/compute/rack1/ssd4"
             },
             "status": 1
           }
@@ -1065,17 +680,10 @@
           "id": "55",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd5",
-            "id": 5,
-            "uniq_id": 55,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd5"
+              "containment": "/compute/rack1/ssd5"
             },
             "status": 1
           }
@@ -1084,17 +692,10 @@
           "id": "56",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd6",
-            "id": 6,
-            "uniq_id": 56,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd6"
+              "containment": "/compute/rack1/ssd6"
             },
             "status": 1
           }
@@ -1103,17 +704,10 @@
           "id": "57",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd7",
-            "id": 7,
-            "uniq_id": 57,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd7"
+              "containment": "/compute/rack1/ssd7"
             },
             "status": 1
           }
@@ -1122,17 +716,10 @@
           "id": "58",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd8",
-            "id": 8,
-            "uniq_id": 58,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd8"
+              "containment": "/compute/rack1/ssd8"
             },
             "status": 1
           }
@@ -1141,17 +728,10 @@
           "id": "59",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd9",
-            "id": 9,
-            "uniq_id": 59,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd9"
+              "containment": "/compute/rack1/ssd9"
             },
             "status": 1
           }
@@ -1160,17 +740,10 @@
           "id": "60",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd10",
-            "id": 10,
-            "uniq_id": 60,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd10"
+              "containment": "/compute/rack1/ssd10"
             },
             "status": 1
           }
@@ -1179,17 +752,10 @@
           "id": "61",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd11",
-            "id": 11,
-            "uniq_id": 61,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd11"
+              "containment": "/compute/rack1/ssd11"
             },
             "status": 1
           }
@@ -1198,17 +764,10 @@
           "id": "62",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd12",
-            "id": 12,
-            "uniq_id": 62,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd12"
+              "containment": "/compute/rack1/ssd12"
             },
             "status": 1
           }
@@ -1217,17 +776,10 @@
           "id": "63",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd13",
-            "id": 13,
-            "uniq_id": 63,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd13"
+              "containment": "/compute/rack1/ssd13"
             },
             "status": 1
           }
@@ -1236,17 +788,10 @@
           "id": "64",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd14",
-            "id": 14,
-            "uniq_id": 64,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd14"
+              "containment": "/compute/rack1/ssd14"
             },
             "status": 1
           }
@@ -1255,17 +800,10 @@
           "id": "65",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd15",
-            "id": 15,
-            "uniq_id": 65,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd15"
+              "containment": "/compute/rack1/ssd15"
             },
             "status": 1
           }
@@ -1274,17 +812,10 @@
           "id": "66",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd16",
-            "id": 16,
-            "uniq_id": 66,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd16"
+              "containment": "/compute/rack1/ssd16"
             },
             "status": 1
           }
@@ -1293,17 +824,10 @@
           "id": "67",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd17",
-            "id": 17,
-            "uniq_id": 67,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd17"
+              "containment": "/compute/rack1/ssd17"
             },
             "status": 1
           }
@@ -1312,17 +836,10 @@
           "id": "68",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd18",
-            "id": 18,
-            "uniq_id": 68,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd18"
+              "containment": "/compute/rack1/ssd18"
             },
             "status": 1
           }
@@ -1331,17 +848,10 @@
           "id": "69",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd19",
-            "id": 19,
-            "uniq_id": 69,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd19"
+              "containment": "/compute/rack1/ssd19"
             },
             "status": 1
           }
@@ -1350,17 +860,10 @@
           "id": "70",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd20",
-            "id": 20,
-            "uniq_id": 70,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd20"
+              "containment": "/compute/rack1/ssd20"
             },
             "status": 1
           }
@@ -1369,17 +872,10 @@
           "id": "71",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd21",
-            "id": 21,
-            "uniq_id": 71,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd21"
+              "containment": "/compute/rack1/ssd21"
             },
             "status": 1
           }
@@ -1388,17 +884,10 @@
           "id": "72",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd22",
-            "id": 22,
-            "uniq_id": 72,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd22"
+              "containment": "/compute/rack1/ssd22"
             },
             "status": 1
           }
@@ -1407,17 +896,10 @@
           "id": "73",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd23",
-            "id": 23,
-            "uniq_id": 73,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd23"
+              "containment": "/compute/rack1/ssd23"
             },
             "status": 1
           }
@@ -1426,17 +908,10 @@
           "id": "74",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd24",
-            "id": 24,
-            "uniq_id": 74,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd24"
+              "containment": "/compute/rack1/ssd24"
             },
             "status": 1
           }
@@ -1445,17 +920,10 @@
           "id": "75",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd25",
-            "id": 25,
-            "uniq_id": 75,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd25"
+              "containment": "/compute/rack1/ssd25"
             },
             "status": 1
           }
@@ -1464,17 +932,10 @@
           "id": "76",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd26",
-            "id": 26,
-            "uniq_id": 76,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd26"
+              "containment": "/compute/rack1/ssd26"
             },
             "status": 1
           }
@@ -1483,17 +944,10 @@
           "id": "77",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd27",
-            "id": 27,
-            "uniq_id": 77,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd27"
+              "containment": "/compute/rack1/ssd27"
             },
             "status": 1
           }
@@ -1502,17 +956,10 @@
           "id": "78",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd28",
-            "id": 28,
-            "uniq_id": 78,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd28"
+              "containment": "/compute/rack1/ssd28"
             },
             "status": 1
           }
@@ -1521,17 +968,10 @@
           "id": "79",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd29",
-            "id": 29,
-            "uniq_id": 79,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd29"
+              "containment": "/compute/rack1/ssd29"
             },
             "status": 1
           }
@@ -1540,17 +980,10 @@
           "id": "80",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd30",
-            "id": 30,
-            "uniq_id": 80,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd30"
+              "containment": "/compute/rack1/ssd30"
             },
             "status": 1
           }
@@ -1559,17 +992,10 @@
           "id": "81",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd31",
-            "id": 31,
-            "uniq_id": 81,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd31"
+              "containment": "/compute/rack1/ssd31"
             },
             "status": 1
           }
@@ -1578,17 +1004,10 @@
           "id": "82",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd32",
-            "id": 32,
-            "uniq_id": 82,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd32"
+              "containment": "/compute/rack1/ssd32"
             },
             "status": 1
           }
@@ -1597,17 +1016,10 @@
           "id": "83",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd33",
-            "id": 33,
-            "uniq_id": 83,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd33"
+              "containment": "/compute/rack1/ssd33"
             },
             "status": 1
           }
@@ -1616,17 +1028,10 @@
           "id": "84",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd34",
-            "id": 34,
-            "uniq_id": 84,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd34"
+              "containment": "/compute/rack1/ssd34"
             },
             "status": 1
           }
@@ -1635,17 +1040,10 @@
           "id": "85",
           "metadata": {
             "type": "ssd",
-            "basename": "ssd",
-            "name": "ssd35",
-            "id": 35,
-            "uniq_id": 85,
-            "rank": -1,
-            "exclusive": true,
             "unit": "GiB",
             "size": 1024,
-            "properties": {},
             "paths": {
-              "containment": "/compute0/rack1/ssd35"
+              "containment": "/compute/rack1/ssd35"
             },
             "status": 1
           }
@@ -1654,683 +1052,343 @@
       "edges": [
         {
           "source": "0",
-          "target": "1",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "1"
         },
         {
           "source": "1",
-          "target": "2",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "2"
         },
         {
           "source": "1",
-          "target": "3",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "3"
         },
         {
           "source": "1",
-          "target": "4",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "4"
         },
         {
           "source": "1",
-          "target": "5",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "5"
         },
         {
           "source": "1",
-          "target": "6",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "6"
         },
         {
           "source": "1",
-          "target": "7",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "7"
         },
         {
           "source": "1",
-          "target": "8",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "8"
         },
         {
           "source": "1",
-          "target": "9",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "9"
         },
         {
           "source": "1",
-          "target": "10",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "10"
         },
         {
           "source": "1",
-          "target": "11",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "11"
         },
         {
           "source": "1",
-          "target": "12",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "12"
         },
         {
           "source": "1",
-          "target": "13",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "13"
         },
         {
           "source": "1",
-          "target": "14",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "14"
         },
         {
           "source": "1",
-          "target": "15",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "15"
         },
         {
           "source": "1",
-          "target": "16",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "16"
         },
         {
           "source": "1",
-          "target": "17",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "17"
         },
         {
           "source": "1",
-          "target": "18",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "18"
         },
         {
           "source": "1",
-          "target": "19",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "19"
         },
         {
           "source": "1",
-          "target": "20",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "20"
         },
         {
           "source": "1",
-          "target": "21",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "21"
         },
         {
           "source": "1",
-          "target": "22",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "22"
         },
         {
           "source": "1",
-          "target": "23",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "23"
         },
         {
           "source": "1",
-          "target": "24",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "24"
         },
         {
           "source": "1",
-          "target": "25",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "25"
         },
         {
           "source": "1",
-          "target": "26",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "26"
         },
         {
           "source": "1",
-          "target": "27",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "27"
         },
         {
           "source": "1",
-          "target": "28",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "28"
         },
         {
           "source": "1",
-          "target": "29",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "29"
         },
         {
           "source": "1",
-          "target": "30",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "30"
         },
         {
           "source": "1",
-          "target": "31",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "31"
         },
         {
           "source": "1",
-          "target": "32",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "32"
         },
         {
           "source": "1",
-          "target": "33",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "33"
         },
         {
           "source": "1",
-          "target": "34",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "34"
         },
         {
           "source": "1",
-          "target": "35",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "35"
         },
         {
           "source": "1",
-          "target": "36",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "36"
         },
         {
           "source": "1",
-          "target": "37",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "37"
         },
         {
           "source": "1",
-          "target": "38",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "38"
         },
         {
           "source": "38",
-          "target": "39",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "39"
         },
         {
           "source": "38",
-          "target": "40",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "40"
         },
         {
           "source": "38",
-          "target": "41",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "41"
         },
         {
           "source": "38",
-          "target": "42",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "42"
         },
         {
           "source": "38",
-          "target": "43",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "43"
         },
         {
           "source": "38",
-          "target": "44",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "44"
         },
         {
           "source": "38",
-          "target": "45",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "45"
         },
         {
           "source": "38",
-          "target": "46",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "46"
         },
         {
           "source": "38",
-          "target": "47",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "47"
         },
         {
           "source": "38",
-          "target": "48",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "48"
         },
         {
           "source": "0",
-          "target": "49",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "49"
         },
         {
           "source": "49",
-          "target": "50",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "50"
         },
         {
           "source": "49",
-          "target": "51",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "51"
         },
         {
           "source": "49",
-          "target": "52",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "52"
         },
         {
           "source": "49",
-          "target": "53",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "53"
         },
         {
           "source": "49",
-          "target": "54",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "54"
         },
         {
           "source": "49",
-          "target": "55",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "55"
         },
         {
           "source": "49",
-          "target": "56",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "56"
         },
         {
           "source": "49",
-          "target": "57",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "57"
         },
         {
           "source": "49",
-          "target": "58",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "58"
         },
         {
           "source": "49",
-          "target": "59",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "59"
         },
         {
           "source": "49",
-          "target": "60",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "60"
         },
         {
           "source": "49",
-          "target": "61",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "61"
         },
         {
           "source": "49",
-          "target": "62",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "62"
         },
         {
           "source": "49",
-          "target": "63",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "63"
         },
         {
           "source": "49",
-          "target": "64",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "64"
         },
         {
           "source": "49",
-          "target": "65",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "65"
         },
         {
           "source": "49",
-          "target": "66",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "66"
         },
         {
           "source": "49",
-          "target": "67",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "67"
         },
         {
           "source": "49",
-          "target": "68",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "68"
         },
         {
           "source": "49",
-          "target": "69",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "69"
         },
         {
           "source": "49",
-          "target": "70",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "70"
         },
         {
           "source": "49",
-          "target": "71",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "71"
         },
         {
           "source": "49",
-          "target": "72",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "72"
         },
         {
           "source": "49",
-          "target": "73",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "73"
         },
         {
           "source": "49",
-          "target": "74",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "74"
         },
         {
           "source": "49",
-          "target": "75",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "75"
         },
         {
           "source": "49",
-          "target": "76",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "76"
         },
         {
           "source": "49",
-          "target": "77",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "77"
         },
         {
           "source": "49",
-          "target": "78",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "78"
         },
         {
           "source": "49",
-          "target": "79",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "79"
         },
         {
           "source": "49",
-          "target": "80",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "80"
         },
         {
           "source": "49",
-          "target": "81",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "81"
         },
         {
           "source": "49",
-          "target": "82",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "82"
         },
         {
           "source": "49",
-          "target": "83",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "83"
         },
         {
           "source": "49",
-          "target": "84",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "84"
         },
         {
           "source": "49",
-          "target": "85",
-          "directed": true,
-          "metadata": {
-            "subsystem": "containment"
-          }
+          "target": "85"
         }
       ]
     }

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -95,7 +95,7 @@ test_expect_success 'fluxion does not allocate a rack/rabbit job after adding do
 '
 
 test_expect_success 'fluxion allocates a rack/rabbit job when rabbit is up' '
-	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan0/rack0/ssd0 up &&
+	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan/rack0/ssd0 up &&
 	JOBID=$(flux job submit ${DATADIR}/rabbit-jobspec.json) &&
 	flux job wait-event -vt 2 -m status=0 ${JOBID} finish &&
 	flux job attach $JOBID &&


### PR DESCRIPTION
Problem: JGF is too large, as described in #193.

As a first step to shrink it, do not output default values, instead skipping them and letting the JGF reader supply them.

Depends on changes introduced in flux-sched by flux-framework/flux-sched/pull/1293. This will remain as a draft until that is merged.