### PR TITLE
dws: rabbit config file support 

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -814,14 +814,6 @@ def setup_parsing():
         help="Increase verbosity of output",
     )
     parser.add_argument(
-        "--transient-condition-timeout",
-        "-e",
-        type=float,
-        default=10,
-        metavar="N",
-        help="Kill workflows in TransientCondition state for more than 'N' seconds",
-    )
-    parser.add_argument(
         "--kubeconfig",
         "-k",
         default=None,
@@ -994,11 +986,12 @@ def main():
     populate_rabbits_dict(k8s_api)
     # create a timer watcher for killing workflows that have been stuck in
     # the "Error" state for too long
+    tc_timeout = handle.conf_get("rabbit.tc_timeout", 10)
     handle.timer_watcher_create(
-        args.transient_condition_timeout / 2,
+        tc_timeout / 2,
         kill_workflows_in_tc,
-        repeat=args.transient_condition_timeout / 2,
-        args=(args.transient_condition_timeout, k8s_api),
+        repeat=tc_timeout / 2,
+        args=(tc_timeout, k8s_api),
     ).start()
     # start watching k8s workflow resources and operate on them when updates occur
     # or new RPCs are received

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -814,13 +814,6 @@ def setup_parsing():
         help="Increase verbosity of output",
     )
     parser.add_argument(
-        "--kubeconfig",
-        "-k",
-        default=None,
-        metavar="FILE",
-        help="Path to kubeconfig file to use",
-    )
-    parser.add_argument(
         "--min-allocation-size",
         "-m",
         default=_MIN_ALLOCATION_SIZE,
@@ -969,7 +962,9 @@ def main():
             handle.conf_get(f"rabbit.policy.maximums.{fs_type}"),
         )
     try:
-        k8s_client = k8s.config.new_client_from_config(config_file=args.kubeconfig)
+        k8s_client = k8s.config.new_client_from_config(
+            handle.conf_get("rabbit.kubeconfig")
+        )
     except ConfigException:
         LOGGER.exception("Kubernetes misconfigured, service will shut down")
         sys.exit(_EXITCODE_NORESTART)

--- a/t/data/workflow-obj/maximums/rabbit.toml
+++ b/t/data/workflow-obj/maximums/rabbit.toml
@@ -1,0 +1,7 @@
+# maximum filesystem capacity per node, in GiB
+[rabbit.policy.maximums]
+xfs = 500
+gfs2 = 200
+raw = 300
+lustre = 100
+

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -474,11 +474,11 @@ test_expect_success 'back-to-back job submissions with 10TiB file systems works'
 
 test_expect_success 'launch service with storage maximum arguments' '
 	flux cancel $DWS_JOBID &&
+	flux config load ${DATADIR}/maximums &&
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws4.out --error=dws4.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local \
-		--max-xfs 500 --max-lustre 100 --max-gfs2 200 --max-raw 300) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -42,11 +42,11 @@ test_expect_success 'job-manager: load dws-jobtap and alloc-bypass plugin' '
 
 test_expect_success 'exec dws service-providing script with bad arguments' '
     KUBECONFIG=/dev/null test_expect_code 3 flux python ${DWS_MODULE_PATH} \
-        -e1 -v &&
-    test_expect_code 3 flux python ${DWS_MODULE_PATH} -e1 -v \
+        -v &&
+    test_expect_code 3 flux python ${DWS_MODULE_PATH} -v \
         --kubeconfig /dev/null &&
     test_expect_code 2 flux python ${DWS_MODULE_PATH} \
-        -e1 -v --foobar
+        -v --foobar
 '
 
 test_expect_success 'exec dws service-providing script with fluxion scheduling disabled' '
@@ -54,7 +54,7 @@ test_expect_success 'exec dws service-providing script with fluxion scheduling d
     DWS_JOBID=$(flux submit \
             --setattr=system.alloc-bypass.R="$R" \
             -o per-resource.type=node --output=dws-fluxion-disabled.out \
-            --error=dws-fluxion-disabled.err python ${DWS_MODULE_PATH} -e1 \
+            --error=dws-fluxion-disabled.err python ${DWS_MODULE_PATH} \
             -vvv --disable-fluxion) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start &&
     flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
@@ -109,7 +109,7 @@ test_expect_success 'exec dws service-providing script' '
 	DWS_JOBID=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws1.out --error=dws1.err \
-	        python ${DWS_MODULE_PATH} -e1 -vvv) &&
+	        python ${DWS_MODULE_PATH} -vvv) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start
 '
 
