### PR TITLE
dws: retry k8s failures while cleaning up workflows

### DIFF
--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -7,22 +7,10 @@ import subprocess
 
 import flux
 from flux.hostlist import Hostlist
-from flux_k8s import crd
+from flux_k8s import crd, cleanup
 
 import kubernetes as k8s
 from kubernetes.client.rest import ApiException
-
-
-def get_k8s_api(config_file):
-    k8s_client = k8s.config.new_client_from_config(config_file=config_file)
-    try:
-        return k8s.client.CustomObjectsApi(k8s_client)
-    except ApiException as rest_exception:
-        if rest_exception.status == 403:
-            raise Exception(
-                "You must be logged in to the K8s or OpenShift cluster to continue"
-            )
-        raise
 
 
 def main():
@@ -52,7 +40,7 @@ def main():
     )
     args = parser.parse_args()
     rabbit_mapping = {"computes": {}, "rabbits": {}}
-    k8s_api = get_k8s_api(args.kubeconfig)
+    k8s_api = cleanup.get_k8s_api(args.kubeconfig)
     # populate as much data as possible using the SystemConfiguration, since
     # it is complete and static, while the Storage resources can come and go
     sysconfig = k8s_api.get_namespaced_custom_object(

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -481,8 +481,7 @@ def _workflow_state_change_cb_inner(workflow, winfo, handle, k8s_api, disable_fl
             log_rpc_response
         )
         save_elapsed_time_to_kvs(handle, jobid, workflow)
-        cleanup.remove_finalizer(winfo.name, k8s_api, workflow)
-        k8s_api.delete_namespaced_custom_object(*crd.WORKFLOW_CRD, winfo.name)
+        cleanup.delete_workflow(workflow)
         winfo.deleted = True
     elif winfo.toredown:
         # in the event of an exception, the workflow will skip to 'teardown'.
@@ -995,6 +994,7 @@ def main():
             "Service cannot run without access to kubernetes, shutting down"
         )
         sys.exit(_EXITCODE_NORESTART)
+    cleanup.setup_cleanup_thread(handle.conf_get("rabbit.kubeconfig"))
     populate_rabbits_dict(k8s_api)
     # create a timer watcher for killing workflows that have been stuck in
     # the "Error" state for too long

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -72,18 +72,7 @@ class WorkflowInfo:
             )
         datamovements = get_datamovements(k8s_api, self.name, self.save_datamovements)
         save_workflow_to_kvs(handle, self.jobid, workflow, datamovements)
-        try:
-            workflow["metadata"]["finalizers"].remove(cleanup.FINALIZER)
-        except ValueError:
-            pass
-        k8s_api.patch_namespaced_custom_object(
-            *crd.WORKFLOW_CRD,
-            self.name,
-            {
-                "spec": {"desiredState": "Teardown"},
-                "metadata": {"finalizers": workflow["metadata"]["finalizers"]},
-            },
-        )
+        cleanup.teardown_workflow(workflow)
         self.toredown = True
 
 

--- a/src/python/flux_k8s/Makefile.am
+++ b/src/python/flux_k8s/Makefile.am
@@ -2,7 +2,8 @@ nobase_fluxk8spy_PYTHON = \
 	__init__.py \
 	crd.py \
 	directivebreakdown.py \
-	watch.py
+	watch.py \
+	cleanup.py
 
 
 clean-local:

--- a/src/python/flux_k8s/cleanup.py
+++ b/src/python/flux_k8s/cleanup.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import threading
 
 import kubernetes as k8s
 from kubernetes.client.rest import ApiException
@@ -10,6 +11,7 @@ from flux_k8s import crd
 
 LOGGER = logging.getLogger(__name__)
 FINALIZER = "flux-framework.readthedocs.io/workflow"
+CLEANUP_LOOP = asyncio.get_event_loop()
 
 
 def remove_finalizer(workflow_name, k8s_api, workflow):
@@ -45,3 +47,64 @@ def get_k8s_api(kubeconfig):
         LOGGER.exception("Cannot access kubernetes")
         raise
     return k8s_api
