### PR TITLE
dws: ignore bad jobids in workflows

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -18,7 +18,6 @@ from fluxion.resourcegraph.V1 import (
 
 
 class ElCapResourcePoolV1(FluxionResourcePoolV1):
-
     """
     ElCap Resource Pool Vertex Class: extend jsongraph's Node class
     """
@@ -267,6 +266,11 @@ def main():
             "e.g. by the 'flux rabbitmapping' script"
         ),
     )
+    parser.add_argument(
+        "--only-sched",
+        action="store_true",
+        help="Only output the 'scheduling' key",
+    )
     args = parser.parse_args()
     if not args.cluster_name:
         args.cluster_name = "".join(
@@ -296,12 +300,12 @@ def main():
             f"Node(s) {dws_computes - set(r_hostlist)} found in rabbit_mapping "
             "but not R from stdin"
         )
-    json.dump(
-        encode(
-            input_r, rabbit_mapping, r_hostlist, args.chunks_per_nnf, args.cluster_name
-        ),
-        sys.stdout,
+    output = encode(
+        input_r, rabbit_mapping, r_hostlist, args.chunks_per_nnf, args.cluster_name
     )
+    if args.only_sched:
+        output = output["scheduling"]
+    json.dump(output, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -418,8 +418,8 @@ def workflow_state_change_cb(event, handle, k8s_api, disable_fluxion):
         workflow = event["object"]
         jobid = int(flux.job.JobID(workflow["spec"]["jobID"]))
         workflow_name = workflow["metadata"]["name"]
-    except KeyError:
-        LOGGER.exception("Invalid event %s in workflow stream: ", event)
+    except Exception:
+        LOGGER.exception("Invalid event in workflow stream: %s", event)
         return
     if not workflow_name.startswith(WORKFLOW_NAME_PREFIX):
         LOGGER.warning("unrecognized workflow '%s' in event stream", workflow_name)


### PR DESCRIPTION
Problem: sometimes users create workflows with nonsense jobids. For instance, on Tuolumne recently a user created a workflow with jobid "manual", crashing the service because the jobid could not be converted to a flux job ID.

Catch all exceptions that occur while trying to fetch basic data about a workflow and log them, but do not let them crash the service.

Exception seen:

```
Traceback (most recent call last):
  File "/usr/bin/coral2_dws.py", line 945, in <module>
    main()
  File "/usr/bin/coral2_dws.py", line 936, in main
    handle.reactor_run()
  File "/usr/lib64/flux/python3.6/flux/core/handle.py", line 
    Flux.raise_if_exception()
  File "/usr/lib64/flux/python3.6/flux/core/handle.py", line 
    raise cls.set_exception(None) from None
  File "/usr/lib64/flux/python3.6/flux/core/watchers.py", line 
    watcher.callback(watcher.flux_handle, watcher, revents, 
  File "/usr/lib64/flux/python3.6/flux_k8s/watch.py", line 63, 
    watchers.watch()
  File "/usr/lib64/flux/python3.6/flux_k8s/watch.py", line 99, 
    watch.watch()
  File "/usr/lib64/flux/python3.6/flux_k8s/watch.py", line 58, 
    self.cb(event, *self.cb_args, **self.cb_kwargs)
  File "/usr/bin/coral2_dws.py", line 390, in 
    jobid = int(flux.job.JobID(workflow["spec"]["jobID"]))
  File "/usr/lib64/flux/python3.6/flux/job/JobID.py", line 64, 
    raise ValueError(f"{value} is not a valid Flux jobid")
ValueError: manual is not a valid Flux jobid
```