### PR TITLE
dws: remove create callback jobtap aux

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -152,9 +152,6 @@ static void create_cb (flux_future_t *f, void *arg)
                                  CREATE_DEP_NAME,
                                  "dws.create RPC returned failure");
         }
-    } else {
-        // add an aux specifying that a workflow has been created for the job
-        flux_jobtap_job_aux_set (args->p, args->id, "flux::dws_workflow_created", (void *)1, NULL);
     }
 }
 
@@ -444,9 +441,8 @@ static int cleanup_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *a
         current_job_exception (p, "Failed to unpack args");
         return -1;
     }
-    // check that the job has a DW attr section AND a workflow was successfully
-    // created for it
-    if (dw && flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::dws_workflow_created")) {
+    // check that the job has a DW attr section
+    if (dw) {
         if (!(create_args = calloc (1, sizeof (struct create_arg_t)))) {
             flux_log_error (h, "error allocating arg struct for %s", idf58 (id));
             current_job_exception (p, "error allocating arg struct");

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -44,6 +44,10 @@ _MIN_ALLOCATION_SIZE = 4  # minimum rabbit allocation size
 _EXITCODE_NORESTART = 3  # exit code indicating to systemd not to restart
 
 
+class UserError(Exception):
+    """Represents user errors."""
+
+
 def message_callback_wrapper(func):
     """Decorator for msg_watcher callbacks.
 
@@ -54,6 +58,8 @@ def message_callback_wrapper(func):
     def wrapper(handle, arg, msg, k8s_api):
         try:
             func(handle, arg, msg, k8s_api)
+        except UserError as exc:
+            handle.respond(msg, {"success": False, "errstr": str(exc)})
         except Exception as exc:
             try:
                 jobid = msg.payload["jobid"]
@@ -121,15 +127,15 @@ def create_cb(handle, _t, msg, arg):
             # remove any blank entries that resulted and add back "#DW "
             dw_directives = ["#DW " + dw.strip() for dw in dw_directives if dw.strip()]
     if not isinstance(dw_directives, list):
-        raise TypeError(
-            f"Malformed dw_directives, not list or string: {dw_directives!r}"
+        raise UserError(
+            f"Malformed #DW directives, not list or string: {dw_directives!r}"
         )
     for i, directive in enumerate(dw_directives):
         if directive.strip() in presets:
             dw_directives[i] = presets[directive.strip()]
         if restrict_persistent and "create_persistent" in directive:
             if userid != owner_uid(handle):
-                raise ValueError(
+                raise UserError(
                     "only the instance owner can create persistent file systems"
                 )
     workflow_name = WorkflowInfo.get_name(jobid)

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -19,8 +19,9 @@ args = parser.parse_args()
 def create_cb(fh, t, msg, arg):
     payload = {
         "success": not args.create_fail,
-        "errstr": "create RPC failed for test purposes",
     }
+    if args.create_fail:
+        payload["errstr"] = "create RPC failed for test purposes"
     fh.respond(msg, payload)
     print(f"Responded to create request with {payload}")
     if args.create_fail:
@@ -43,6 +44,7 @@ def setup_cb(fh, t, msg, arg):
     payload = {"success": not args.setup_fail}
     if args.setup_fail:
         payload["errstr"] = "setup RPC failed for test purposes"
+    print(f"Responded to setup request with {payload}")
     fh.respond(msg, payload)
     fh.rpc(
         "job-manager.dws.prolog-remove",
@@ -58,6 +60,7 @@ def post_run_cb(fh, t, msg, arg):
     if args.post_run_fail:
         payload["errstr"] = "post_run RPC failed for test purposes"
     fh.respond(msg, payload)
+    print(f"Responded to post_run request with {payload}")
     if not args.post_run_fail:
         fh.rpc(
             "job-manager.dws.epilog-remove",

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -24,7 +24,6 @@ def create_cb(fh, t, msg, arg):
     fh.respond(msg, payload)
     print(f"Responded to create request with {payload}")
     if args.create_fail:
-        fh.reactor_stop()
         return
     fh.rpc(
         "job-manager.dws.resource-update",


### PR DESCRIPTION
Similarly to #286, remove a jobtap aux that is set to indicate that a workflow has been created for a job. This aux would cause problems if the plugin were reloaded, so this PR re-architects things so that it is not needed.