### PR TITLE
dws: update dws systemstatus resource

### DIFF
--- a/doc/guide/rabbit.rst
+++ b/doc/guide/rabbit.rst
@@ -145,9 +145,16 @@ in a batch script:
 Fetching Rabbit Information
 ---------------------------
 
-:man1:`flux-getrabbit` can be used to look up the rabbits used by a job,
-as well as what rabbits have PCIe links to which compute nodes and vice
+The :man1:`flux-getrabbit` command can be used to look up the rabbits used by
+a job, as well as what rabbits have PCIe links to which compute nodes and vice
 versa.
+
+For example, to list the rabbits used by a job:
+
+::
+
+  $ flux getrabbit -j $JOBID
+  rabbit[1001,1003]
 
 
 Additional Attributes of Rabbit Jobs

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -37,6 +37,7 @@ from flux_k8s.watch import Watchers, Watch
 from flux_k8s import directivebreakdown
 from flux_k8s import cleanup
 from flux_k8s import storage
+from flux_k8s import systemstatus
 from flux_k8s.workflow import (
     TransientConditionInfo,
     WorkflowInfo,
@@ -891,6 +892,7 @@ def main():
     )
     cleanup.setup_cleanup_thread(handle.conf_get("rabbit.kubeconfig"))
     storage.populate_rabbits_dict(k8s_api)
+    systemstatus.start_watch(k8s_api, handle)
     # start watching k8s workflow resources and operate on them when updates occur
     # or new RPCs are received
     with Watchers(handle, watch_interval=args.watch_interval) as watchers:

--- a/src/python/flux_k8s/Makefile.am
+++ b/src/python/flux_k8s/Makefile.am
@@ -5,7 +5,8 @@ nobase_fluxk8spy_PYTHON = \
 	watch.py \
 	cleanup.py \
 	workflow.py \
-	storage.py
+	storage.py \
+	systemstatus.py
 
 
 clean-local:

--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 CRD = namedtuple("CRD", ["group", "version", "namespace", "plural"])
 
 DWS_GROUP = "dataworkflowservices.github.io"
-DWS_API_VERSION = "v1alpha3"
+DWS_API_VERSION = "v1alpha4"
 DEFAULT_NAMESPACE = "default"
 
 NNF_GROUP = "nnf.cray.hpe.com"
@@ -70,7 +70,7 @@ CLIENTMOUNT_CRD = CRD(
 
 SYSTEMSTATUS_CRD = CRD(
     group=DWS_GROUP,
-    version="v1alpha4",
+    version=DWS_API_VERSION,
     namespace=DEFAULT_NAMESPACE,
     plural="systemstatuses",
 )

--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -67,3 +67,10 @@ CLIENTMOUNT_CRD = CRD(
     namespace=None,
     plural="clientmounts",
 )
+
+SYSTEMSTATUS_CRD = CRD(
+    group=DWS_GROUP,
+    version="v1alpha4",
+    namespace=DEFAULT_NAMESPACE,
+    plural="systemstatuses",
+)

--- a/src/python/flux_k8s/storage.py
+++ b/src/python/flux_k8s/storage.py
@@ -1,4 +1,4 @@
-"""Module defining cleanup routines for the coral2_dws service."""
+"""Module defining routines for handling k8s Storage resources."""
 
 import logging
 

--- a/src/python/flux_k8s/systemstatus.py
+++ b/src/python/flux_k8s/systemstatus.py
@@ -1,0 +1,42 @@
+"""Module defining routines for handling k8s SystemStatus resources."""
+
+import logging
+
+import flux
+from flux.idset import IDset
+from flux.hostlist import Hostlist
+from flux_k8s import crd
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _update_resource(rpc, hlist, k8s_api):
+    """Update k8s `systemstatus` resource based on online brokers."""
+    online = IDset(rpc.get()["members"])
+    offline = IDset(f"0-{len(hlist) - 1}") - online
+    disabled_dict = {node_name: "Disabled" for node_name in hlist[offline]}
+    k8s_api.patch_namespaced_custom_object(
+        *crd.SYSTEMSTATUS_CRD, "default", {"data": {"nodes": disabled_dict}}
+    )
+
+
+def _rpc_callback(rpc, hlist, k8s_api):
+    """Wrap _update_resource in try/finally."""
+    try:
+        _update_resource(rpc, hlist, k8s_api)
+    except Exception:
+        LOGGER.exception("Exception in systemstatus watch:")
+        raise
+    finally:
+        rpc.reset()
+
+
+def start_watch(k8s_api, handle):
+    """Start watching for node status updates on `handle` and update k8s."""
+    hlist = Hostlist(handle.attr_get("hostlist"))
+    handle.rpc(
+        "groups.get",
+        {"name": "broker.online"},
+        nodeid=0,
+        flags=flux.constants.FLUX_RPC_STREAMING,
+    ).then(_rpc_callback, hlist, k8s_api)


### PR DESCRIPTION
As described in #341, DWS needs Flux to tell it what nodes are up or down so it can potentially forget about some rabbit file system mounts, allowing jobs to clean up.

Fixes #341 .