### PR TITLE
github: run workflow on push to any branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,4 @@
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [pull_request, push]
 name: ci
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Problem: github workflows don't run in feature branches of private forks.

Change the rules so that ci runs on branches other than master.

Fixes #317