### PR TITLE
`getrabbit`: jobid memo lookups

### DIFF
--- a/t/t2001-getrabbit.t
+++ b/t/t2001-getrabbit.t
@@ -77,15 +77,23 @@ test_expect_success 'flux rabbitmapping works in nested instances' '
 '
 
 test_expect_success 'flux rabbitmapping works on jobids' '
-    echo "{\"computes\": {\"$(hostname)\": \"rabbit101\"}}" > local_rabbitmapping &&
+    echo "{\"computes\": {\"$(hostname)\": \"rabbit219\"}}" > local_rabbitmapping &&
     echo "
 [rabbit]
 mapping = \"$(pwd)/local_rabbitmapping\"
     " | flux config load &&
-    jobid=$(flux submit -n1 hostname) &&
-    $CMD -j ${jobid} &&
+    jobid=$(flux submit -n1 sleep 1) &&
+    flux job memo ${jobid} rabbits=rabbit101
     test $($CMD -j ${jobid}) = rabbit101 &&
-    test $($CMD -j ${jobid} -c $(hostname)) = rabbit101
+    jobid=$(flux submit -n1 sleep 1) &&
+    flux job memo ${jobid} rabbits=rabbit[202-210] &&
+    test $($CMD -j ${jobid}) = rabbit[202-210] &&
+    test $($CMD -j ${jobid} -c $(hostname)) = rabbit[202-210,219]
+'
+
+test_expect_success 'flux rabbitmapping fails when job has no rabbit memo' '
+    jobid=$(flux submit -n1 hostname) &&
+    test_must_fail $CMD -j ${jobid}
 '
 
 test_done


### PR DESCRIPTION
Problem: https://github.com/flux-framework/flux-coral2/pull/272 added a way to look up the rabbits for a job. It works correctly in all cases, however in the future for lustre file systems, the rabbits associated with a job may no longer be the rabbits local to the compute nodes in the job.

There is already [a memo](https://github.com/flux-framework/flux-coral2/blob/8abdb50447589c20985777da9347ffb2db0891ba/src/modules/coral2_dws.py#L319) associated with every rabbit job, specifying what rabbits are used. That should be used instead.

Fixes #275 .