### PR TITLE
`getrabbit`: list all rabbits

### DIFF
--- a/src/cmd/flux-getrabbit.py
+++ b/src/cmd/flux-getrabbit.py
@@ -43,8 +43,6 @@ def main():
             "Both rabbits and computes (with '--computes') cannot be "
             "looked up at the same time"
         )
-    if not args.computes and not args.rabbits:
-        sys.exit("At least one rabbit or compute node must be specified")
     # load the mapping file
     handle = flux.Flux()
     path = handle.conf_get("rabbit.mapping")
@@ -62,6 +60,11 @@ def main():
         sys.exit(f"File {path!r} could not be parsed as JSON: {jexc}")
     # construct and print the hostlist of rabbits
     hlist = Hostlist()
+    if not args.computes and not args.rabbits:
+        # print out all rabbits
+        hlist.append(mapping["rabbits"].keys())
+        print(hlist.uniq().encode())
+        return
     if args.computes:
         aggregated_computes = Hostlist()
         for computes in args.computes:

--- a/t/t2001-getrabbit.t
+++ b/t/t2001-getrabbit.t
@@ -40,7 +40,6 @@ test_expect_success 'flux rabbitmapping works on computes' '
 '
 
 test_expect_success 'flux rabbitmapping parses arguments correctly' '
-	test_must_fail $CMD &&
 	test_must_fail $CMD --computes &&
 	test_must_fail $CMD rzadams201 -c rzadams1001
 '
@@ -57,6 +56,10 @@ mapping = \"$DATADIR/tuolumne_rabbitmapping\"
 
 test_expect_success 'flux rabbitmapping works on computes with second mapping' '
     test $($CMD -c tuolumne[1385-1416]) = tuolumne[225-226]
+'
+
+test_expect_success 'flux rabbitmapping works with no arguments' '
+    test $($CMD) = tuolumne[201-272]
 '
 
 test_done


### PR DESCRIPTION
Problem: there is no way to get a list of all rabbit nodes from
the `flux getrabbit` command.

Make it so that passing no arguments to `getrabbit` makes it print
a hostlist of all rabbits.