### PR TITLE
cray-pals: refactor and add test options

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
   flux-core (>= 0.49.0),
   python3-dev,
   python3-kubernetes,
-  pylint3,
+  pylint,
   jq
 
 Homepage: https://github.com/flux-framework/flux-core

--- a/doc/man1/flux-shell-cray-pals.rst
+++ b/doc/man1/flux-shell-cray-pals.rst
@@ -26,18 +26,6 @@ SHELL OPTIONS
   Enable only the cray-pals PMI plugin.  Other PMI implementations may
   be added, separated by commas.
 
-.. option:: cray-pals.no-edit-env
-
-  Prevent the cray-pals PMI plugin from removing Flux's PMI library
-  directory from :envvar:`LD_LIBRARY_PATH`, if present.
-
-  It is removed by default to ensure that Cray PMI library is found
-  before Flux's.
-
-.. option:: cray-pals.apinfo-version=1
-
-  Force HPE apinfo version 1.  The default is version 5.
-
 .. note::
 
   On systems where Cray MPICH is used, it may be helpful for system
@@ -53,13 +41,36 @@ SHELL OPTIONS
   :program:`simple` PMI is required to launch Flux instances, so if the
   :option:`pmi` default is changed, be sure to include it also.
 
+.. option:: cray-pals.no-edit-env
+
+  Prevent the cray-pals PMI plugin from removing Flux's PMI library
+  directory from :envvar:`LD_LIBRARY_PATH`, if present.
+
+  It is removed by default to ensure that Cray PMI library is found
+  before Flux's.
+
+.. option:: cray-pals.apinfo-version=1
+
+  Force HPE apinfo version 1.  The default is version 5.
+
 .. option:: cray-pals.timeout=SECONDS
 
   The plugin synchronously watches the job eventlog for data from the
   ``cray_pals_port_distributor`` jobtap plugin.  The job is aborted
-  the eventlog does not make progress for the specified number of
+  if the eventlog does not make progress for the specified number of
   seconds.  Setting the timeout to a negative value disables it.
   Default: 10.
+
+.. option:: cray-pals.pmi-bootstrap=off
+
+  Disable setting :envvar:`PMI_CONTROL_PORT` and
+  :envvar:`PMI_SHARED_SECRET`.  This is mainly useful for testing.
+
+.. option:: cray-pals.pmi-bootstrap=[port1,port2,secret]
+
+  Provide fixed values for setting :envvar:`PMI_CONTROL_PORT` and
+  and :envvar:`PMI_SHARED_SECRET`.  The option value is expressed
+  as a JSON array of three integers.  This is mainly useful for testing.
 
 ENVIRONMENT
 ===========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -81,3 +81,4 @@ libcxi
 ROCm
 Behlendorf
 Faaland
+JSON

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -12,4 +12,6 @@ noinst_LTLIBRARIES = libutil.la
 
 libutil_la_SOURCES = \
 	errprintf.h \
-	errprintf.c
+	errprintf.c \
+	eventlog.h \
+	eventlog.c

--- a/src/common/libutil/eventlog.c
+++ b/src/common/libutil/eventlog.c
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#include "eventlog_helpers.h"
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <errno.h>
 #include <fcntl.h>
