### PR TITLE
cray_pals: use apinfo v5

### DIFF
--- a/src/common/libapinfo/Makefile.am
+++ b/src/common/libapinfo/Makefile.am
@@ -17,6 +17,8 @@ libapinfo_la_SOURCES = \
 	apinfo.h \
 	apinfo1.c \
 	apinfo1.h \
+	apinfo5.c \
+	apinfo5.h \
 	apimpl.h
 
 TESTS = test_apinfo.t

--- a/src/common/libapinfo/apinfo.c
+++ b/src/common/libapinfo/apinfo.c
@@ -24,9 +24,11 @@
 #include "apimpl.h"
 
 extern struct apinfo_impl apinfo1;
+extern struct apinfo_impl apinfo5;
 
 static struct apinfo_impl *itab[] = {
     &apinfo1,
+    &apinfo5,
 };
 
 struct apinfo {

--- a/src/common/libapinfo/apinfo1.c
+++ b/src/common/libapinfo/apinfo1.c
@@ -72,7 +72,7 @@ static void set_sizes (struct apinfo1 *ap)
 
 /* Write the entire apinfo object to the specified stream.
  */
-int op_write (void *handle, FILE *stream)
+static int op_write (void *handle, FILE *stream)
 {
     struct apinfo1 *ap = handle;
 
@@ -178,7 +178,7 @@ static int set_pes (struct apinfo1 *ap, const struct taskmap *map)
     return 0;
 }
 
-int op_set_taskmap (void *handle, const struct taskmap *map, int cpus_per_pe)
+static int op_set_taskmap (void *handle, const struct taskmap *map, int cpus_per_pe)
 {
     struct apinfo1 *ap = handle;
 
@@ -188,7 +188,7 @@ int op_set_taskmap (void *handle, const struct taskmap *map, int cpus_per_pe)
     return 0;
 }
 
-int op_set_hostlist (void *handle, const struct hostlist *hosts)
+static int op_set_hostlist (void *handle, const struct hostlist *hosts)
 {
     struct apinfo1 *ap = handle;
     int nnodes = hostlist_count ((struct hostlist *)hosts);
@@ -289,7 +289,7 @@ static const struct hostlist *op_get_hostlist (void *handle)
  * To check that the two are equivalent, call taskmap_encode()
  * with the TASKMAP_ENCODE_RAW flag and compare the result.
  */
-const struct taskmap *op_get_taskmap (void *handle)
+static const struct taskmap *op_get_taskmap (void *handle)
 {
     struct apinfo1 *ap = handle;
     struct taskmap *map;

--- a/src/common/libapinfo/apinfo5.c
+++ b/src/common/libapinfo/apinfo5.c
@@ -1,0 +1,374 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <flux/hostlist.h>
+#include <flux/idset.h>
+#include <flux/taskmap.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "apinfo5.h"
+#include "apimpl.h"
+
+struct apinfo5 {
+    pals_header_t hdr;
+    pals_comm_profile_t *comms;
+    pals_cmd_t *cmds;
+    pals_pe_t *pes;
+    pals_node_t *nodes;
+    pals_hsn_nic_t *nics;
+    pals_distance_t *dist;
+    int *status;
+
+    // missing from pals_header_t
+    int ndist;
+    int nstatus;
+    size_t status_size;
+
+    struct hostlist *hosts;  // cache for op_get_hostlist()
+    struct taskmap *map;     // cache for op_get_taskmap()
+};
+
+/* Assign section offsets after section element counts have been updated.
+ */
+static void set_offsets (struct apinfo5 *ap)
+{
+    pals_header_t *hdr = &ap->hdr;
+    size_t offset = sizeof (*hdr);
+
+    hdr->comm_profile_offset = offset;
+    offset += hdr->comm_profile_size * hdr->ncomm_profiles;
+    hdr->cmd_offset = offset;
+    offset += hdr->cmd_size * hdr->ncmds;
+    hdr->pe_offset = offset;
+    offset += hdr->pe_size * hdr->npes;
+    hdr->node_offset = offset;
+    offset += hdr->node_size * hdr->nnodes;
+    hdr->nic_offset = offset;
+    offset += hdr->nic_size * hdr->nnics;
+
+    /* Breaking from the pattern above:
+     - pals_header_t does not contain "ndist", so set dist_offset=0 if unused
+     - pals_header_t does not contain "nstatus", so set status_offset=0 if unused.
+     * pals_header_t does not contain "status_size"
+     */
+    hdr->dist_offset = ap->ndist > 0 ? offset : 0;
+    offset += hdr->dist_size * ap->ndist;
+    hdr->status_offset = ap->nstatus > 0 ? offset : 0;
+    offset += ap->status_size * ap->nstatus;
+
+    hdr->total_size = offset;
+}
+
+/* Assign section element sizes.
+ */
+static void set_sizes (struct apinfo5 *ap)
+{
+    pals_header_t *hdr = &ap->hdr;
+
+    hdr->comm_profile_size = sizeof (ap->comms[0]);
+    hdr->cmd_size = sizeof (ap->cmds[0]);
+    hdr->pe_size = sizeof (ap->pes[0]);
+    hdr->node_size = sizeof (ap->nodes[0]);
+    hdr->nic_size = sizeof (ap->nics[0]);
+    hdr->dist_size = sizeof (ap->dist[0]);
+    ap->status_size = sizeof (ap->status[0]);
+}
+
+/* Write the entire apinfo object to the specified stream.
+ */
+static int op_write (void *handle, FILE *stream)
+{
+    struct apinfo5 *ap = handle;
+
+    if (fwrite (&ap->hdr, sizeof (ap->hdr), 1, stream) != 1)
+        return -1;
+    if (fwrite (ap->comms, ap->hdr.comm_profile_size, ap->hdr.ncomm_profiles, stream)
+        != ap->hdr.ncomm_profiles)
+        return -1;
+    if (fwrite (ap->cmds, ap->hdr.cmd_size, ap->hdr.ncmds, stream) != ap->hdr.ncmds)
+        return -1;
+    if (fwrite (ap->pes, ap->hdr.pe_size, ap->hdr.npes, stream) != ap->hdr.npes)
+        return -1;
+    if (fwrite (ap->nodes, ap->hdr.node_size, ap->hdr.nnodes, stream) != ap->hdr.nnodes)
+        return -1;
+    if (fwrite (ap->nics, ap->hdr.nic_size, ap->hdr.nnics, stream) != ap->hdr.nnics)
+        return -1;
+    if (fwrite (ap->dist, ap->hdr.dist_size, ap->ndist, stream) != ap->ndist)
+        return -1;
+    if (fwrite (ap->status, ap->status_size, ap->nstatus, stream) != ap->nstatus)
+        return -1;
+
+    return 0;
+}
+
+/* Find the maximum number of tasks per node.
+ * Helper for set_cmd()
+ */
+static int max_ntasks (const struct taskmap *map)
+{
+    int max_ntasks = 0;
+
+    for (int nodeid = 0; nodeid < taskmap_nnodes (map); nodeid++) {
+        int ntasks = taskmap_ntasks (map, nodeid);
+
+        if (max_ntasks < ntasks)
+            max_ntasks = ntasks;
+    }
+
+    return max_ntasks;
+}
+
+/* For now, no MPMD support - just one cmd element.
+ */
+static int set_cmd (struct apinfo5 *ap, const struct taskmap *map, int cpus_per_pe)
+{
+    int ncmds = 1;
+    pals_cmd_t *cmds;
+
+    if (!(cmds = calloc (ncmds, sizeof (*cmds))))
+        return -1;
+
+    cmds[0].npes = taskmap_total_ntasks (map);
+    cmds[0].pes_per_node = max_ntasks (map);
+    cmds[0].cpus_per_pe = cpus_per_pe;
+
+    free (ap->cmds);
+    ap->cmds = cmds;
+    ap->hdr.ncmds = ncmds;
+    set_offsets (ap);
+
+    return 0;
+}
+
+/* Given a global taskid and a nodeid, find the task's localidx.
+ * Helper for set_pes().
+ */
+static int localidx (const struct taskmap *map, int nodeid, int taskid)
+{
+    const struct idset *ids;
+    unsigned int id;
+    int localidx = 0;
+
+    if (!(ids = taskmap_taskids (map, nodeid)))
+        return -1;
+
+    id = idset_first (ids);
+    while (id != IDSET_INVALID_ID) {
+        if (id == taskid)
+            return localidx;
+        localidx++;
+        id = idset_next (ids, id);
+    }
+
+    return -1;
+}
+
+static int set_pes (struct apinfo5 *ap, const struct taskmap *map)
+{
+    int npes = taskmap_total_ntasks (map);
+    pals_pe_t *pes;
+
+    if (!(pes = calloc (npes, sizeof (*pes))))
+        return -1;
+
+    for (int taskid = 0; taskid < npes; taskid++) {
+        int nodeid = taskmap_nodeid (map, taskid);
+        pes[taskid].nodeidx = nodeid;
+        pes[taskid].localidx = localidx (map, nodeid, taskid);
+        pes[taskid].cmdidx = 0;
+    }
+
+    free (ap->pes);
+    ap->pes = pes;
+    ap->hdr.npes = npes;
+    set_offsets (ap);
+
+    return 0;
+}
+
+static int op_set_taskmap (void *handle, const struct taskmap *map, int cpus_per_pe)
+{
+    struct apinfo5 *ap = handle;
+
+    if (set_pes (ap, map) < 0 || set_cmd (ap, map, cpus_per_pe) < 0)
+        return -1;
+
+    return 0;
+}
+
+static int op_set_hostlist (void *handle, const struct hostlist *hosts)
+{
+    struct apinfo5 *ap = handle;
+    int nnodes = hostlist_count ((struct hostlist *)hosts);
+    pals_node_t *nodes;
+
+    if (!(nodes = calloc (nnodes, sizeof (*nodes))))
+        return -1;
+
+    for (int nodeid = 0; nodeid < nnodes; nodeid++) {
+        const char *host = hostlist_nth ((struct hostlist *)hosts, nodeid);
+        snprintf (nodes[nodeid].hostname, sizeof (nodes[nodeid].hostname), "%s", host);
+        nodes[nodeid].nid = nodeid;
+    }
+    free (ap->nodes);
+    ap->nodes = nodes;
+    ap->hdr.nnodes = nnodes;
+    set_offsets (ap);
+
+    return 0;
+}
+
+static int op_check (void *handle, flux_error_t *error)
+{
+    struct apinfo5 *ap = handle;
+
+    // check that the all nodeidx referenced from pes are valid
+    for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+        if (ap->pes[taskid].nodeidx >= ap->hdr.nnodes) {
+            errprintf (error, "pes[%d].nodeidx >= nnodes (%d)", taskid, ap->hdr.nnodes);
+            goto error;
+        }
+    }
+
+    // check that all nodes have a PE reference
+    for (int nodeid = 0; nodeid < ap->hdr.nnodes; nodeid++) {
+        bool found = false;
+        for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+            if (ap->pes[taskid].nodeidx == ap->nodes[nodeid].nid) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            errprintf (error,
+                       "no PE references nodeid %d (%s)",
+                       ap->nodes[nodeid].nid,
+                       ap->nodes[nodeid].hostname);
+            goto error;
+        }
+    }
+    return 0;
+error:
+    errno = EINVAL;
+    return -1;
+}
+
+static size_t op_get_size (void *handle)
+{
+    struct apinfo5 *ap = handle;
+    return ap->hdr.total_size;
+}
+
+static int op_get_nnodes (void *handle)
+{
+    struct apinfo5 *ap = handle;
+    return ap->hdr.nnodes;
+}
+
+static int op_get_npes (void *handle)
+{
+    struct apinfo5 *ap = handle;
+    return ap->hdr.npes;
+}
+
+static const struct hostlist *op_get_hostlist (void *handle)
+{
+    struct apinfo5 *ap = handle;
+    struct hostlist *hosts;
+
+    if (!(hosts = hostlist_create ()))
+        return NULL;
+    for (int nodeid = 0; nodeid < ap->hdr.nnodes; nodeid++) {
+        if (hostlist_append (hosts, ap->nodes[nodeid].hostname) < 0) {
+            hostlist_destroy (hosts);
+            return NULL;
+        }
+    }
+    hostlist_destroy (ap->hosts);
+    ap->hosts = hosts;
+    return ap->hosts;
+}
+
+// see note in apinfo1.c
+static const struct taskmap *op_get_taskmap (void *handle)
+{
+    struct apinfo5 *ap = handle;
+    struct taskmap *map;
+
+    if (!(map = taskmap_create ()))
+        return NULL;
+    for (int taskid = 0; taskid < ap->hdr.npes; taskid++) {
+        if (taskmap_append (map, ap->pes[taskid].nodeidx, 1, 1) < 0) {
+            taskmap_destroy (map);
+            return NULL;
+        }
+    }
+    taskmap_destroy (ap->map);
+    ap->map = map;
+    return ap->map;
+}
+
+static void *op_create (void)
+{
+    struct apinfo5 *ap;
+
+    if (!(ap = calloc (1, sizeof (*ap))))
+        return NULL;
+
+    ap->hdr.version = PALS_APINFO_VERSION;
+    set_sizes (ap);
+    set_offsets (ap);
+
+    return ap;
+}
+
+static void op_destroy (void *handle)
+{
+    struct apinfo5 *ap = handle;
+
+    if (ap) {
+        int saved_errno = errno;
+        taskmap_destroy (ap->map);
+        hostlist_destroy (ap->hosts);
+        free (ap->comms);
+        free (ap->cmds);
+        free (ap->pes);
+        free (ap->nodes);
+        free (ap->nics);
+        free (ap->status);
+        free (ap);
+        errno = saved_errno;
+    }
+}
+
+struct apinfo_impl apinfo5 = {
+    .version = PALS_APINFO_VERSION,
+    .create = op_create,
+    .destroy = op_destroy,
+    .write = op_write,
+    .set_hostlist = op_set_hostlist,
+    .set_taskmap = op_set_taskmap,
+    .check = op_check,
+    .get_size = op_get_size,
+    .get_nnodes = op_get_nnodes,
+    .get_npes = op_get_npes,
+    .get_hostlist = op_get_hostlist,
+    .get_taskmap = op_get_taskmap,
+};
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/apinfo5.h
+++ b/src/common/libapinfo/apinfo5.h
@@ -1,0 +1,91 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBAPINFO_APINFO5_H
+#define _LIBAPINFO_APINFO5_H
+
+/* Application file format version */
+#define PALS_APINFO_VERSION 5
+
+typedef struct {
+    int version;
+    size_t total_size;
+    size_t comm_profile_size;
+    size_t comm_profile_offset;
+    int ncomm_profiles;
+    size_t cmd_size;
+    size_t cmd_offset;
+    int ncmds;
+    size_t pe_size;
+    size_t pe_offset;
+    int npes;
+    size_t node_size;
+    size_t node_offset;
+    int nnodes;
+    size_t nic_size;
+    size_t nic_offset;
+    int nnics;
+    size_t status_offset;
+    size_t dist_size;
+    size_t dist_offset;
+} pals_header_t;
+
+/* Network communication profile structure */
+typedef struct {
+    uint32_t svc_id;          /**< CXI service ID */
+    uint32_t traffic_classes; /**< Bitmap of allowed traffic classes */
+    uint16_t vnis[4];         /**< VNIs for this service */
+    uint8_t nvnis;            /**< Number of VNIs */
+    char device_name[16];     /**< NIC device for this profile */
+} pals_comm_profile_t;
+
+/* MPMD command information structure */
+typedef struct {
+    int npes;         /* Number of tasks in this command */
+    int pes_per_node; /* Number of tasks per node */
+    int cpus_per_pe;  /* Number of CPUs per task */
+} pals_cmd_t;
+
+/* PE (i.e. task) information structure */
+typedef struct {
+    int localidx; /* Node-local PE index */
+    int cmdidx;   /* Command index for this PE */
+    int nodeidx;  /* Node index this PE is running on */
+} pals_pe_t;
+
+/* Node information structure */
+typedef struct {
+    int nid;           /* Node ID */
+    char hostname[64]; /* Node hostname */
+} pals_node_t;
+
+/* NIC address type */
+typedef enum { PALS_ADDR_IPV4, PALS_ADDR_IPV6, PALS_ADDR_MAC } pals_address_type_t;
+
+/* NIC information structure */
+typedef struct {
+    int nodeidx;                      /**< Node index this NIC belongs to */
+    pals_address_type_t address_type; /**< Address type for this NIC */
+    char address[64];                 /**< Address of this NIC */
+    short numa_node;                  /**< NUMA node it is in */
+    char device_name[16];             /**< Device name */
+    long _unused[2];
+} pals_hsn_nic_t;
+
+/* Distance to NIC information structure */
+typedef struct {
+    uint8_t num_nic_distances;     /**< Number of CPU->NIC distances on current node */
+    uint8_t accelerator_distances; /**< Accel distances too? (bool). Set to 0, not used. */
+    uint8_t distances[0];          /* < One for each NIC, two if using accelerators */
+} pals_distance_t;
+
+#endif  // !_LIBAPINFO_APINFO5_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libapinfo/test/pals.c
+++ b/src/common/libapinfo/test/pals.c
@@ -21,14 +21,14 @@
 
 #include "apinfo.h"
 
-void empty_apinfo1 (char *path)
+void empty_apinfo (char *path, int version)
 {
     struct apinfo *ap;
     pals_rc_t rc;
     pals_state_t *state;
 
-    if (!(ap = apinfo_create (1)))
-        BAIL_OUT ("apinfo_create version=1 failed");
+    if (!(ap = apinfo_create (version)))
+        BAIL_OUT ("apinfo_create version=%d failed", version);
     if (apinfo_put (ap, path) < 0)
         BAIL_OUT ("apinfo_put path=simple failed");
     apinfo_destroy (ap);
@@ -73,7 +73,7 @@ void empty_apinfo1 (char *path)
     ok (rc == PALS_OK, "pals_fini is OK");
 }
 
-void simple_apinfo1 (char *path)
+void simple_apinfo (char *path, int version)
 {
     struct apinfo *ap;
     pals_rc_t rc;
@@ -81,8 +81,8 @@ void simple_apinfo1 (char *path)
     struct hostlist *hosts;
     struct taskmap *map;
 
-    if (!(ap = apinfo_create (1)))
-        BAIL_OUT ("apinfo_create version=1 failed");
+    if (!(ap = apinfo_create (version)))
+        BAIL_OUT ("apinfo_create version=%d failed", version);
     if (!(hosts = hostlist_decode ("test[0-3]")) || apinfo_set_hostlist (ap, hosts) < 0)
         BAIL_OUT ("error setting hostlist");
     if (!(map = taskmap_decode ("[[0,4,256,1]]", NULL)) || apinfo_set_taskmap (ap, map, 1) < 0)
@@ -172,8 +172,13 @@ int main (int argc, char *argv[])
         || setenv ("PALS_NODEID", "0", 1) < 0)
         BAIL_OUT ("error setting PALS environment variables");
 
-    empty_apinfo1 (path);
-    simple_apinfo1 (path);
+    diag ("testing APINFO v1");
+    empty_apinfo (path, 1);
+    simple_apinfo (path, 1);
+
+    diag ("testing APINFO v5");
+    empty_apinfo (path, 5);
+    simple_apinfo (path, 5);
 
     unlink (path);
 

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -158,10 +158,16 @@ test_expect_success 'shell: pals shell plugin creates apinfo file' '
 	&& test ! -z \$PALS_APINFO && test -f \$PALS_APINFO"
 '
 
+test_expect_success 'shell: apinfo version 1 can be selected' '
+	apinfo=$(flux run -o userrc=$(pwd)/$USERRC_NAME -o cray-pals.apinfo-version=1 -N1 -n1 ${PYTHON:-python3} \
+	${SHARNESS_TEST_SRCDIR}/scripts/apinfo_checker.py) &&
+	echo "$apinfo" | jq -e ".version == 1"
+'
+
 test_expect_success 'shell: apinfo file contents are valid for one task' '
 	apinfo=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 ${PYTHON:-python3} \
 	${SHARNESS_TEST_SRCDIR}/scripts/apinfo_checker.py) &&
-	echo "$apinfo" | jq -e ".version == 1" &&
+	echo "$apinfo" | jq -e ".version == 5" &&
 	echo "$apinfo" | jq -e ".cmds[0].npes == 1" &&
 	echo "$apinfo" | jq -e ".pes[0].localidx == 0" &&
 	echo "$apinfo" | jq -e ".pes[0].cmdidx == 0" &&


### PR DESCRIPTION
This moves apinfo to v5 (as first demonstrated in @jameshcorbett 's #282 ), with an option to fall back to v1.

The fallback option is `-o cray-pals.apinfo-version=1`