### PR TITLE
rabbitmapping: fetch by jobid

### DIFF
--- a/src/cmd/flux-getrabbit.py
+++ b/src/cmd/flux-getrabbit.py
@@ -11,13 +11,8 @@ from flux.job import JobID
 from flux.hostlist import Hostlist
 
 
-def main():
-    """Create a JSON file mapping compute nodes <-> rabbits.
-
-    Fetch the SystemConfiguration from kubernetes and use that for the mapping.
-    Also fetch Storage resources from kubernetes to populate the JSON file with
-    capacity data.
-    """
+def read_args():
+    """Read in command-line args."""
     parser = argparse.ArgumentParser(
         formatter_class=flux.util.help_formatter(),
         description=("Map compute nodes to rabbits and vice versa."),
@@ -28,23 +23,63 @@ def main():
         nargs="+",
         metavar="HOSTS",
         type=Hostlist,
-        help="One or more hostlists of compute nodes",
+        help="hostlists of compute nodes, to map to rabbits",
     )
     parser.add_argument(
         "--jobids",
         "-j",
         nargs="+",
         metavar="JOBID",
-        help="One or more jobids",
+        help="jobids, to map to rabbits",
     )
     parser.add_argument(
         "rabbits",
         nargs="*",
         metavar="RABBITS",
         type=Hostlist,
-        help="One or more hostlists of rabbit nodes",
+        help="hostlists of rabbits, to map to compute nodes",
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def map_to_rabbits(args, handle, mapping):
+    """Map compute nodes to rabbit nodes, and print.
+
+    If job IDs are provided, turn them into a hostlist of compute nodes and
+    then proceed.
+    """
+    hlist = Hostlist()
+    if not args.computes:
+        args.computes = []
+    if args.jobids:
+        for jobid in args.jobids:
+            try:
+                nodelist = (
+                    flux.job.job_list_id(handle, JobID(jobid), ["nodelist"])
+                    .get_jobinfo()
+                    .nodelist
+                )
+            except FileNotFoundError:
+                sys.exit(f"Could not find job {jobid}")
+            except Exception as exc:
+                sys.exit(f"Lookup of job {jobid} failed: {exc}")
+            args.computes.append(nodelist)
+    aggregated_computes = Hostlist()
+    for computes in args.computes:
+        aggregated_computes.append(computes)
+    aggregated_computes.uniq()
+    for hostname in aggregated_computes:
+        try:
+            rabbit = mapping["computes"][hostname]
+        except KeyError:
+            sys.exit(f"Could not find compute {hostname}")
+        hlist.append(rabbit)
+    print(hlist.uniq().encode())
+
+
+def main():
+    """Construct a hostlist of rabbits or compute nodes, depending on arguments."""
+    args = read_args()
     if args.rabbits and (args.computes or args.jobids):
         sys.exit(
             "Both rabbits and computes or jobids cannot be looked up at the same time"
@@ -55,8 +90,8 @@ def main():
     if path is None:
         sys.exit("Flux is misconfigured, 'rabbit.mapping' key not set")
     try:
-        with open(path, "r", encoding="utf8") as fd:
-            mapping = json.load(fd)
+        with open(path, "r", encoding="utf8") as json_fd:
+            mapping = json.load(json_fd)
     except FileNotFoundError:
         sys.exit(
             f"Could not find file {path!r} specified under "
@@ -64,36 +99,17 @@ def main():
         )
     except json.JSONDecodeError as jexc:
         sys.exit(f"File {path!r} could not be parsed as JSON: {jexc}")
-    # construct and print the hostlist of rabbits
+    # construct and print the hostlist of rabbits or compute nodes,
+    # depending on arguments
     hlist = Hostlist()
     if not args.computes and not args.rabbits and not args.jobids:
-        # print out all rabbits
+        # no arguments: print out all rabbits
         hlist.append(mapping["rabbits"].keys())
         print(hlist.uniq().encode())
         return
-    if args.jobids:
-        for jobid in args.jobids:
-            try:
-                JobID(jobid)
-            except Exception as exc:
-                sys.exit(f"Could not interpret {jobid} as a flux Jobid: {exc}")
-            try:
-                nodelist = flux.job.job_list_id(handle, jobid, ["nodelist"]).nodelist
-            except FileNotFoundError:
-                sys.exit(f"Could not find job {jobid}")
-            args.computes.append(nodelist)
-    if args.computes:
-        aggregated_computes = Hostlist()
-        for computes in args.computes:
-            aggregated_computes.append(computes)
-        aggregated_computes.uniq()
-        for hostname in aggregated_computes:
-            try:
-                rabbit = mapping["computes"][hostname]
-            except KeyError:
-                sys.exit(f"Could not find compute {hostname}")
-            hlist.append(rabbit)
-        print(hlist.uniq().encode())
+    if args.jobids or args.computes:
+        # construct and print the hostlist of rabbits
+        map_to_rabbits(args, handle, mapping)
         return
     # construct and print the hostlist of compute nodes
     aggregated_rabbits = Hostlist()

--- a/t/t2001-getrabbit.t
+++ b/t/t2001-getrabbit.t
@@ -40,8 +40,11 @@ test_expect_success 'flux rabbitmapping works on computes' '
 '
 
 test_expect_success 'flux rabbitmapping parses arguments correctly' '
-	test_must_fail $CMD --computes &&
-	test_must_fail $CMD rzadams201 -c rzadams1001
+    test_must_fail $CMD --computes &&
+    test_must_fail $CMD rzadams201 -c rzadams1001 &&
+    test_must_fail $CMD rzadams201 -j foobar &&
+    test_must_fail $CMD -j foobar &&
+    test_must_fail $CMD -j 124.469
 '
 
 test_expect_success 'flux rabbitmapping works with second mapping' '
@@ -60,6 +63,18 @@ test_expect_success 'flux rabbitmapping works on computes with second mapping' '
 
 test_expect_success 'flux rabbitmapping works with no arguments' '
     test $($CMD) = tuolumne[201-272]
+'
+
+test_expect_success 'flux rabbitmapping works on jobids' '
+    echo "{\"computes\": {\"$(hostname)\": \"rabbit101\"}}" > local_rabbitmapping &&
+    echo "
+[rabbit]
+mapping = \"$(pwd)/local_rabbitmapping\"
+    " | flux config load &&
+    jobid=$(flux submit -n1 hostname) &&
+    $CMD -j ${jobid} &&
+    test $($CMD -j ${jobid}) = rabbit101 &&
+    test $($CMD -j ${jobid} -c $(hostname)) = rabbit101
 '
 
 test_done


### PR DESCRIPTION
Problem: `flux getrabbit` could save users a bit of work by accepting
job IDs.

Make it take job IDs.

Closes #268 .