@@ -16,6 +18,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+
+#include "eventlog.h"
 
 bool eventlog_entry_validate (json_t *entry)
 {
@@ -106,3 +110,5 @@ int eventlog_entry_parse (json_t *entry, double *timestamp, const char **name, j
 
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/eventlog.h
+++ b/src/common/libutil/eventlog.h
@@ -22,3 +22,5 @@ json_t *eventlog_entry_decode (const char *entry);
 int eventlog_entry_parse (json_t *entry, double *timestamp, const char **name, json_t **context);
 
 #endif /* !_EVENTLOG_HELPERS_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/Makefile.am
+++ b/src/shell/plugins/Makefile.am
@@ -20,9 +20,7 @@ shell_plugin_LTLIBRARIES = \
 	cray_pals.la \
 	dws_environment.la
 
-cray_pals_la_SOURCES = cray_pals.c \
-	eventlog_helpers.c \
-	eventlog_helpers.h
+cray_pals_la_SOURCES = cray_pals.c
 cray_pals_la_CPPFLAGS = $(AM_CPPFLAGS)
 cray_pals_la_LIBADD = \
 	$(top_builddir)/src/common/libapinfo/libapinfo.la \
@@ -36,11 +34,10 @@ cray_pals_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	$(fluxplugin_ldflags) -module
 
-dws_environment_la_SOURCES = dws_environment.c \
-	eventlog_helpers.c \
-	eventlog_helpers.h
+dws_environment_la_SOURCES = dws_environment.c
 dws_environment_la_CPPFLAGS = $(AM_CPPFLAGS)
 dws_environment_la_LIBADD = \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(FLUX_CORE_LIBS) \
 	$(FLUX_HOSTLIST_LIBS) \
 	$(JANSSON_LIBS)

--- a/src/shell/plugins/cray_pals.c
+++ b/src/shell/plugins/cray_pals.c
@@ -26,7 +26,7 @@
 #include <flux/shell.h>
 #include <flux/taskmap.h>
 
-#include "eventlog_helpers.h"
+#include "src/common/libutil/eventlog.h"
 #include "src/common/libapinfo/apinfo.h"
 
 /* PALS --- interface with HPE/Cray's PMI.

--- a/src/shell/plugins/dws_environment.c
+++ b/src/shell/plugins/dws_environment.c
@@ -18,7 +18,7 @@
 #include <flux/hostlist.h>
 #include <flux/shell.h>
 
-#include "eventlog_helpers.h"
+#include "src/common/libutil/eventlog.h"
 
 /* DWS Environment --- set environment variables provided by DWS
  *

--- a/t/sharness.d/02-flux-sharness.sh
+++ b/t/sharness.d/02-flux-sharness.sh
@@ -32,6 +32,28 @@ test_size_large() {
     echo ${size}
 }
 
+#
+#  Like test_must_fail(), but additionally allow process to be
+#   terminated by SIGKILL or SIGTERM
+#
+test_must_fail_or_be_terminated() {
+    "$@"
+    exit_code=$?
+    # Allow death by SIGTERM or SIGKILL
+    if test $exit_code = 143 -o $exit_code = 137; then
+        return 0
+    elif test $exit_code = 0; then
+        echo >&2 "test_must_fail_or_be_terminated: command succeeded: $*"
+        return 1
+    elif test $exit_code -ge 129 -a $exit_code -le 192; then
+        echo >&2 "test_must_fail_or_be_terminated: died by signal $(($exit_code-128)): $*"
+        return 1
+    elif test $exit_code = 127; then
+        echo >&2 "test_must_fail_or_be_terminated: command not found: $*"
+        return 1
+    fi
+    return 0
+}
 
 #
 #  Tests using test_under_flux() and which load their own modules should

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -141,6 +141,27 @@ test_expect_success 'shell: pals shell plugin timeout must be a number' '
 	test_must_fail_or_be_terminated flux run -o cray-pals.timeout=42s \
 	    -o userrc=$(pwd)/$USERRC_NAME true
 '
+test_expect_success 'shell: pals shell plugin pmi-bootstrap=[1,2,3] works' '
+	cat >cmdline.exp <<-EOT &&
+	1,2
+	3
+	EOT
+	flux run -o cray-pals.pmi-bootstrap=[1,2,3] \
+	    -o userrc=$(pwd)/$USERRC_NAME \
+	    printenv PMI_CONTROL_PORT PMI_SHARED_SECRET >cmdline.out &&
+	test_cmp cmdline.exp cmdline.out
+'
+test_expect_success 'shell: pals shell plugin pmi-bootstrap=off works' '
+	flux run -N2 -o cray-pals.pmi-bootstrap=off \
+	    -o userrc=$(pwd)/$USERRC_NAME \
+	    printenv >env.out &&
+	test_must_fail grep PMI_CONTROL_PORT env.out &&
+	test_must_fail grep PMI_SHARED_SECRET env.out
+'
+test_expect_success 'shell: pals shell plugin pmi-bootstrap must have three elements' '
+	test_must_fail_or_be_terminated flux run -o cray-pals.pmi-bootstrap="[1,2]" \
+	    -o userrc=$(pwd)/$USERRC_NAME true
+'
 test_expect_success 'shell: pals shell plugin sets environment' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 env) &&
 	echo "$environment" | grep PALS_NODEID=0 &&

--- a/t/t1001-cray-pals.t
+++ b/t/t1001-cray-pals.t
@@ -129,6 +129,18 @@ test_expect_success 'shell: the -o cray-pals=no-edit-env shell option works' '
 	test_cmp libedit3.exp libedit3.out
 '
 
+test_expect_success 'shell: pals shell plugin hates unknown options' '
+	test_must_fail_or_be_terminated flux run -o cray-pals.xyz=1 \
+	    -o userrc=$(pwd)/$USERRC_NAME true
+'
+test_expect_success 'shell: pals shell plugin timeout can be set' '
+	flux run -o cray-pals.timeout=2 \
+	    -o userrc=$(pwd)/$USERRC_NAME true
+'
+test_expect_success 'shell: pals shell plugin timeout must be a number' '
+	test_must_fail_or_be_terminated flux run -o cray-pals.timeout=42s \
+	    -o userrc=$(pwd)/$USERRC_NAME true
+'
 test_expect_success 'shell: pals shell plugin sets environment' '
 	environment=$(flux run -o userrc=$(pwd)/$USERRC_NAME -N1 -n1 env) &&
 	echo "$environment" | grep PALS_NODEID=0 &&


### PR DESCRIPTION
Problem: cray-pals isn't set up very well for being extended, and we may need to do some work in it to support VNIs and to improve the port distribution mechanism.

Refactor the plugin to add a global state container that reduces some complexity and provides a way to hold future items that can have their life cycle tied to plugin loading.

Tighten up option parsing.  Add an option to set the pmi port and secret, and then decouple that from the eventlog watching somewhat, so that we can add a collective based method later more easily.

I've played with this a bit and also tested on El Cap with a couple of nodes.  Pretty sure I didn't break anything :-)