### PR TITLE
dws: add 'mapping' to accepted config keys

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -933,6 +933,7 @@ def validate_config(config):
         "restrict_persistent_creation",
         "policy",
         "presets",
+        "mapping",
     }
     keys = set(config.keys())
     if not keys <= accepted_keys:


### PR DESCRIPTION
Problem: 'rabbit.mapping' is rejected by coral2_dws as a config key, but it is valid.

Make coral2_dws accept it.