### PR TITLE
dws2jgf: fix broken error message

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -254,7 +254,7 @@ def main():
         if proc.returncode != 0:
             raise ValueError(
                 f"Could not parse config file {args.from_config!r}, "
-                "error message was {proc.stderr}"
+                f"error message was {proc.stderr}"
             )
         input_r = json.loads(proc.stdout)
     with open(args.rabbitmapping, "r", encoding="utf8") as rabbitmap_fd:

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python3
 
+"""Script to create a JSON file mapping compute nodes <-> rabbits."""
+
 import argparse
 import sys
 import json
-import subprocess
 
 import flux
 from flux.hostlist import Hostlist
 from flux_k8s import crd, cleanup
 
-import kubernetes as k8s
-from kubernetes.client.rest import ApiException
-
 
 def main():
+    """Create a JSON file mapping compute nodes <-> rabbits.
+
+    Fetch the SystemConfiguration from kubernetes and use that for the mapping.
+    Also fetch Storage resources from kubernetes to populate the JSON file with
+    capacity data.
+    """
     parser = argparse.ArgumentParser(
         formatter_class=flux.util.help_formatter(),
         description=("Create a mapping between compute nodes and rabbit nodes"),


### PR DESCRIPTION
Problem: an f-string in flux-dws2jgf is missing its `f` prefix, so an error message is not printed correctly.

Fix it, and remove some unused imports identified by pylint.