### PR TITLE
dws-jobtap: rpc responses

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -602,9 +602,9 @@ static void resource_update_msg_cb (flux_t *h,
 {
     flux_plugin_t *p = (flux_plugin_t *)arg;
     json_int_t jobid;
-    json_t *resources = NULL, *errmsg, *constraints = NULL;
+    json_t *resources = NULL, *errmsg_json, *constraints = NULL;
     int copy_offload;
-    const char *errmsg_str, *exclude_str;
+    const char *errmsg = "", *exclude_str;
 
     if (flux_msg_unpack (msg,
                          "{s:I, s:o, s:b, s:o, s:s}",
@@ -615,31 +615,34 @@ static void resource_update_msg_cb (flux_t *h,
                          "copy-offload",
                          &copy_offload,
                          "errmsg",
-                         &errmsg,
+                         &errmsg_json,
                          "exclude",
                          &exclude_str)
         < 0) {
-        flux_log_error (h, "received malformed dws.resource-update RPC");
-        return;
+        errmsg = "received malformed dws.resource-update RPC";
+        goto error;
     }
     if (strlen (exclude_str) > 0) {
         if (!(constraints = generate_constraints (h, p, jobid, exclude_str))) {
-            flux_log_error (h, "Could not generate exclusion constraint for %s", idf58 (jobid));
-            raise_job_exception (p, jobid, PLUGIN_NAME, "Could not generate exclusion constraint");
-            return;
+            errmsg = "Could not generate exclusion constraint";
+            flux_log_error (h, "%s for %s", errmsg, idf58 (jobid));
+            raise_job_exception (p, jobid, PLUGIN_NAME, errmsg);
+            goto error;
         }
     }
-    if (!json_is_null (errmsg)) {
-        if (!(errmsg_str = json_string_value (errmsg))) {
-            flux_log_error (h,
-                            "received malformed dws.resource-update RPC, errmsg must be string or "
-                            "JSON null: %s",
-                            idf58 (jobid));
-            errmsg_str = "<could not fetch error message>";
+    if (!json_is_null (errmsg_json)) {
+        if (!(errmsg = json_string_value (errmsg_json))) {
+            raise_job_exception (p, jobid, PLUGIN_NAME, "<could not fetch error message>");
+            errmsg = "malformed dws.resource-update RPC, errmsg must be string or null";
+            json_decref (constraints);
+            goto error;
+        } else {
+            raise_job_exception (p, jobid, PLUGIN_NAME, errmsg);
+            json_decref (constraints);
+            if (flux_respond (h, msg, NULL) < 0)
+                flux_log_error (h, PLUGIN_NAME " %s: flux_respond", __FUNCTION__);
+            return;
         }
-        raise_job_exception (p, jobid, PLUGIN_NAME, errmsg_str);
-        json_decref (constraints);
-        return;
     } else if (flux_jobtap_job_aux_set (p,
                                         jobid,
                                         "flux::dws-copy-offload",
@@ -654,17 +657,27 @@ static void resource_update_msg_cb (flux_t *h,
                                                       "attributes.system.constraints",
                                                       constraints)
                       < 0) {
-        flux_log_error (h,
-                        "could not update jobspec for %s with new constraints and resources",
-                        idf58 (jobid));
+        errmsg = "could not update jobspec with new constraints and resources";
+        flux_log_error (h, "%s: %s", idf58 (jobid), errmsg);
         raise_job_exception (p, jobid, PLUGIN_NAME, "Internal error: failed to update jobspec");
         json_decref (constraints);
-        return;
+        goto error;
     }
     if (flux_jobtap_dependency_remove (p, jobid, CREATE_DEP_NAME) < 0) {
-        raise_job_exception (p, jobid, CREATE_DEP_NAME, "Failed to remove dependency for job");
-        return;
+        errmsg = "Failed to remove dependency for job";
+        raise_job_exception (p, jobid, CREATE_DEP_NAME, errmsg);
+        goto error;
     }
+
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond", __FUNCTION__);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, 0, errmsg) < 0) {
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond_error", __FUNCTION__);
+    }
+    return;
 }
 
 /*
@@ -681,10 +694,11 @@ static void prolog_remove_msg_cb (flux_t *h,
     json_t *env = NULL;
     int *prolog_active, junk_prolog_active = 1;
     int copy_offload = 0;
+    const char *errmsg = "";
 
     if (flux_msg_unpack (msg, "{s:I, s:o}", "id", &jobid, "variables", &env) < 0) {
-        flux_log_error (h, "received malformed dws.prolog-remove RPC");
-        return;
+        errmsg = "received malformed dws.prolog-remove RPC";
+        goto error;
     }
     if (flux_jobtap_job_aux_get (p, (flux_jobid_t)jobid, "flux::dws-copy-offload")) {
         copy_offload = 1;
@@ -706,10 +720,23 @@ static void prolog_remove_msg_cb (flux_t *h,
                                      copy_offload)
             < 0
         || flux_jobtap_job_aux_set (p, jobid, "flux::dws_run_started", (void *)1, NULL) < 0) {
-        dws_prolog_finish (h, p, jobid, 0, "failed to post dws_environment event", prolog_active);
-    } else {
-        dws_prolog_finish (h, p, jobid, 1, "success!", prolog_active);
+        errmsg = "failed to post dws_environment event";
+        dws_prolog_finish (h, p, jobid, 0, errmsg, prolog_active);
+        goto error;
     }
+    if (dws_prolog_finish (h, p, jobid, 1, "success!", prolog_active) < 0) {
+        errmsg = "failed to finish prolog";
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond", __FUNCTION__);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, 0, errmsg) < 0) {
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond_error", __FUNCTION__);
+    }
+    return;
 }
 
 /*
@@ -723,12 +750,25 @@ static void epilog_remove_msg_cb (flux_t *h,
 {
     flux_plugin_t *p = (flux_plugin_t *)arg;
     json_int_t jobid;
+    const char *errmsg = "";
 
     if (flux_msg_unpack (msg, "{s:I}", "id", &jobid) < 0) {
-        flux_log_error (h, "received malformed dws.epilog-remove RPC");
-        return;
+        errmsg = "received malformed dws.epilog-remove RPC";
+        goto error;
     }
-    dws_epilog_finish (h, p, jobid, 1, "success!");
+    if (dws_epilog_finish (h, p, jobid, 1, "success!") < 0) {
+        errmsg = "could not finish epilog";
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond", __FUNCTION__);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, 0, errmsg) < 0) {
+        flux_log_error (h, PLUGIN_NAME " %s: flux_respond_error", __FUNCTION__);
+    }
+    return;
 }
 
 static const struct flux_plugin_handler tab[] = {

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -48,6 +48,18 @@ class UserError(Exception):
     """Represents user errors."""
 
 
+def log_rpc_response(rpc, jobid):
+    """RPC callback for logging response."""
+    jobid = flux.job.JobID(jobid).f58plain
+    try:
+        msg = rpc.get()
+    except Exception as exc:
+        LOGGER.warning("RPC error for job %s: %s", jobid, repr(exc))
+    else:
+        if msg:
+            LOGGER.debug("RPC response for job %s was %s", jobid, msg)
+
+
 def message_callback_wrapper(func):
     """Decorator for msg_watcher callbacks.
 
@@ -142,7 +154,7 @@ def create_cb(handle, _t, msg, arg):
     spec = {
         "desiredState": "Proposal",
         "dwDirectives": dw_directives,
-        "jobID": flux.job.JobID(jobid).f58.replace("ƒ", "f"),
+        "jobID": flux.job.JobID(jobid).f58plain,
         "userID": userid,
         "groupID": pwd.getpwuid(userid).pw_gid,
         "wlmID": "flux",
@@ -166,7 +178,7 @@ def create_cb(handle, _t, msg, arg):
     handle.rpc(
         "job-manager.memo",
         payload={"id": jobid, "memo": {"rabbit_workflow": workflow_name}},
-    ).then(storage.log_rpc_response)
+    ).then(log_rpc_response, jobid)
 
 
 @message_callback_wrapper
@@ -194,7 +206,7 @@ def setup_cb(handle, _t, msg, k8s_api):
             "id": jobid,
             "memo": {"rabbits": Hostlist(nodes_per_nnf.keys()).encode()},
         },
-    ).then(storage.log_rpc_response)
+    ).then(log_rpc_response, jobid)
     k8s_api.patch_namespaced_custom_object(
         crd.COMPUTE_CRD.group,
         crd.COMPUTE_CRD.version,
@@ -253,7 +265,7 @@ def post_run_cb(handle, _t, msg, k8s_api):
             # workflow doesn't exist, presumably it was never created
             WorkflowInfo.remove(jobid)
             handle.rpc("job-manager.dws.epilog-remove", payload={"id": jobid}).then(
-                storage.log_rpc_response
+                log_rpc_response, jobid
             )
         else:
             # workflow does exist
@@ -350,7 +362,7 @@ def _workflow_state_change_cb_inner(workflow, winfo, handle, k8s_api, disable_fl
         # Attempt to remove the finalizer again in case the state transitioned
         # too quickly for it to be noticed earlier.
         handle.rpc("job-manager.dws.epilog-remove", payload={"id": jobid}).then(
-            storage.log_rpc_response
+            log_rpc_response, jobid
         )
         save_elapsed_time_to_kvs(handle, jobid, workflow)
         cleanup.delete_workflow(workflow)
@@ -395,7 +407,7 @@ def _workflow_state_change_cb_inner(workflow, winfo, handle, k8s_api, disable_fl
                     else ""
                 ),
             },
-        ).then(storage.log_rpc_response)
+        ).then(log_rpc_response, jobid)
         save_workflow_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "Setup"):
         # move workflow to next stage, DataIn
@@ -413,7 +425,7 @@ def _workflow_state_change_cb_inner(workflow, winfo, handle, k8s_api, disable_fl
                 "id": jobid,
                 "variables": workflow["status"].get("env", {}),
             },
-        ).then(storage.log_rpc_response)
+        ).then(log_rpc_response, jobid)
         save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, "PostRun"):
         # move workflow to next stage, DataOut

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -32,7 +32,6 @@ def create_cb(fh, t, msg, arg):
             "id": msg.payload["jobid"],
             "resources": msg.payload["resources"],
             "copy-offload": False,
-            "errmsg": None,
             "exclude": "",
         },
     )


### PR DESCRIPTION
Problem: the `dws-jobtap` plugin does not respond to the RPCs it
receives. This could lead to the buildup of matchtags in the sender,
in this case `coral2_dws.py`.

Add handling for responding to all RPCs received.