### PR TITLE
dws: use systemconfiguration for rabbit mapping

### DIFF
--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -7,26 +7,22 @@ import subprocess
 
 import flux
 from flux.hostlist import Hostlist
+from flux_k8s import crd
 
 import kubernetes as k8s
 from kubernetes.client.rest import ApiException
 
 
-def get_storage(config_file):
+def get_k8s_api(config_file):
     k8s_client = k8s.config.new_client_from_config(config_file=config_file)
     try:
-        api_instance = k8s.client.CustomObjectsApi(k8s_client)
+        return k8s.client.CustomObjectsApi(k8s_client)
     except ApiException as rest_exception:
         if rest_exception.status == 403:
             raise Exception(
                 "You must be logged in to the K8s or OpenShift cluster to continue"
             )
         raise
-
-    group = "dataworkflowservices.github.io"
-    version = "v1alpha2"
-    plural = "storages"
-    return api_instance.list_cluster_custom_object(group, version, plural)
 
 
 def main():
@@ -56,15 +52,45 @@ def main():
     )
     args = parser.parse_args()
     rabbit_mapping = {"computes": {}, "rabbits": {}}
-    for nnf in get_storage(args.kubeconfig)["items"]:
+    k8s_api = get_k8s_api(args.kubeconfig)
+    # populate as much data as possible using the SystemConfiguration, since
+    # it is complete and static, while the Storage resources can come and go
+    sysconfig = k8s_api.get_namespaced_custom_object(
+        *crd.SYSTEMCONFIGURATION_CRD, "default"
+    )
+    for nnf in sysconfig["spec"]["storageNodes"]:
         hlist = Hostlist()
-        nnf_name = nnf["metadata"]["name"]
-        for compute in nnf["status"]["access"].get("computes", []):
+        nnf_name = nnf["name"]
+        for compute in nnf.get("computesAccess", []):
             hlist.append(compute["name"])
             rabbit_mapping["computes"][compute["name"]] = nnf_name
         rabbit_mapping["rabbits"][nnf_name] = {}
         rabbit_mapping["rabbits"][nnf_name]["hostlist"] = hlist.uniq().encode()
-        rabbit_mapping["rabbits"][nnf_name]["capacity"] = nnf["status"]["capacity"]
+    # fetch storages to fill in capacity field
+    storages = k8s_api.list_cluster_custom_object(
+        crd.RABBIT_CRD.group, crd.RABBIT_CRD.version, crd.RABBIT_CRD.plural
+    )
+    max_capacity = 0
+    for nnf in storages["items"]:
+        nnf_name = nnf["metadata"]["name"]
+        for compute in nnf["status"]["access"].get("computes", []):
+            compute_name = compute["name"]
+            if rabbit_mapping["computes"].get(compute_name) != nnf_name:
+                raise RuntimeError(
+                    f"Mismatch: rabbit {nnf_name} claims to be "
+                    f"connected to {compute_name} but systemconfiguration gives "
+                    f"{rabbit_mapping['computes'].get(compute_name)}"
+                )
+            capacity = nnf.get("status", {}).get("capacity", 0)
+            max_capacity = max(capacity, max_capacity)
+            if capacity == 0:
+                capacity = max_capacity
+            rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
+    # go back through sysconfig, make sure capacity is there for all resources
+    for nnf in sysconfig["spec"]["storageNodes"]:
+        nnf_name = nnf["name"]
+        if rabbit_mapping["rabbits"][nnf_name].get("capacity") is None:
+            rabbit_mapping["rabbits"][nnf_name]["capacity"] = max_capacity
     json.dump(rabbit_mapping, sys.stdout, indent=args.indent, sort_keys=args.nosort)
 
 

--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -40,3 +40,10 @@ SERVER_CRD = CRD(
     namespace=DEFAULT_NAMESPACE,
     plural="servers",
 )
+
+SYSTEMCONFIGURATION_CRD = CRD(
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
+    plural="systemconfigurations",
+)

--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -2,37 +2,41 @@ from collections import namedtuple
 
 CRD = namedtuple("CRD", ["group", "version", "namespace", "plural"])
 
+DWS_GROUP = "dataworkflowservices.github.io"
+DWS_API_VERSION = "v1alpha2"
+DEFAULT_NAMESPACE = "default"
+
 WORKFLOW_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
     plural="workflows",
 )
 
 RABBIT_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
     plural="storages",
 )
 
 DIRECTIVEBREAKDOWN_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
     plural="directivebreakdowns",
 )
 
 COMPUTE_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
     plural="computes",
 )
 
 SERVER_CRD = CRD(
-    group="dataworkflowservices.github.io",
-    version="v1alpha2",
-    namespace="default",
+    group=DWS_GROUP,
+    version=DWS_API_VERSION,
+    namespace=DEFAULT_NAMESPACE,
     plural="servers",
 )


### PR DESCRIPTION
flux-coral2 code in various places reads rabbit info (in particular, the mapping from compute nodes to rabbit nodes and vice versa) from `Storage` resources when it should instead read from the `Systemconfiguration` resource, which is comprehensive and static.

Fixes #221. 