### PR TITLE
Rabbit preset dw strings

### DIFF
--- a/t/data/workflow-obj/maximums/rabbit.toml
+++ b/t/data/workflow-obj/maximums/rabbit.toml
@@ -5,3 +5,7 @@ gfs2 = 200
 raw = 300
 lustre = 100
 
+[rabbit.presets]
+lustre_toobig = "#DW jobdw type=lustre capacity=200GiB name=toobig"
+gfs2_toobig = "#DW jobdw type=gfs2 capacity=250GiB name=toobig"
+xfs_justright = "#DW jobdw type=xfs capacity=100GiB name=justright"


### PR DESCRIPTION
Problem: some users may not want to write custom #DW strings for
their jobs. It can take a while to learn the syntax and figure out
what options to use.

Add configurable preset #DW strings that can be defined in a config
file. Administrators can define some presets they think would work
for a large number of users of the system.

Fixes #200 .