### PR TITLE
dws: only allow owner to create persistent

### DIFF
--- a/t/scripts/sign-as.py
+++ b/t/scripts/sign-as.py
@@ -1,0 +1,14 @@
+import sys
+
+from flux.security import SecurityContext
+
+if len(sys.argv) < 2:
+    print("Usage: {0} USERID".format(sys.argv[0]))
+    sys.exit(1)
+
+userid = int(sys.argv[1])
+ctx = SecurityContext()
+payload = sys.stdin.read()
+
+print(ctx.sign_wrap_as(userid, payload, mech_type="none").decode("utf-8"))
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: until futher work is done to support various usage policies for persistent file systems, it is sometimes desirable to restrict their creation to the instance owner.

Reject jobs with `create_persistent` strings unless the job was submitted by the instance owner.

Add a flag to disable the check.

Fixes #205.