### PR TITLE
dws: add negative requires hostlist for down rabbits

### DIFF
--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -32,6 +32,7 @@ def create_cb(fh, t, msg, arg):
             "resources": msg.payload["resources"],
             "copy-offload": False,
             "errmsg": None,
+            "exclude": "",
         },
     )
 


### PR DESCRIPTION
Problem: Fluxion continues to have problems with rabbits on
production systems. However, users need a way for Flux to
automatically schedule around down rabbits.

As a workaround, maintain a hostlist of all nodes that are attached
to down rabbits. Add this hostlist to jobs' constraints, as a negative hostlist constraint (like
`--requires=-hosts:foobar[1-20]`)