### PR TITLE
dws: fix memory leak in callback

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -649,12 +649,6 @@ def _workflow_state_change_cb_inner(
             "DWS/Rabbit interactions failed: workflow hit an error: "
             f"{workflow['status'].get('message', '')}",
         )
-        # for most states, raising an exception should be enough to trigger other logic
-        # that eventually moves the workflow to Teardown. However, if the
-        # workflow is in PostRun or DataOut, the exception won't affect the dws-epilog
-        # action holding the job, so the workflow should be moved to Teardown now.
-        if workflow["spec"]["desiredState"] in ("PostRun", "DataOut"):
-            winfo.move_to_teardown(handle, k8s_api, workflow)
     elif workflow["status"].get("status") == "TransientCondition":
         prerun = workflow["status"]["state"] == "PreRun"
         # a potentially fatal error has occurred, but may resolve itself


### PR DESCRIPTION
Problem: in `cleanup_cb`, there are multiple `return` statements after some memory has been allocated but before the memory is set to a jobtap aux for automatic deletion. Those `return` statements would therefore cause the memory to be leaked.

Assign the memory to a jobtap aux at the time of allocation.