### PR TITLE
dws: change exclusion constraint to a property 

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -598,7 +598,7 @@ static json_t *generate_constraints(flux_t *h, flux_plugin_t *p, flux_jobid_t jo
         return NULL;
     }
     if (!constraints) {
-        if (!(constraints = json_pack ("{s:[{s:[s]}]}", "not", "hostlist", exclude_str))){
+        if (!(constraints = json_pack ("{s:[{s:[s]}]}", "not", "properties", exclude_str))){
             flux_log_error (h, "Failed to create new constraints object");
             flux_plugin_arg_destroy (args);
             return NULL;
@@ -615,14 +615,14 @@ static json_t *generate_constraints(flux_t *h, flux_plugin_t *p, flux_jobid_t jo
     }
     flux_plugin_arg_destroy (args);
     if (!(not = json_object_get (constraints, "not"))) {
-        if (json_object_set_new (constraints, "not", json_pack ("[{s:[s]}]", "hostlist", exclude_str)) < 0) {
+        if (json_object_set_new (constraints, "not", json_pack ("[{s:[s]}]", "properties", exclude_str)) < 0) {
             flux_log_error (h, "Failed to create new NOT constraints object");
             json_decref (constraints);
             return NULL;
         }
         return constraints;
     }
-    if (json_array_append_new (not, json_pack ("{s:[s]}", "hostlist", exclude_str)) < 0) {
+    if (json_array_append_new (not, json_pack ("{s:[s]}", "properties", exclude_str)) < 0) {
         flux_log_error (h, "Failed to create new NOT constraints object");
         json_decref (constraints);
         return NULL;
@@ -654,8 +654,8 @@ static void resource_update_msg_cb (flux_t *h,
     }
     if (strlen(exclude_str) > 0) {
         if (!(constraints = generate_constraints (h, p, jobid, exclude_str))) {
-            flux_log_error (h, "Could not generate exclusion hostlist");
-            raise_job_exception (p, jobid, "dws", "Could not generate exclusion hostlist");
+            flux_log_error (h, "Could not generate exclusion constraint");
+            raise_job_exception (p, jobid, "dws", "Could not generate exclusion constraint");
             return;
         }
     }

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -217,6 +217,12 @@ test_expect_success 'exec Storage watching script with --disable-fluxion' '
 [rabbit]
 drain_compute_nodes = false
     " | flux config load &&
+    flux kvs put resource.R="$(flux R encode --local)" &&
+    flux module remove -f sched-fluxion-qmanager &&
+    flux module remove -f sched-fluxion-resource &&
+    flux module reload resource &&
+    flux module load sched-fluxion-resource &&
+    flux module load sched-fluxion-qmanager &&
     flux jobtap load ${PLUGINPATH}/dws-jobtap.so &&
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws5.out \
@@ -239,7 +245,8 @@ test_expect_success 'Storages are up and rabbit jobs can run' '
     flux job wait-event -vt 10 ${JOBID} alloc &&
     flux job wait-event -vt 10 -m status=0 ${JOBID} finish &&
     flux job wait-event -vt 20 ${JOBID} clean &&
-    flux job attach $JOBID
+    flux job attach $JOBID &&
+    test_must_fail flux ion-resource get-property /cluster0/compute-01 badrabbit
 '
 
 test_expect_success 'update to the Storage status is caught by the watch' '
@@ -262,7 +269,8 @@ test_expect_success 'rabbits now marked as down are not allocated' '
     flux job wait-event -vt 10 ${JOBID} jobspec-update &&
     test_must_fail flux job wait-event -vt 3 ${JOBID} alloc &&
     flux job wait-event -vt 1 ${JOBID} exception &&
-    flux job wait-event -vt 2 ${JOBID} clean
+    flux job wait-event -vt 2 ${JOBID} clean &&
+    flux ion-resource get-property /cluster0/compute-01 badrabbit
 '
 
 test_expect_success 'revert the changes to the Storage' '
@@ -286,7 +294,8 @@ test_expect_success 'rabbits now marked as up and can be allocated' '
     flux job wait-event -vt 10 ${JOBID} jobspec-update &&
     flux job wait-event -vt 5 ${JOBID} alloc &&
     flux job wait-event -vt 25 -m status=0 ${JOBID} finish
-    flux job wait-event -vt 20 ${JOBID} clean
+    flux job wait-event -vt 20 ${JOBID} clean &&
+    test_must_fail flux ion-resource get-property /cluster0/compute-01 badrabbit
 '
 
 test_expect_success 'unload fluxion' '

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -47,7 +47,9 @@ test_expect_success 'load Fluxion with rabbit resource graph' '
 test_expect_success 'rabbits default to down and are not allocated' '
     JOBID=$(flux job submit ${DATA_DIR}/rabbit-jobspec.json) &&
     test_must_fail flux job wait-event -vt 3 ${JOBID} alloc &&
-    flux cancel $JOBID
+    flux cancel $JOBID &&
+    flux ion-resource find status=down --format=jgf | grep \"ssd\" &&
+    flux ion-resource find status=up --format=jgf | test_must_fail grep \"ssd\"
 '
 
 test_expect_success 'exec Storage watching script' '
@@ -76,7 +78,9 @@ test_expect_success 'Storage watching script marks rabbits as up' '
     JOBID=$(flux job submit ${DATA_DIR}/rabbit-jobspec.json) &&
     flux job wait-event -vt 3 ${JOBID} alloc &&
     flux job wait-event -vt 3 -m status=0 ${JOBID} finish &&
-    flux job attach $JOBID
+    flux job attach $JOBID &&
+    flux ion-resource find status=up --format=jgf | grep \"ssd\" &&
+    flux ion-resource find status=down --format=jgf | test_must_fail grep \"ssd\"
 '
 
 test_expect_success 'update to the Storage status is caught by the watch' '
@@ -96,7 +100,9 @@ test_expect_success 'update to the Storage status is caught by the watch' '
 test_expect_success 'rabbits now marked as down are not allocated' '
     JOBID=$(flux job submit ${DATA_DIR}/rabbit-jobspec.json) &&
     test_must_fail flux job wait-event -vt 3 ${JOBID} alloc &&
-    flux cancel $JOBID
+    flux cancel $JOBID &&
+    flux ion-resource find status=down --format=jgf | grep \"ssd\" &&
+    flux ion-resource find status=up --format=jgf | test_must_fail grep \"ssd\"
 '
 
 test_expect_success 'revert the changes to the Storage' '
@@ -117,7 +123,9 @@ test_expect_success 'rabbits now marked as up and can be allocated' '
     JOBID=$(flux job submit ${DATA_DIR}/rabbit-jobspec.json) &&
     flux job wait-event -vt 3 ${JOBID} alloc &&
     flux job wait-event -vt 3 -m status=0 ${JOBID} finish &&
-    flux job attach $JOBID
+    flux job attach $JOBID &&
+    flux ion-resource find status=up --format=jgf | grep \"ssd\" &&
+    flux ion-resource find status=down --format=jgf | test_must_fail grep \"ssd\"
 '
 
 test_expect_success 'test that flux drains Offline compute nodes' '


### PR DESCRIPTION
Problem: Fluxion continues to have problems with rabbits on
production systems. However, users need a way for Flux to
automatically schedule around down rabbits.

Previously (see #252), a hostlist constraint was used. However, that doesn't
work very well when queue times are long, because rabbit status can
change while the job sits in the queue.

Instead, use a property constraint.