+
+
+def log_error(fut):
+    try:
+        fut.result()
+    except Exception as exc:
+        LOGGER.exception("Exception in cleanup routine")
+
+
+async def delete_workflow_coro(workflow):
+    """Delete a workflow, retrying indefinitely (with backoff) upon error."""
+    k8s_api = threading.current_thread().k8s_api
+    attempts = 0
+    name = workflow["metadata"]["name"]
+    # attempt to delete the workflow in a loop
+    while True:
+        try:
+            remove_finalizer(name, k8s_api, workflow)
+            k8s_api.delete_namespaced_custom_object(*crd.WORKFLOW_CRD, name)
+        except Exception as gen_exc:
+            if isinstance(gen_exc, ApiException) and gen_exc.status == 404:
+                # workflow was not found, presume it was deleted already
+                return
+            attempts += 1
+            if attempts >= 5:
+                LOGGER.warning(
+                    "Failed to delete workflow %s after %i attempts. Error is %s",
+                    name,
+                    attempts,
+                    gen_exc,
+                )
+            await asyncio.sleep(5 * 2 ** (attempts - 1))
+        else:
+            return
+
+
+def delete_workflow(workflow):
+    asyncio.run_coroutine_threadsafe(
+        delete_workflow_coro(workflow), CLEANUP_LOOP
+    ).add_done_callback(log_error)
+
+
+def cleanup_target(kubeconfig):
+    """Run the asyncio event loop indefinitely."""
+    curr_thread = threading.current_thread()
+    curr_thread.k8s_api = get_k8s_api(kubeconfig)
+    try:
+        CLEANUP_LOOP.run_forever()
+    finally:
+        CLEANUP_LOOP.close()
+
+
+def setup_cleanup_thread(kubeconfig):
+    """Start the thread that will run cleanup actions on workflows."""
+    cleanup_thread = threading.Thread(
+        target=cleanup_target,
+        args=(kubeconfig,),
+        name="workflow_cleanup_thread",
+        daemon=True,
+    )
+    cleanup_thread.start()

--- a/src/python/flux_k8s/cleanup.py
+++ b/src/python/flux_k8s/cleanup.py
@@ -1,0 +1,20 @@
+"""Module defining cleanup routines for the coral2_dws service."""
+
+from flux_k8s import crd
+
+FINALIZER = "flux-framework.readthedocs.io/workflow"
+
+
+def remove_finalizer(workflow_name, k8s_api, workflow):
+    """Remove the finalizer from the workflow so it can be deleted."""
+    try:
+        workflow["metadata"]["finalizers"].remove(FINALIZER)
+    except ValueError:
+        # finalizer is not present, nothing to do
+        pass
+    else:
+        k8s_api.patch_namespaced_custom_object(
+            *crd.WORKFLOW_CRD,
+            workflow_name,
+            {"metadata": {"finalizers": workflow["metadata"]["finalizers"]}},
+        )

--- a/src/python/flux_k8s/cleanup.py
+++ b/src/python/flux_k8s/cleanup.py
@@ -1,7 +1,14 @@
 """Module defining cleanup routines for the coral2_dws service."""
 
+import asyncio
+import logging
+
+import kubernetes as k8s
+from kubernetes.client.rest import ApiException
+
 from flux_k8s import crd
 
+LOGGER = logging.getLogger(__name__)
 FINALIZER = "flux-framework.readthedocs.io/workflow"
 
 
@@ -18,3 +25,23 @@ def remove_finalizer(workflow_name, k8s_api, workflow):
             workflow_name,
             {"metadata": {"finalizers": workflow["metadata"]["finalizers"]}},
         )
+
+
+def get_k8s_api(kubeconfig):
+    """Return a handle to the k8s cluster's CustomObjectsApi."""
+    try:
+        k8s_client = k8s.config.new_client_from_config(kubeconfig)
+    except ConfigException:
+        LOGGER.exception("Kubernetes misconfigured")
+        raise
+    try:
+        k8s_api = k8s.client.CustomObjectsApi(k8s_client)
+    except ApiException as rest_exception:
+        if rest_exception.status == 403:
+            LOGGER.exception(
+                "You must be logged in to the K8s or OpenShift cluster to continue"
+            )
+            raise
+        LOGGER.exception("Cannot access kubernetes")
+        raise
+    return k8s_api


### PR DESCRIPTION
Related to #159 and #197 . Add async routines to try to teardown and delete k8s workflows in an infinite loop until success. 