### PR TITLE
add libapinfo convenience library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,9 @@ AC_CHECK_FUNCS([gettimeofday localtime_r memset strchr strdup strerror strstr st
 # Checks for packages
 PKG_CHECK_MODULES([SODIUM], [libsodium >= 1.0.14], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
+PKG_CHECK_MODULES([PALS], [libpals], [HAVE_PALS=yes], [HAVE_PALS=no])
+
+AM_CONDITIONAL([HAVE_PALS], [test "x$HAVE_PALS" = "xyes"])
 
 ##
 # Project directories

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,7 @@ AC_CONFIG_FILES([Makefile
   src/common/Makefile
   src/common/libtap/Makefile
   src/common/libutil/Makefile
+  src/common/libapinfo/Makefile
   src/job-manager/Makefile
   src/job-manager/plugins/Makefile
   src/shell/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ AC_CONFIG_FILES([Makefile
   src/Makefile
   src/common/Makefile
   src/common/libtap/Makefile
+  src/common/libutil/Makefile
   src/job-manager/Makefile
   src/job-manager/plugins/Makefile
   src/shell/Makefile

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,3 +1,4 @@
 SUBDIRS = \
 	libutil \
-	libtap
+	libtap \
+	libapinfo

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,2 +1,3 @@
 SUBDIRS = \
+	libutil \
 	libtap

--- a/src/common/libapinfo/Makefile.am
+++ b/src/common/libapinfo/Makefile.am
@@ -1,0 +1,20 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	$(CODE_COVERAGE_CPPFLAGS)
+
+noinst_LTLIBRARIES = \
+	libapinfo.la
+
+libapinfo_la_SOURCES = \
+	apinfo.c \
+	apinfo.h \
+	apinfo1.c \
+	apinfo1.h \
+	apimpl.h

--- a/src/common/libapinfo/Makefile.am
+++ b/src/common/libapinfo/Makefile.am
@@ -18,3 +18,41 @@ libapinfo_la_SOURCES = \
 	apinfo1.c \
 	apinfo1.h \
 	apimpl.h
+
+TESTS =
+
+if HAVE_PALS
+TESTS += test_pals.t
+endif
+
+test_ldadd = \
+	$(builddir)/libapinfo.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(FLUX_CORE_LIBS) \
+	$(FLUX_HOSTLIST_LIBS) \
+	$(FLUX_TASKMAP_LIBS) \
+	$(FLUX_IDSET_LIBS)
+
+test_cppflags = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap \
+	$(FLUX_CORE_CFLAGS) \
+	$(FLUX_HOSTLIST_CFLAGS) \
+	$(FLUX_TASKMAP_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS)
+
+check_PROGRAMS = \
+	$(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_pals_t_SOURCES = test/pals.c
+test_pals_t_CPPFLAGS = \
+	$(PALS_CFLAGS) \
+	$(test_cppflags)
+test_pals_t_LDADD = \
+	$(PALS_LIBS) \
+	$(test_ldadd)

--- a/src/common/libapinfo/Makefile.am
+++ b/src/common/libapinfo/Makefile.am
@@ -19,7 +19,7 @@ libapinfo_la_SOURCES = \
 	apinfo1.h \
 	apimpl.h
 
-TESTS =
+TESTS = test_apinfo.t
 
 if HAVE_PALS
 TESTS += test_pals.t
@@ -56,3 +56,7 @@ test_pals_t_CPPFLAGS = \
 test_pals_t_LDADD = \
 	$(PALS_LIBS) \
 	$(test_ldadd)
+
+test_apinfo_t_SOURCES = test/apinfo.c
+test_apinfo_t_CPPFLAGS = $(test_cppflags)
+test_apinfo_t_LDADD = $(test_ldadd)

--- a/src/common/libapinfo/apimpl.h
+++ b/src/common/libapinfo/apimpl.h
@@ -1,0 +1,36 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBAPINFO_IMPL_H
+#define _LIBAPINFO_IMPL_H
+
+#include <stdio.h>
+#include <flux/core.h>
+#include <flux/hostlist.h>
+#include <flux/taskmap.h>
+
+struct apinfo_impl {
+    int version;
+    void *(*create) (void);
+    void (*destroy) (void *impl);
+    int (*write) (void *impl, FILE *stream);
+    int (*set_taskmap) (void *impl, const struct taskmap *map, int cpus_per_pe);
+    int (*set_hostlist) (void *impl, const struct hostlist *hosts);
+    int (*check) (void *impl, flux_error_t *error);
+    size_t (*get_size) (void *impl);
+    int (*get_nnodes) (void *impl);
+    int (*get_npes) (void *impl);
+    const struct hostlist *(*get_hostlist) (void *impl);
+    const struct taskmap *(*get_taskmap) (void *impl);
+};
+
+#endif  // !_LIBAPINFO_IMPL_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/apinfo.c
+++ b/src/common/libapinfo/apinfo.c
@@ -1,0 +1,170 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <flux/core.h>
+#include <flux/taskmap.h>
+#include <flux/hostlist.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "apinfo.h"
+#include "apimpl.h"
+
+extern struct apinfo_impl apinfo1;
+
+static struct apinfo_impl *itab[] = {
+    &apinfo1,
+};
+
+struct apinfo {
+    struct apinfo_impl *impl;
+    void *handle;
+};
+
+static struct apinfo_impl *lookup_impl (int version)
+{
+    for (int i = 0; i < sizeof (itab) / sizeof (itab[0]); i++) {
+        if (itab[i]->version == version)
+            return itab[i];
+    }
+    errno = ENOENT;
+    return NULL;
+}
+
+struct apinfo *apinfo_create (int version)
+{
+    struct apinfo *ap;
+
+    if (!(ap = calloc (1, sizeof (*ap))))
+        return NULL;
+    if (!(ap->impl = lookup_impl (version)))
+        goto error;
+    if (!(ap->handle = ap->impl->create ()))
+        goto error;
+    return ap;
+error:
+    apinfo_destroy (ap);
+    return NULL;
+}
+
+void apinfo_destroy (struct apinfo *ap)
+{
+    if (ap) {
+        int saved_errno = errno;
+        if (ap->impl)
+            ap->impl->destroy (ap->handle);
+        free (ap);
+        errno = saved_errno;
+    }
+}
+
+int apinfo_write (struct apinfo *ap, FILE *stream)
+{
+    if (!ap || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+    return ap->impl->write (ap->handle, stream);
+}
+
+int apinfo_put (struct apinfo *ap, const char *path)
+{
+    FILE *stream;
+    if (!ap || !path) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(stream = fopen (path, "w+")))
+        return -1;
+    if (apinfo_write (ap, stream) < 0) {
+        int saved_errno = errno;
+        (void)fclose (stream);
+        errno = saved_errno;
+        return -1;
+    }
+    if (fclose (stream) != 0)
+        return -1;
+    return 0;
+}
+
+int apinfo_set_hostlist (struct apinfo *ap, const struct hostlist *hosts)
+{
+    if (!ap || !hosts) {
+        errno = EINVAL;
+        return -1;
+    }
+    return ap->impl->set_hostlist (ap->handle, hosts);
+}
+
+int apinfo_set_taskmap (struct apinfo *ap, const struct taskmap *map, int cpus_per_pe)
+{
+    if (!ap || !map) {
+        errno = EINVAL;
+        return -1;
+    }
+    return ap->impl->set_taskmap (ap->handle, map, cpus_per_pe);
+}
+
+int apinfo_check (struct apinfo *ap, flux_error_t *error)
+{
+    if (!ap) {
+        errprintf (error, "invalid argument");
+        errno = EINVAL;
+        return -1;
+    }
+    return ap->impl->check (ap->handle, error);
+}
+
+size_t apinfo_get_size (struct apinfo *ap)
+{
+    if (!ap)
+        return 0;
+    return ap->impl->get_size (ap->handle);
+}
+
+int apinfo_get_nnodes (struct apinfo *ap)
+{
+    if (!ap)
+        return 0;
+    return ap->impl->get_nnodes (ap->handle);
+}
+
+int apinfo_get_npes (struct apinfo *ap)
+{
+    if (!ap)
+        return 0;
+    return ap->impl->get_npes (ap->handle);
+}
+
+const struct hostlist *apinfo_get_hostlist (struct apinfo *ap)
+{
+    if (!ap) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ap->impl->get_hostlist (ap->handle);
+}
+
+const struct taskmap *apinfo_get_taskmap (struct apinfo *ap)
+{
+    if (!ap) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ap->impl->get_taskmap (ap->handle);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/apinfo.h
+++ b/src/common/libapinfo/apinfo.h
@@ -1,0 +1,57 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBAPINFO_APINFO_H
+#define _LIBAPINFO_APINFO_H
+
+#include <flux/core.h>
+#include <flux/hostlist.h>
+#include <flux/taskmap.h>
+#include <stdio.h>
+
+/* Create/destroy an apinfo object of the specified version.
+ * All its sections are initially empty.
+ */
+struct apinfo *apinfo_create (int version);
+void apinfo_destroy (struct apinfo *ap);
+
+/* Write the apinfo object to a file/stream.
+ */
+int apinfo_write (struct apinfo *ap, FILE *stream);
+int apinfo_put (struct apinfo *ap, const char *path);
+
+/* Populate the nodes section with the specified hostlist,
+ * which must be in nodeid order.
+ */
+int apinfo_set_hostlist (struct apinfo *ap, const struct hostlist *hosts);
+
+/* Populate the cmd and pes sections using the specified taskmap.
+ * There is no MPMD support at this point so there is always one cmd element
+ * that is assigned to all PEs.
+ *
+ * cmd.cpus_per_pe is set to the value provided here.  What is this used for? -jg
+ */
+int apinfo_set_taskmap (struct apinfo *ap, const struct taskmap *map, int cpus_per_pe);
+
+/* Check the apinfo object for consistency.
+ */
+int apinfo_check (struct apinfo *ap, flux_error_t *error);
+
+/* The following accessors are intended for testing.
+ */
+size_t apinfo_get_size (struct apinfo *ap);
+int apinfo_get_npes (struct apinfo *ap);
+int apinfo_get_nnodes (struct apinfo *ap);
+const struct hostlist *apinfo_get_hostlist (struct apinfo *ap);
+const struct taskmap *apinfo_get_taskmap (struct apinfo *ap);
+
+#endif  // !_LIBAPINFO_APINFO_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/apinfo1.c
+++ b/src/common/libapinfo/apinfo1.c
@@ -1,0 +1,357 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <flux/hostlist.h>
+#include <flux/idset.h>
+#include <flux/taskmap.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "apinfo1.h"
+#include "apimpl.h"
+
+struct apinfo1 {
+    pals_header_t hdr;
+    pals_comm_profile_t *comms;
+    pals_cmd_t *cmds;
+    pals_pe_t *pes;
+    pals_node_t *nodes;
+    pals_nic_t *nics;
+
+    struct hostlist *hosts;  // cache for op_get_hostlist()
+    struct taskmap *map;     // cache for op_get_taskmap()
+};
+
+/* Assign section offsets after section element counts have been updated.
+ */
+static void set_offsets (struct apinfo1 *ap)
+{
+    pals_header_t *hdr = &ap->hdr;
+    size_t offset = sizeof (*hdr);
+
+    hdr->comm_profile_offset = offset;
+    offset += hdr->comm_profile_size * hdr->ncomm_profiles;
+    hdr->cmd_offset = offset;
+    offset += hdr->cmd_size * hdr->ncmds;
+    hdr->pe_offset = offset;
+    offset += hdr->pe_size * hdr->npes;
+    hdr->node_offset = offset;
+    offset += hdr->node_size * hdr->nnodes;
+    hdr->nic_offset = offset;
+    offset += hdr->nic_size * hdr->nnics;
+
+    hdr->total_size = offset;
+}
+
+/* Assign section element sizes.
+ */
+static void set_sizes (struct apinfo1 *ap)
+{
+    pals_header_t *hdr = &ap->hdr;
+
+    hdr->comm_profile_size = sizeof (ap->comms[0]);
+    hdr->cmd_size = sizeof (ap->cmds[0]);
+    hdr->pe_size = sizeof (ap->pes[0]);
+    hdr->node_size = sizeof (ap->nodes[0]);
+    hdr->nic_size = sizeof (ap->nics[0]);
+}
+
+/* Write the entire apinfo object to the specified stream.
+ */
+int op_write (void *handle, FILE *stream)
+{
+    struct apinfo1 *ap = handle;
+
+    if (fwrite (&ap->hdr, sizeof (ap->hdr), 1, stream) != 1)
+        return -1;
+    if (fwrite (ap->comms, ap->hdr.comm_profile_size, ap->hdr.ncomm_profiles, stream)
+        != ap->hdr.ncomm_profiles)
+        return -1;
+    if (fwrite (ap->cmds, ap->hdr.cmd_size, ap->hdr.ncmds, stream) != ap->hdr.ncmds)
+        return -1;
+    if (fwrite (ap->pes, ap->hdr.pe_size, ap->hdr.npes, stream) != ap->hdr.npes)
+        return -1;
+    if (fwrite (ap->nodes, ap->hdr.node_size, ap->hdr.nnodes, stream) != ap->hdr.nnodes)
+        return -1;
+    if (fwrite (ap->nics, ap->hdr.nic_size, ap->hdr.nnics, stream) != ap->hdr.nnics)
+        return -1;
+
+    return 0;
+}
+
+/* Find the maximum number of tasks per node.
+ * Helper for set_cmd()
+ */
+static int max_ntasks (const struct taskmap *map)
+{
+    int max_ntasks = 0;
+
+    for (int nodeid = 0; nodeid < taskmap_nnodes (map); nodeid++) {
+        int ntasks = taskmap_ntasks (map, nodeid);
+
+        if (max_ntasks < ntasks)
+            max_ntasks = ntasks;
+    }
+
+    return max_ntasks;
+}
+
+/* For now, no MPMD support - just one cmd element.
+ */
+static int set_cmd (struct apinfo1 *ap, const struct taskmap *map, int cpus_per_pe)
+{
+    int ncmds = 1;
+    pals_cmd_t *cmds;
+
+    if (!(cmds = calloc (ncmds, sizeof (*cmds))))
+        return -1;
+
+    cmds[0].npes = taskmap_total_ntasks (map);
+    cmds[0].pes_per_node = max_ntasks (map);
+    cmds[0].cpus_per_pe = cpus_per_pe;
+
+    free (ap->cmds);
+    ap->cmds = cmds;
+    ap->hdr.ncmds = ncmds;
+    set_offsets (ap);
+
+    return 0;
+}
+
+/* Given a global taskid and a nodeid, find the task's localidx.
+ * Helper for set_pes().
+ */
+static int localidx (const struct taskmap *map, int nodeid, int taskid)
+{
+    const struct idset *ids;
+    unsigned int id;
+    int localidx = 0;
+
+    if (!(ids = taskmap_taskids (map, nodeid)))
+        return -1;
+
+    id = idset_first (ids);
+    while (id != IDSET_INVALID_ID) {
+        if (id == taskid)
+            return localidx;
+        localidx++;
+        id = idset_next (ids, id);
+    }
+
+    return -1;
+}
+
+static int set_pes (struct apinfo1 *ap, const struct taskmap *map)
+{
+    int npes = taskmap_total_ntasks (map);
+    pals_pe_t *pes;
+
+    if (!(pes = calloc (npes, sizeof (*pes))))
+        return -1;
+
+    for (int taskid = 0; taskid < npes; taskid++) {
+        int nodeid = taskmap_nodeid (map, taskid);
+        pes[taskid].nodeidx = nodeid;
+        pes[taskid].localidx = localidx (map, nodeid, taskid);
+        pes[taskid].cmdidx = 0;
+    }
+
+    free (ap->pes);
+    ap->pes = pes;
+    ap->hdr.npes = npes;
+    set_offsets (ap);
+
+    return 0;
+}
+
+int op_set_taskmap (void *handle, const struct taskmap *map, int cpus_per_pe)
+{
+    struct apinfo1 *ap = handle;
+
+    if (set_pes (ap, map) < 0 || set_cmd (ap, map, cpus_per_pe) < 0)
+        return -1;
+
+    return 0;
+}
+
+int op_set_hostlist (void *handle, const struct hostlist *hosts)
+{
+    struct apinfo1 *ap = handle;
+    int nnodes = hostlist_count ((struct hostlist *)hosts);
+    pals_node_t *nodes;
+
+    if (!(nodes = calloc (nnodes, sizeof (*nodes))))
+        return -1;
+
+    for (int nodeid = 0; nodeid < nnodes; nodeid++) {
+        const char *host = hostlist_nth ((struct hostlist *)hosts, nodeid);
+        snprintf (nodes[nodeid].hostname, sizeof (nodes[nodeid].hostname), "%s", host);
+        nodes[nodeid].nid = nodeid;
+    }
+    free (ap->nodes);
+    ap->nodes = nodes;
+    ap->hdr.nnodes = nnodes;
+    set_offsets (ap);
+
+    return 0;
+}
+
+static int op_check (void *handle, flux_error_t *error)
+{
+    struct apinfo1 *ap = handle;
+
+    // check that the all nodeidx referenced from pes are valid
+    for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+        if (ap->pes[taskid].nodeidx >= ap->hdr.nnodes) {
+            errprintf (error, "pes[%d].nodeidx >= nnodes (%d)", taskid, ap->hdr.nnodes);
+            goto error;
+        }
+    }
+
+    // check that all nodes have a PE reference
+    for (int nodeid = 0; nodeid < ap->hdr.nnodes; nodeid++) {
+        bool found = false;
+        for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+            if (ap->pes[taskid].nodeidx == ap->nodes[nodeid].nid) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            errprintf (error,
+                       "no PE references nodeid %d (%s)",
+                       ap->nodes[nodeid].nid,
+                       ap->nodes[nodeid].hostname);
+            goto error;
+        }
+    }
+    return 0;
+error:
+    errno = EINVAL;
+    return -1;
+}
+
+static size_t op_get_size (void *handle)
+{
+    struct apinfo1 *ap = handle;
+    return ap->hdr.total_size;
+}
+
+static int op_get_nnodes (void *handle)
+{
+    struct apinfo1 *ap = handle;
+    return ap->hdr.nnodes;
+}
+
+static int op_get_npes (void *handle)
+{
+    struct apinfo1 *ap = handle;
+    return ap->hdr.npes;
+}
+
+static const struct hostlist *op_get_hostlist (void *handle)
+{
+    struct apinfo1 *ap = handle;
+    struct hostlist *hosts;
+
+    if (!(hosts = hostlist_create ()))
+        return NULL;
+    for (int nodeid = 0; nodeid < ap->hdr.nnodes; nodeid++) {
+        if (hostlist_append (hosts, ap->nodes[nodeid].hostname) < 0) {
+            hostlist_destroy (hosts);
+            return NULL;
+        }
+    }
+    hostlist_destroy (ap->hosts);
+    ap->hosts = hosts;
+    return ap->hosts;
+}
+
+/* N.B. this builds a taskmap that is equivalent to the original,
+ * but unoptimized.  For example:
+ * [[0,2,2,1]] => [[0,1,2,1],[1,1,2,1]]
+ * [[0,4,4,1]] => [[0,1,4,1],[1,1,4,1],[2,1,4,1],[3,1,4,1]]
+ *
+ * To check that the two are equivalent, call taskmap_encode()
+ * with the TASKMAP_ENCODE_RAW flag and compare the result.
+ */
+const struct taskmap *op_get_taskmap (void *handle)
+{
+    struct apinfo1 *ap = handle;
+    struct taskmap *map;
+
+    if (!(map = taskmap_create ()))
+        return NULL;
+    for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+        if (taskmap_append (map, ap->pes[taskid].nodeidx, 1, 1) < 0) {
+            taskmap_destroy (map);
+            return NULL;
+        }
+    }
+    taskmap_destroy (ap->map);
+    ap->map = map;
+    return ap->map;
+}
+
+static void *op_create (void)
+{
+    struct apinfo1 *ap;
+
+    if (!(ap = calloc (1, sizeof (*ap))))
+        return NULL;
+
+    ap->hdr.version = PALS_APINFO_VERSION;
+    set_sizes (ap);
+    set_offsets (ap);
+
+    return ap;
+}
+
+static void op_destroy (void *handle)
+{
+    struct apinfo1 *ap = handle;
+
+    if (ap) {
+        int saved_errno = errno;
+        taskmap_destroy (ap->map);
+        hostlist_destroy (ap->hosts);
+        free (ap->comms);
+        free (ap->cmds);
+        free (ap->pes);
+        free (ap->nodes);
+        free (ap->nics);
+        free (ap);
+        errno = saved_errno;
+    }
+}
+
+struct apinfo_impl apinfo1 = {
+    .version = PALS_APINFO_VERSION,
+    .create = op_create,
+    .destroy = op_destroy,
+    .write = op_write,
+    .set_hostlist = op_set_hostlist,
+    .set_taskmap = op_set_taskmap,
+    .check = op_check,
+    .get_size = op_get_size,
+    .get_nnodes = op_get_nnodes,
+    .get_npes = op_get_npes,
+    .get_hostlist = op_get_hostlist,
+    .get_taskmap = op_get_taskmap,
+};
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/apinfo1.h
+++ b/src/common/libapinfo/apinfo1.h
@@ -1,0 +1,84 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBAPINFO_APINFO1_H
+#define _LIBAPINFO_APINFO1_H
+
+/* Application file format version */
+#define PALS_APINFO_VERSION 1
+
+/* File header structure */
+typedef struct {
+    int version;               // Set to PALS_APINFO_VERSION
+    size_t total_size;         // Size of the whole file in bytes
+    size_t comm_profile_size;  // sizeof(pals_comm_profile_t)
+    // offset from beginning of file to the first comm_profile_t
+    size_t comm_profile_offset;
+    // number of comm_profile_t (not used yet, set to 0)
+    int ncomm_profiles;
+    size_t cmd_size;  // sizeof(pals_cmd_t)
+    // offset from beginning of file to the first pals_cmd_t
+    size_t cmd_offset;
+    int ncmds;       // number of commands (MPMD programs)
+    size_t pe_size;  // sizeof(pals_pe_t)
+    // offset from beginning of file to the first pals_pe_t
+    size_t pe_offset;
+    int npes;          // number of PEs (processes/ranks)
+    size_t node_size;  // sizeof(pals_node_t)
+    // offset from beginning of file to the first pals_node_t
+    size_t node_offset;
+    int nnodes;       // number of nodes
+    size_t nic_size;  // sizeof(pals_nic_t)
+    // offset from beginning of file to the first pals_nic_t
+    size_t nic_offset;
+    int nnics;  // number of NICs (not used yet, set to 0)
+} pals_header_t;
+
+/* Network communication profile structure */
+typedef struct {
+    char tokenid[40];    /* Token UUID */
+    int vni;             /* VNI associated with this token */
+    int vlan;            /* VLAN associated with this token */
+    int traffic_classes; /* Bitmap of allowed traffic classes */
+} pals_comm_profile_t;
+
+/* MPMD command information structure */
+typedef struct {
+    int npes;         /* Number of tasks in this command */
+    int pes_per_node; /* Number of tasks per node */
+    int cpus_per_pe;  /* Number of CPUs per task */
+} pals_cmd_t;
+
+/* PE (i.e. task) information structure */
+typedef struct {
+    int localidx; /* Node-local PE index */
+    int cmdidx;   /* Command index for this PE */
+    int nodeidx;  /* Node index this PE is running on */
+} pals_pe_t;
+
+/* Node information structure */
+typedef struct {
+    int nid;           /* Node ID */
+    char hostname[64]; /* Node hostname */
+} pals_node_t;
+
+/* NIC address type */
+typedef enum { PALS_ADDR_IPV4, PALS_ADDR_IPV6, PALS_ADDR_MAC } pals_address_type_t;
+
+/* NIC information structure */
+typedef struct {
+    int nodeidx;                      /* Node index this NIC belongs to */
+    pals_address_type_t address_type; /* Address type for this NIC */
+    char address[40];                 /* Address of this NIC */
+} pals_nic_t;
+
+#endif  // !_LIBAPINFO_APINFO1_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/test/apinfo.c
+++ b/src/common/libapinfo/test/apinfo.c
@@ -1,0 +1,251 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <unistd.h>
+#include <flux/taskmap.h>
+#include <flux/hostlist.h>
+
+#include "tap.h"
+
+#include "apinfo.h"
+
+struct input {
+    /* inputs */
+    int cpus_per_pe;
+    const char *hosts;
+    const char *taskmap;
+    /* expected outputs */
+    int nnodes;
+    int npes;
+};
+
+struct input good[] = {
+    // RFC 34 taskmap test vectors */
+    {1, "test0", "[[0,1,1,1]]", 1, 1},
+    {1, "test[0-1]", "[[0,2,1,1]]", 2, 2},
+    {1, "test0", "[[0,1,2,1]]", 1, 2},
+    {1, "test[0-1]", "[[0,2,2,1]]", 2, 4},
+    {1, "test[0-1]", "[[0,2,1,2]]", 2, 4},
+    {1, "test[0-1]", "[[1,1,1,1],[0,1,1,1]]", 2, 2},
+    {1, "test[0-3]", "[[0,4,4,1]]", 4, 16},
+    {1, "test[0-3]", "[[0,4,1,4]]", 4, 16},
+    {1, "test[0-3]", "[[0,4,2,2]]", 4, 16},
+    {1, "test[0-5]", "[[0,4,2,1],[4,2,4,1]]", 6, 16},
+    {1, "test[0-5]", "[[0,6,1,2],[4,2,1,2]]", 6, 16},
+    {1, "test[0-5]", "[[5,1,4,1],[4,1,4,1],[3,1,2,1],[2,1,2,1],[1,1,2,1],[0,1,2,1]]", 6, 16},
+    {1, "test[0-7]", "[[0,5,2,1],[6,1,2,1],[5,1,2,1],[7,1,2,1]]", 8, 16},
+    {1, "test[0-3]", "[[3,1,4,1],[2,1,4,1],[1,1,4,1],[0,1,4,1]]", 4, 16},
+};
+
+bool equal_hostlists (struct hostlist *hosts1, struct hostlist *hosts2)
+{
+    const char *host1 = hostlist_first (hosts1);
+    const char *host2 = hostlist_first (hosts2);
+    while (host1 || host2) {
+        if (!host1 || !host2 || strcmp (host1, host2) != 0)
+            return false;
+        host1 = hostlist_next (hosts1);
+        host2 = hostlist_next (hosts2);
+    }
+    return true;
+}
+
+// see note in apinfo1.op_get_taskmap()
+bool equal_taskmaps (const struct taskmap *map1, const struct taskmap *map2)
+{
+    char *m1 = taskmap_encode (map1, TASKMAP_ENCODE_RAW);
+    char *m2 = taskmap_encode (map2, TASKMAP_ENCODE_RAW);
+    if (!m1 || !m2 || strcmp (m1, m2) != 0) {
+        return false;
+    }
+    return true;
+}
+
+int check (struct apinfo *ap, struct input *in, const char *path)
+{
+    struct hostlist *hosts = hostlist_decode (in->hosts);
+    struct taskmap *map = taskmap_decode (in->taskmap, NULL);
+    flux_error_t error;
+    if (!hosts || !map)
+        BAIL_OUT ("error decoding test input");
+    if (apinfo_set_hostlist (ap, hosts) < 0)
+        return -1;
+    if (apinfo_set_taskmap (ap, map, in->cpus_per_pe) < 0)
+        return -1;
+    if (apinfo_get_nnodes (ap) != in->nnodes)
+        return -1;
+    if (apinfo_get_npes (ap) != in->npes)
+        return -1;
+    if (!equal_hostlists ((struct hostlist *)apinfo_get_hostlist (ap), hosts))
+        return -1;
+    if (!equal_taskmaps (apinfo_get_taskmap (ap), map))
+        return -1;
+    if (apinfo_check (ap, &error) < 0) {
+        diag ("%s", error.text);
+        return -1;
+    }
+    if (apinfo_put (ap, path) < 0)
+        return -1;
+    taskmap_destroy (map);
+    hostlist_destroy (hosts);
+    return 0;
+}
+
+void test_good (const char *path)
+{
+    struct apinfo *ap;
+
+    if (!(ap = apinfo_create (1)))
+        BAIL_OUT ("apinfo_create failed");
+
+    for (int i = 0; i < sizeof (good) / sizeof (good[0]); i++) {
+        int rc = check (ap, &good[i], path);
+        ok (rc == 0, "checked %s %s %d", good[i].hosts, good[i].taskmap, good[i].cpus_per_pe);
+    }
+    apinfo_destroy (ap);
+}
+
+void test_empty (const char *path)
+{
+    struct apinfo *ap;
+    struct stat sb;
+
+    ok ((ap = apinfo_create (1)) != NULL, "apinfo_create version=1 works");
+
+    ok (apinfo_check (ap, NULL) == 0, "apinfo_check says good!");
+
+    ok (apinfo_put (ap, path) == 0, "apinfo_put works");
+
+    ok (stat (path, &sb) == 0 && sb.st_size == apinfo_get_size (ap),
+        "file size matches apinfo_get_size");
+
+    apinfo_destroy (ap);
+}
+
+void test_check (const char *path)
+{
+    struct apinfo *ap;
+    struct hostlist *hosts;
+    struct taskmap *map;
+    flux_error_t error;
+
+    if (!((ap = apinfo_create (1))))
+        BAIL_OUT ("apinfo_create failed");
+    if (!((map = taskmap_decode ("[[0,2,1,1]]", NULL))))
+        BAIL_OUT ("taskmap_decode failed");
+    if (!((hosts = hostlist_decode ("test[0-3]"))))
+        BAIL_OUT ("taskmap_decode failed");
+    if (apinfo_set_taskmap (ap, map, 1) < 0)
+        BAIL_OUT ("apinfo_set_taskmap failed");
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (apinfo_check (ap, &error) < 0 && errno == EINVAL,
+        "apinfo_check finds pe referencing invalid nodeid");
+    diag ("%s", error.text);
+
+    if (apinfo_set_hostlist (ap, hosts) < 0)
+        BAIL_OUT ("apinfo_set_hostlist failed");
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (apinfo_check (ap, &error) < 0 && errno == EINVAL, "apinfo_check finds unreferenced nodeid");
+    diag ("%s", error.text);
+
+    apinfo_destroy (ap);
+    taskmap_destroy (map);
+    hostlist_destroy (hosts);
+}
+
+void test_inval (const char *path)
+{
+    struct apinfo *ap;
+    struct hostlist *hosts;
+    struct taskmap *map;
+    flux_error_t error;
+
+    if (!((ap = apinfo_create (1))))
+        BAIL_OUT ("apinfo_create failed");
+    if (!((hosts = hostlist_decode ("test[0-1]"))))
+        BAIL_OUT ("hostlist_decode failed");
+    if (!((map = taskmap_decode ("[[0,2,1,1]]", NULL))))
+        BAIL_OUT ("taskmap_decode failed");
+
+    errno = 0;
+    ok (apinfo_create (42) == NULL && errno == ENOENT,
+        "apinfo_create version=42 fails with ENOENT");
+    errno = 0;
+    error.text[0] = '\0';
+    ok (apinfo_check (NULL, &error) < 0 && errno == EINVAL,
+        "apinfo_check ap=NULL fails with EINVAL");
+    diag ("%s", error.text);
+    errno = 0;
+    ok (apinfo_write (NULL, stdout) < 0 && errno == EINVAL,
+        "apinfo_write ap=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_write (ap, NULL) < 0 && errno == EINVAL,
+        "apinfo_write stream=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_put (NULL, "foo") < 0 && errno == EINVAL, "apinfo_put ap=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_put (ap, NULL) < 0 && errno == EINVAL, "apinfo_put path=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_set_hostlist (ap, NULL) < 0 && errno == EINVAL,
+        "apinfo_set_hostlist hosts=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_set_hostlist (NULL, hosts) < 0 && errno == EINVAL,
+        "apinfo_set_hostlist ap=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_get_hostlist (NULL) == NULL && errno == EINVAL,
+        "apinfo_get_hostlist ap=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_set_taskmap (NULL, map, 1) < 0 && errno == EINVAL,
+        "apinfo_set_taskmap ap=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_set_taskmap (ap, NULL, 1) < 0 && errno == EINVAL,
+        "apinfo_set_taskmap map=NULL fails with EINVAL");
+    errno = 0;
+    ok (apinfo_get_taskmap (NULL) == NULL && errno == EINVAL,
+        "apinfo_get_taskmap map=NULL fails with EINVAL");
+
+    lives_ok ({ apinfo_destroy (NULL); }, "apinfo_destroy NULL doesn't cash");
+
+    hostlist_destroy (hosts);
+    taskmap_destroy (map);
+    apinfo_destroy (ap);
+}
+
+int main (int argc, char *argv[])
+{
+    char path[1024] = "/tmp/apinfo.XXXXXX";
+
+    plan (NO_PLAN);
+
+    if (mkstemp (path) < 0)
+        BAIL_OUT ("mkstemp failed");
+
+    test_empty (path);
+    test_good (path);
+    test_check (path);
+    test_inval (path);
+
+    unlink (path);
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/test/pals.c
+++ b/src/common/libapinfo/test/pals.c
@@ -1,0 +1,183 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <unistd.h>
+#include <flux/taskmap.h>
+#include <flux/hostlist.h>
+#include <pals.h>
+
+#include "tap.h"
+
+#include "apinfo.h"
+
+void empty_apinfo1 (char *path)
+{
+    struct apinfo *ap;
+    pals_rc_t rc;
+    pals_state_t *state;
+
+    if (!(ap = apinfo_create (1)))
+        BAIL_OUT ("apinfo_create version=1 failed");
+    if (apinfo_put (ap, path) < 0)
+        BAIL_OUT ("apinfo_put path=simple failed");
+    apinfo_destroy (ap);
+    diag ("created %s: empty", path);
+
+    rc = pals_init2 (&state);
+    ok (rc == PALS_OK, "pals_init2 is OK");
+
+    int nodeidx = -1;
+    rc = pals_get_nodeidx (state, &nodeidx);
+    ok (rc == PALS_OK && nodeidx == 0, "pals_get_nodeidx is OK and returned 0");
+
+    int peidx = -1;
+    rc = pals_get_peidx (state, &peidx);
+    ok (rc == PALS_OK && peidx == 0, "pals_get_peidx is OK and returned 0");
+
+    int nnodes = -1;
+    rc = pals_get_num_nodes (state, &nnodes);
+    ok (rc == PALS_OK && nnodes == 0, "pals_get_nnodes is OK and returned 0");
+
+    int ncmds = -1;
+    rc = pals_get_num_cmds (state, &ncmds);
+    ok (rc == PALS_OK && ncmds == 0, "pals_get_num_cmds is OK and returned 0");
+
+    int npes = -1;
+    rc = pals_get_num_pes (state, &npes);
+    ok (rc == PALS_OK && npes == 0, "pals_get_num_pes is OK and returned 0");
+
+    int ncomm_profiles = -1;
+    rc = pals_get_num_comm_profiles (state, &ncomm_profiles);
+    ok (rc == PALS_OK && ncomm_profiles == 0, "pals_get_num_comm_profiles is OK and returned 0");
+
+    int nnics = -1;
+    rc = pals_get_num_nics (state, &nnics);
+    ok (rc == PALS_OK && nnics == 0, "pals_get_num_nics is OK and returned 0");
+
+    nnics = -1;
+    rc = pals_get_num_hsn_nics (state, &nnics);
+    ok (rc == PALS_OK && nnics == 0, "pals_get_num_hsn_nics is OK and returned 0");
+
+    rc = pals_fini (state);
+    ok (rc == PALS_OK, "pals_fini is OK");
+}
+
+void simple_apinfo1 (char *path)
+{
+    struct apinfo *ap;
+    pals_rc_t rc;
+    pals_state_t *state;
+    struct hostlist *hosts;
+    struct taskmap *map;
+
+    if (!(ap = apinfo_create (1)))
+        BAIL_OUT ("apinfo_create version=1 failed");
+    if (!(hosts = hostlist_decode ("test[0-3]")) || apinfo_set_hostlist (ap, hosts) < 0)
+        BAIL_OUT ("error setting hostlist");
+    if (!(map = taskmap_decode ("[[0,4,256,1]]", NULL)) || apinfo_set_taskmap (ap, map, 1) < 0)
+        BAIL_OUT ("error setting taskmap");
+    if (apinfo_put (ap, path) < 0)
+        BAIL_OUT ("apinfo_put path=simple failed");
+    apinfo_destroy (ap);
+    hostlist_destroy (hosts);
+    taskmap_destroy (map);
+    diag ("created %s: 4n1024p, block distribution", path);
+
+    rc = pals_init2 (&state);
+    ok (rc == PALS_OK, "pals_init2 is OK");
+
+    int nodeidx = -1;
+    rc = pals_get_nodeidx (state, &nodeidx);
+    ok (rc == PALS_OK && nodeidx == 0, "pals_get_nodeidx is OK and returned 0");
+
+    int peidx = -1;
+    rc = pals_get_peidx (state, &peidx);
+    ok (rc == PALS_OK && peidx == 0, "pals_get_peidx failed");
+
+    int nnodes = -1;
+    rc = pals_get_num_nodes (state, &nnodes);
+    ok (rc == PALS_OK && nnodes == 4, "pals_get_nnodes is OK and returned 4");
+
+    nnodes = -1;
+    pals_node_t *nodes = NULL;
+    rc = pals_get_nodes (state, &nodes, &nnodes);
+    ok (rc == PALS_OK && nnodes == 4 && nodes != NULL && nodes[0].nid == 0
+            && !strcmp (nodes[0].hostname, "test0") && nodes[1].nid == 1
+            && !strcmp (nodes[1].hostname, "test1") && nodes[2].nid == 2
+            && !strcmp (nodes[2].hostname, "test2") && nodes[3].nid == 3
+            && !strcmp (nodes[3].hostname, "test3"),
+        "pals_get_nodes is OK and returned expected content");
+
+    int ncmds = -1;
+    rc = pals_get_num_cmds (state, &ncmds);
+    ok (rc == PALS_OK && ncmds == 1, "pals_get_num_cmds is OK and returned 1");
+
+    ncmds = 0;
+    pals_cmd_t *cmds = NULL;
+    rc = pals_get_cmds (state, &cmds, &ncmds);
+    ok (rc == PALS_OK && ncmds == 1 && cmds != NULL && cmds[0].npes == 1024
+            && cmds[0].pes_per_node == 256 && cmds[0].cpus_per_pe == 1,
+        "pals_get_cmds is OK and returned expected content");
+
+    int npes = -1;
+    rc = pals_get_num_pes (state, &npes);
+    ok (rc == PALS_OK && npes == 1024, "pals_get_num_pes is OK and returned 1024");
+
+    // just spot check this one
+    npes = 0;
+    pals_pe_t *pes = NULL;
+    rc = pals_get_pes (state, &pes, &npes);
+    ok (rc == PALS_OK && npes == 1024 && pes != NULL && pes[0].localidx == 0 && pes[0].cmdidx == 0
+            && pes[0].nodeidx == 0 && pes[513].localidx == 1 && pes[513].cmdidx == 0
+            && pes[513].nodeidx == 2 && pes[1023].localidx == 255 && pes[1023].cmdidx == 0
+            && pes[1023].nodeidx == 3,
+        "pals_get_pes is OK and returned expected content");
+
+    int ncomm_profiles = -1;
+    rc = pals_get_num_comm_profiles (state, &ncomm_profiles);
+    ok (rc == PALS_OK && ncomm_profiles == 0, "pals_get_num_comm_profiles is OK and returned 0");
+
+    int nnics = -1;
+    rc = pals_get_num_nics (state, &nnics);
+    ok (rc == PALS_OK && nnics == 0, "pals_get_num_nics is OK and returned 0");
+
+    nnics = -1;
+    rc = pals_get_num_hsn_nics (state, &nnics);
+    ok (rc == PALS_OK && nnics == 0, "pals_get_num_hsn_nics is OK and returned 0");
+
+    rc = pals_fini (state);
+    ok (rc == PALS_OK, "pals_fini is OK");
+}
+
+int main (int argc, char *argv[])
+{
+    char path[1024] = "/tmp/apinfo.XXXXXX";
+
+    plan (NO_PLAN);
+
+    if (mkstemp (path) < 0)
+        BAIL_OUT ("mkstemp failed");
+    if (setenv ("PALS_APINFO", path, 1) < 0 || setenv ("PALS_RANKID", "0", 1) < 0
+        || setenv ("PALS_NODEID", "0", 1) < 0)
+        BAIL_OUT ("error setting PALS environment variables");
+
+    empty_apinfo1 (path);
+    simple_apinfo1 (path);
+
+    unlink (path);
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -1,0 +1,15 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	$(CODE_COVERAGE_CPPFLAGS)
+
+noinst_LTLIBRARIES = libutil.la
+
+libutil_la_SOURCES = \
+	errprintf.h \
+	errprintf.c

--- a/src/common/libutil/errprintf.c
+++ b/src/common/libutil/errprintf.c
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+#include "errprintf.h"
+
+int verrprintf (flux_error_t *errp, const char *fmt, va_list ap)
+{
+    if (errp) {
+        int saved_errno = errno;
+        memset (errp->text, 0, sizeof (errp->text));
+        if (fmt) {
+            int n;
+            n = vsnprintf (errp->text, sizeof (errp->text), fmt, ap);
+            if (n > sizeof (errp->text))
+                errp->text[sizeof (errp->text) - 2] = '+';
+        }
+        errno = saved_errno;
+    }
+    return -1;
+}
+
+int errprintf (flux_error_t *errp, const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    verrprintf (errp, fmt, ap);
+    va_end (ap);
+    return -1;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/errprintf.h
+++ b/src/common/libutil/errprintf.h
@@ -1,0 +1,38 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_ERRPRINTF_H
+#define _UTIL_ERRPRINTF_H
+
+#include <flux/core.h>
+#include <stdarg.h>
+#include <string.h>
+
+/*
+ *  Utility function for printing an error to a flux_error_t container.
+ *  This function always returns -1 as a convenience in error handling
+ *   functions, e.g.
+ *
+ *  return errprintf (errp, "Function failed");
+ *
+ */
+int errprintf (flux_error_t *errp, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+
+int verrprintf (flux_error_t *errp, const char *fmt, va_list ap);
+
+static inline void err_init (flux_error_t *errp)
+{
+    if (errp)
+        memset (errp->text, 0, sizeof (errp->text));
+}
+
+#endif /* !_UTIL_ERRPRINTF_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -6,6 +6,7 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
+	-I$(top_srcdir) \
 	$(FLUX_CORE_CFLAGS) \
 	$(FLUX_HOSTLIST_CFLAGS) \
 	$(FLUX_TASKMAP_CFLAGS) \
@@ -24,6 +25,8 @@ cray_pals_la_SOURCES = cray_pals.c \
 	eventlog_helpers.h
 cray_pals_la_CPPFLAGS = $(AM_CPPFLAGS)
 cray_pals_la_LIBADD = \
+	$(top_builddir)/src/common/libapinfo/libapinfo.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(FLUX_CORE_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
 	$(FLUX_TASKMAP_LIBS) \

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -466,7 +466,7 @@ int flux_plugin_init (flux_plugin_t *p)
         // otherwise libPALS might pick up and try to use them
         return unset_pals_env (shell);
 
-    shell_debug ("enabled");
+    shell_debug ("enabled (version %s)", PACKAGE_VERSION);
 
     // If -o cray-pals.no-edit-env is was specified set a flag for later
     no_edit_env = 0;


### PR DESCRIPTION
This pulls out the apinfo v1 stuff from the `cray_pals` shell plugin, refactors it, and puts it in a convenience library with unit tests.  I think it'll be pretty easy to add apinfo v5 support as proposed in #282 with a way to fall back to the well tested v1 at runtime.

One thing I did not quite understand - what is the `cpus_per_pe` parameter used for?  I can't for the life of me think why a PMI would need to know how many cpus per task there are, but it'll probably be a "duh" moment when someone tells me.

I did add a test using `libpals` as suggested by HPE although obviously we can't run it in CI at this point.  (It isn't compiled if libpals is unavailable).

Marking WIP pending end to end manual  testing on El Cap.