@@ -336,7 +336,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
+		python ${DWS_MODULE_PATH} --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '
@@ -420,7 +420,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
+		python ${DWS_MODULE_PATH} --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
@@ -478,7 +478,7 @@ test_expect_success 'launch service with storage maximum arguments' '
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws4.out --error=dws4.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
+		python ${DWS_MODULE_PATH} --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -42,11 +42,11 @@ test_expect_success 'job-manager: load dws-jobtap and alloc-bypass plugin' '
 
 test_expect_success 'exec dws service-providing script with bad arguments' '
     KUBECONFIG=/dev/null test_expect_code 3 flux python ${DWS_MODULE_PATH} \
-        -e1 -v -rR.local &&
-    test_expect_code 3 flux python ${DWS_MODULE_PATH} -e1 -v -rR.local \
+        -e1 -v &&
+    test_expect_code 3 flux python ${DWS_MODULE_PATH} -e1 -v \
         --kubeconfig /dev/null &&
     test_expect_code 2 flux python ${DWS_MODULE_PATH} \
-        -e1 -v -rR.local --foobar
+        -e1 -v --foobar
 '
 
 test_expect_success 'exec dws service-providing script with fluxion scheduling disabled' '
@@ -109,7 +109,7 @@ test_expect_success 'exec dws service-providing script' '
 	DWS_JOBID=$(flux submit \
 	        --setattr=system.alloc-bypass.R="$R" \
 	        -o per-resource.type=node --output=dws1.out --error=dws1.err \
-	        python ${DWS_MODULE_PATH} -e1 -vvv -rR.local) &&
+	        python ${DWS_MODULE_PATH} -e1 -vvv) &&
 	flux job wait-event -vt 15 -p guest.exec.eventlog ${DWS_JOBID} shell.start
 '
 
@@ -336,7 +336,7 @@ test_expect_success 'exec dws service-providing script with custom config path' 
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws2.out --error=dws2.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '
@@ -420,7 +420,7 @@ test_expect_success 'dws service script handles restarts while a job is running'
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws3.out --error=dws3.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 5 -m status=0 ${jobid} finish &&
 	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
@@ -478,7 +478,7 @@ test_expect_success 'launch service with storage maximum arguments' '
 	DWS_JOBID=$(flux submit \
 		--setattr=system.alloc-bypass.R="$R" \
 		-o per-resource.type=node --output=dws4.out --error=dws4.err \
-		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv -rR.local) &&
+		python ${DWS_MODULE_PATH} -e1 --kubeconfig $PWD/kubeconfig -vvv) &&
 	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
 	${RPC} "dws.create"
 '

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -52,6 +52,19 @@ kubeconfig = \"/dev/null\"
         -v --foobar
 '
 
+test_expect_success 'exec dws service-providing script with bad config' '
+    echo "
+[rabbit]
+foobar = false
+    " | flux config load &&
+    test_must_fail flux python ${DWS_MODULE_PATH} -v &&
+    echo "
+[rabbit.policy.maximums]
+fake = 1
+    " | flux config load &&
+    test_must_fail flux python ${DWS_MODULE_PATH} -v
+'
+
 test_expect_success 'exec dws service-providing script with fluxion scheduling disabled' '
     flux config reload &&
     R=$(flux R encode -r 0) &&

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -52,7 +52,7 @@ test_expect_success 'rabbits default to down and are not allocated' '
 test_expect_success 'exec Storage watching script' '
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws1.out --error=dws1.err \
-            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local) &&
+            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start
 '
 
@@ -139,7 +139,7 @@ drain_compute_nodes = false
     " | flux config load &&
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws2.out --error=dws2.err \
-            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local) &&
+            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv) &&
     flux job wait-event -vt 15 -p guest.exec.eventlog ${jobid} shell.start
 '
 
@@ -168,7 +168,7 @@ test_expect_success 'exec Storage watching script with invalid --drain-queues ar
     flux cancel ${jobid} &&
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws3.out --error=dws3.err \
-            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local \
+            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv \
             --drain-queues notaqueue alsonotaqueue) &&
     flux job wait-event -vt 5 ${jobid} finish &&
     test_must_fail flux job attach ${jobid}
@@ -190,8 +190,7 @@ test_expect_success 'exec Storage watching script with --drain-queues' '
     flux config reload &&
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws4.out --error=dws4.err \
-            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv -rR.local.queues \
-            --drain-queues debug) &&
+            -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv --drain-queues debug) &&
     kubectl patch storage kind-worker2 --type=json \
         -p "[{\"op\":\"replace\", \"path\":\"/spec/mode\", \"value\": \"Testing\"}]" &&
     kubectl get storages kind-worker2 -ojson | jq -e ".spec.mode == \"Testing\"" &&


### PR DESCRIPTION
Moves a bunch of `coral2_dws.py` command-line arguments to a `[rabbit]` table in the Flux config.

See also https://github.com/flux-framework/flux-docs/pull/286 for a description of what the config file should look like.

Fixes #220.