### PR TITLE
directivebreakdown: condense allocationCount

### DIFF
--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -102,21 +102,24 @@ def build_allocation_sets(breakdown_alloc_sets, nodes_per_nnf, hlist, min_alloc_
                 )
                 # place the allocations on the rabbits with the most nodes allocated
                 # to this job (and therefore the largest storage allocations)
+                counts_per_rabbit = {}
                 while count > 0:
                     # count may be greater than the rabbits available, so we may need
                     # to place multiple on a single rabbit (hence the outer while-loop)
                     for name, _ in collections.Counter(nodes_per_nnf).most_common(
                         count
                     ):
-                        storage_field.append(
-                            {
-                                "allocationCount": 1,
-                                "name": name,
-                            }
-                        )
+                        counts_per_rabbit[name] = counts_per_rabbit.get(name, 0) + 1
                         count -= 1
                         if count == 0:
                             break
+                for name, val in counts_per_rabbit.items():
+                    storage_field.append(
+                        {
+                            "allocationCount": val,
+                            "name": name,
+                        }
+                    )
             else:
                 nodecount_gcd = functools.reduce(math.gcd, nodes_per_nnf.values())
                 server_alloc_set["allocationSize"] = math.ceil(

--- a/t/data/breakdown/lustre10gb_count2.yaml
+++ b/t/data/breakdown/lustre10gb_count2.yaml
@@ -1,0 +1,57 @@
+apiVersion: dataworkflowservices.github.io/v1alpha3
+kind: DirectiveBreakdown
+metadata:
+  finalizers:
+  - nnf.cray.hpe.com/directiveBreakdown
+  generation: 1
+  labels:
+    dataworkflowservices.github.io/owner.kind: Workflow
+  name: fluxjob-399639606020015104-0
+  namespace: default
+spec:
+  directive: '#DW jobdw type=lustre capacity=10GiB name=project1 profile=osts-count-2'
+  userID: 31193
+status:
+  compute:
+    constraints:
+      location:
+      - access:
+        - priority: mandatory
+          type: network
+        - priority: bestEffort
+          type: physical
+        reference:
+          fieldPath: servers.spec.allocationSets[0]
+          kind: Servers
+          name: fluxjob-399639606020015104-0
+          namespace: default
+      - access:
+        - priority: mandatory
+          type: network
+        reference:
+          fieldPath: servers.spec.allocationSets[1]
+          kind: Servers
+          name: fluxjob-399639606020015104-0
+          namespace: default
+  ready: true
+  storage:
+    allocationSets:
+    - allocationStrategy: AllocateAcrossServers
+      constraints:
+        count: 2
+        labels:
+        - dataworkflowservices.github.io/storage=Rabbit
+      label: ost
+      minimumCapacity: 10737418240
+    - allocationStrategy: AllocateAcrossServers
+      constraints:
+        count: 1
+        labels:
+        - dataworkflowservices.github.io/storage=Rabbit
+      label: mdt
+      minimumCapacity: 274877906944
+    lifetime: job
+    reference:
+      kind: Servers
+      name: fluxjob-399639606020015104-0
+      namespace: default


### PR DESCRIPTION
Problem: when an explicit allocationCount is requested in a storage profile, `directivebreakdown.py` sometimes lays out the storage in a way that causes an error.

Fix it.

Fixes #322.