### PR TITLE
dws2jgf: remove python 3.7+ feature

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -247,7 +247,8 @@ def main():
     else:
         proc = subprocess.run(
             f"flux R parse-config {args.from_config}".split(),
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             check=False,
         )
         if proc.returncode != 0:
@@ -255,7 +256,7 @@ def main():
                 f"Could not parse config file {args.from_config!r}, "
                 "error message was {proc.stderr}"
             )
-        input_r = json.load(proc.stdout)
+        input_r = json.loads(proc.stdout)
     with open(args.rabbitmapping, "r", encoding="utf8") as rabbitmap_fd:
         rabbit_mapping = json.load(rabbitmap_fd)
     r_hostlist = Hostlist(input_r["execution"]["nodelist"])

--- a/t/data/dws2jgf/expected-configfile.jgf
+++ b/t/data/dws2jgf/expected-configfile.jgf
@@ -1,0 +1,1315 @@
+{
+  "version": 1,
+  "execution": {
+    "R_lite": [
+      {
+        "rank": "0",
+        "children": {
+          "core": "0-4"
+        }
+      }
+    ],
+    "starttime": 0.0,
+    "expiration": 0.0,
+    "nodelist": [
+      "compute-01"
+    ]
+  },
+  "scheduling": {
+    "graph": {
+      "directed": false,
+      "nodes": [
+        {
+          "id": "0",
+          "metadata": {
+            "type": "cluster",
+            "name": "compute",
+            "paths": {
+              "containment": "/compute"
+            }
+          }
+        },
+        {
+          "id": "1",
+          "metadata": {
+            "type": "rack",
+            "id": 0,
+            "properties": {
+              "rabbit": "kind-worker2",
+              "ssdcount": "36"
+            },
+            "paths": {
+              "containment": "/compute/rack0"
+            }
+          }
+        },
+        {
+          "id": "2",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd0"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "3",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd1"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "4",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd2"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "5",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd3"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "6",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd4"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "7",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd5"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "8",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd6"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "9",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd7"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "10",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd8"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "11",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd9"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "12",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd10"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "13",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd11"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "14",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd12"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "15",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd13"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "16",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd14"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "17",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd15"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "18",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd16"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "19",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd17"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "20",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd18"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "21",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd19"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "22",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd20"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "23",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd21"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "24",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd22"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "25",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd23"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "26",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd24"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "27",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd25"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "28",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd26"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "29",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd27"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "30",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd28"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "31",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd29"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "32",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "33",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "34",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "35",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "36",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "37",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack0/ssd35"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "38",
+          "metadata": {
+            "type": "node",
+            "name": "compute-01",
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01"
+            }
+          }
+        },
+        {
+          "id": "39",
+          "metadata": {
+            "type": "core",
+            "id": 0,
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01/core0"
+            }
+          }
+        },
+        {
+          "id": "40",
+          "metadata": {
+            "type": "core",
+            "id": 1,
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01/core1"
+            }
+          }
+        },
+        {
+          "id": "41",
+          "metadata": {
+            "type": "core",
+            "id": 2,
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01/core2"
+            }
+          }
+        },
+        {
+          "id": "42",
+          "metadata": {
+            "type": "core",
+            "id": 3,
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01/core3"
+            }
+          }
+        },
+        {
+          "id": "43",
+          "metadata": {
+            "type": "core",
+            "id": 4,
+            "rank": 0,
+            "paths": {
+              "containment": "/compute/rack0/compute-01/core4"
+            }
+          }
+        },
+        {
+          "id": "44",
+          "metadata": {
+            "type": "rack",
+            "id": 1,
+            "properties": {
+              "rabbit": "kind-worker3",
+              "ssdcount": "36"
+            },
+            "paths": {
+              "containment": "/compute/rack1"
+            }
+          }
+        },
+        {
+          "id": "45",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd0"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "46",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd1"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "47",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd2"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "48",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd3"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "49",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd4"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "50",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd5"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "51",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd6"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "52",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd7"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "53",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd8"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "54",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd9"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "55",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd10"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "56",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd11"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "57",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd12"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "58",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd13"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "59",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd14"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "60",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd15"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "61",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd16"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "62",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd17"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "63",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd18"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "64",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd19"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "65",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd20"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "66",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd21"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "67",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd22"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "68",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd23"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "69",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd24"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "70",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd25"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "71",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd26"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "72",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd27"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "73",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd28"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "74",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd29"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "75",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd30"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "76",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd31"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "77",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd32"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "78",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd33"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "79",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd34"
+            },
+            "status": 1
+          }
+        },
+        {
+          "id": "80",
+          "metadata": {
+            "type": "ssd",
+            "unit": "GiB",
+            "size": 1024,
+            "paths": {
+              "containment": "/compute/rack1/ssd35"
+            },
+            "status": 1
+          }
+        }
+      ],
+      "edges": [
+        {
+          "source": "0",
+          "target": "1"
+        },
+        {
+          "source": "1",
+          "target": "2"
+        },
+        {
+          "source": "1",
+          "target": "3"
+        },
+        {
+          "source": "1",
+          "target": "4"
+        },
+        {
+          "source": "1",
+          "target": "5"
+        },
+        {
+          "source": "1",
+          "target": "6"
+        },
+        {
+          "source": "1",
+          "target": "7"
+        },
+        {
+          "source": "1",
+          "target": "8"
+        },
+        {
+          "source": "1",
+          "target": "9"
+        },
+        {
+          "source": "1",
+          "target": "10"
+        },
+        {
+          "source": "1",
+          "target": "11"
+        },
+        {
+          "source": "1",
+          "target": "12"
+        },
+        {
+          "source": "1",
+          "target": "13"
+        },
+        {
+          "source": "1",
+          "target": "14"
+        },
+        {
+          "source": "1",
+          "target": "15"
+        },
+        {
+          "source": "1",
+          "target": "16"
+        },
+        {
+          "source": "1",
+          "target": "17"
+        },
+        {
+          "source": "1",
+          "target": "18"
+        },
+        {
+          "source": "1",
+          "target": "19"
+        },
+        {
+          "source": "1",
+          "target": "20"
+        },
+        {
+          "source": "1",
+          "target": "21"
+        },
+        {
+          "source": "1",
+          "target": "22"
+        },
+        {
+          "source": "1",
+          "target": "23"
+        },
+        {
+          "source": "1",
+          "target": "24"
+        },
+        {
+          "source": "1",
+          "target": "25"
+        },
+        {
+          "source": "1",
+          "target": "26"
+        },
+        {
+          "source": "1",
+          "target": "27"
+        },
+        {
+          "source": "1",
+          "target": "28"
+        },
+        {
+          "source": "1",
+          "target": "29"
+        },
+        {
+          "source": "1",
+          "target": "30"
+        },
+        {
+          "source": "1",
+          "target": "31"
+        },
+        {
+          "source": "1",
+          "target": "32"
+        },
+        {
+          "source": "1",
+          "target": "33"
+        },
+        {
+          "source": "1",
+          "target": "34"
+        },
+        {
+          "source": "1",
+          "target": "35"
+        },
+        {
+          "source": "1",
+          "target": "36"
+        },
+        {
+          "source": "1",
+          "target": "37"
+        },
+        {
+          "source": "1",
+          "target": "38"
+        },
+        {
+          "source": "38",
+          "target": "39"
+        },
+        {
+          "source": "38",
+          "target": "40"
+        },
+        {
+          "source": "38",
+          "target": "41"
+        },
+        {
+          "source": "38",
+          "target": "42"
+        },
+        {
+          "source": "38",
+          "target": "43"
+        },
+        {
+          "source": "0",
+          "target": "44"
+        },
+        {
+          "source": "44",
+          "target": "45"
+        },
+        {
+          "source": "44",
+          "target": "46"
+        },
+        {
+          "source": "44",
+          "target": "47"
+        },
+        {
+          "source": "44",
+          "target": "48"
+        },
+        {
+          "source": "44",
+          "target": "49"
+        },
+        {
+          "source": "44",
+          "target": "50"
+        },
+        {
+          "source": "44",
+          "target": "51"
+        },
+        {
+          "source": "44",
+          "target": "52"
+        },
+        {
+          "source": "44",
+          "target": "53"
+        },
+        {
+          "source": "44",
+          "target": "54"
+        },
+        {
+          "source": "44",
+          "target": "55"
+        },
+        {
+          "source": "44",
+          "target": "56"
+        },
+        {
+          "source": "44",
+          "target": "57"
+        },
+        {
+          "source": "44",
+          "target": "58"
+        },
+        {
+          "source": "44",
+          "target": "59"
+        },
+        {
+          "source": "44",
+          "target": "60"
+        },
+        {
+          "source": "44",
+          "target": "61"
+        },
+        {
+          "source": "44",
+          "target": "62"
+        },
+        {
+          "source": "44",
+          "target": "63"
+        },
+        {
+          "source": "44",
+          "target": "64"
+        },
+        {
+          "source": "44",
+          "target": "65"
+        },
+        {
+          "source": "44",
+          "target": "66"
+        },
+        {
+          "source": "44",
+          "target": "67"
+        },
+        {
+          "source": "44",
+          "target": "68"
+        },
+        {
+          "source": "44",
+          "target": "69"
+        },
+        {
+          "source": "44",
+          "target": "70"
+        },
+        {
+          "source": "44",
+          "target": "71"
+        },
+        {
+          "source": "44",
+          "target": "72"
+        },
+        {
+          "source": "44",
+          "target": "73"
+        },
+        {
+          "source": "44",
+          "target": "74"
+        },
+        {
+          "source": "44",
+          "target": "75"
+        },
+        {
+          "source": "44",
+          "target": "76"
+        },
+        {
+          "source": "44",
+          "target": "77"
+        },
+        {
+          "source": "44",
+          "target": "78"
+        },
+        {
+          "source": "44",
+          "target": "79"
+        },
+        {
+          "source": "44",
+          "target": "80"
+        }
+      ]
+    }
+  }
+}

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -62,6 +62,22 @@ test_expect_success 'flux-dws2jgf.py handles properties correctly' '
 	test_cmp ${DATADIR}/expected-properties.jgf actual-properties.jgf
 '
 
+test_expect_success 'flux-dws2jgf.py can read from a config file' '
+	cat >resourceconf.toml <<-EOT &&
+	[[resource.config]]
+	hosts = "compute-01"
+	cores = "0-4"
+	EOT
+	flux python ${CMD} --no-validate --from-config resourceconf.toml rabbits.json | jq . > actual-configfile.jgf &&
+	test_cmp ${DATADIR}/expected-configfile.jgf actual-configfile.jgf
+'
+
+test_expect_success 'flux-dws2jgf.py reading from config file is same as parse-config' '
+	flux R parse-config resourceconf.toml | \
+	flux python ${CMD} --no-validate rabbits.json | jq . > actual-configfile-parseconfig.jgf &&
+	test_cmp ${DATADIR}/expected-configfile.jgf actual-configfile-parseconfig.jgf
+'
+
 test_expect_success 'fluxion rejects a rack/rabbit job when no rabbits are recognized' '
 	flux module remove -f sched-fluxion-qmanager &&
 	flux module remove -f sched-fluxion-resource &&


### PR DESCRIPTION
Problem: the `capture_output` argument to subprocess.run requires python 3.7+ but LC machines are still on 3.6.

Replace the argument with a 3.6+ compatible equivalent.