### PR TITLE
dws: increase nnfdatamovement version to v1alpha4

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -172,7 +172,7 @@ def get_datamovements(k8s_api, workflow_name, count):
     try:
         api_response = k8s_api.list_cluster_custom_object(
             group="nnf.cray.hpe.com",
-            version="v1alpha2",
+            version="v1alpha4",
             plural="nnfdatamovements",
             label_selector=(
                 f"dataworkflowservices.github.io/workflow.name={workflow_name},"


### PR DESCRIPTION
Problem: new releases of the DWS rabbit software stack have upped the recommended nnfdatamovement resource version from v1alpha2 to v1alpha4.

Change the version.