### PR TITLE
readthedocs: fix imghdr not found error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.12"
 
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
Problem: sphinx attempts to import the `imghdr` standard library, but it was removed in Python 3.13+. The readthedocs builder uses 3.13.

Downgrade the builder to 3.12.

Another option would have been to upgrade sphinx, because newer versions no longer import `imghdr`, but flux projects universally require sphinx version < 6.0.0, and it seemed desirable to maintain consistency of sphinx versioning.

See e.g. https://app.readthedocs.org/projects/flux-coral2/builds/27470351/