### PR TITLE
dws: teardown timeout

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,7 +10,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-shell-cray-pals.1 \
 	man1/flux-rabbitmapping.1 \
 	man1/flux-getrabbit.1 \
-	man1/flux-dws2jgf.1
+	man1/flux-dws2jgf.1 \
+	man1/flux-jobtap-dws.1
 
 RST_FILES  = \
 	$(MAN1_FILES_PRIMARY:.1=.rst)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,10 @@ domainrefs = {
         "text": "%s(5)",
         "url": "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man5/%s.html",
     },
+    "core:man7": {
+        "text": "%s(7)",
+        "url": "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man7/%s.html",
+    },
 }
 
 # Disable "smartquotes" to avoid things such as turning long-options

--- a/doc/guide/rabbit_config.rst
+++ b/doc/guide/rabbit_config.rst
@@ -69,6 +69,15 @@ Flux's interactions with the rabbits.
   (optional) Time in seconds to tolerate a workflow stuck in TransientCondition state
   before killing the associated job. Defaults to 10 seconds.
 
+**teardown_after** (float)
+  (optional) Maximum time for a workflow to be in either `PostRun` or `DataOut` state
+  before it is moved to Teardown. If unset or negative, allow the workflow to stay
+  in those states indefinitely. See also the ``epilog-timeout`` option to
+  :man7:`dws-jobtap.so`, which is similar but takes more drastic action. It may be
+  useful to set the ``teardown_after`` timeout to something smaller than the
+  ``epilog-timeout``, to give the NNF software time to clean up before the
+  ``epilog-timeout`` takes effect.
+
 **drain_compute_nodes** (boolean)
   (optional) Whether to automatically drain compute nodes that lose PCIe connection
   with their rabbit. Defaults to ``true``.
@@ -105,6 +114,7 @@ The following is an example of the config options described above.
     drain_compute_nodes = true
     save_datamovements = 5
     restrict_persistent_creation = true
+    teardown_after = 4800.0
 
     # maximum filesystem capacity per node, in GiB
     [rabbit.policy.maximums]

--- a/doc/guide/rabbit_config.rst
+++ b/doc/guide/rabbit_config.rst
@@ -5,7 +5,7 @@ Configuring Flux with Rabbits
 =============================
 
 In order for a Flux system instance to be able to allocate
-rabbit storage, the ``dws_jobtap.so`` plugin must be loaded.
+rabbit storage, the :man1:`flux-jobtap-dws` plugin must be loaded.
 The plugin can be loaded in a config file like so:
 
 .. code-block::
@@ -89,26 +89,6 @@ Flux's interactions with the rabbits.
   (optional) Defines preset #DW strings. May potentially save users time and energy,
   allowing them to run, for instance, ``flux alloc -N1 -S dw=NAME`` rather than
   ``flux alloc -N1 -S "dw=#DW jobdw ..."`` See below for an example.
-
-
-Jobtap Plugin Config
-~~~~~~~~~~~~~~~~~~~~
-
-After a rabbit job finishes, and as it enters the cleanup state, the `dws-jobtap.so`
-plugin holds the job in an epilog action while compute nodes unmount the rabbit file
-system and data is moved off of the job's rabbits.
-
-The dws-jobtap plugin has a config option, `epilog-timeout`, that takes a
-floating-point number giving the maximum number of seconds that the epilog
-action should be allowed to run. If the timeout expires with the epilog
-action still active, an exception will be raised and the following actions
-are taken:
-
-#. Any nodes in the job that have not unmounted their file systems will be drained.
-#. Any rabbits used by the job that have not cleaned up their file systems will be marked as ``Disabled`` and will not be used by Flux until they are manually returned to service.
-
-
-If ``epilog-timeout`` is 0 or negative, no timeout is set.
 
 
 Example

--- a/doc/man1/flux-jobtap-dws.rst
+++ b/doc/man1/flux-jobtap-dws.rst
@@ -1,0 +1,51 @@
+==================
+flux-jobtap-dws(1)
+==================
+
+
+SYNOPSIS
+========
+
+**flux** **jobtap** **load** *dws-jobtap.so* [*epilog-timeout=N*]
+
+
+DESCRIPTION
+===========
+
+``dws-jobtap.so`` is a :core:man1:`flux-jobtap` plugin for holding jobs in various
+states while rabbit work is being done.
+
+When a rabbit job is first submitted, a dependency is placed on it while the
+rabbit resource requirements are worked out.
+
+After a rabbit job is allocated resources, the ``dws-jobtap`` plugin holds the job
+in a prolog action while the rabbit file systems are created and mounted, and data
+movement (if requested) is performed.
+
+After a rabbit job finishes, and as it enters the cleanup state, the ``dws-jobtap``
+plugin holds the job in an epilog action while compute nodes unmount the rabbit file
+system and data is moved off of the job's rabbits.
+
+
+OPTIONS
+=======
+
+.. option:: epilog-timeout=N
+
+  A floating-point number giving the maximum number of seconds that the epilog
+  action should be allowed to run. If the timeout expires with the epilog
+  action still active, an exception will be raised and the following actions
+  are taken:
+
+  #. Any nodes in the job that have not unmounted their file systems will be drained.
+  #. Any rabbits used by the job that have not cleaned up their file systems will be marked as ``Disabled`` and will not be used by Flux until they are manually returned to service.
+
+
+  If ``epilog-timeout`` is 0 or negative, no timeout is set.
+
+
+
+SEE ALSO
+========
+
+:core:man1:`flux-jobtap`, :core:man7:`flux-jobtap-plugins`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -50,4 +50,11 @@ man_pages = [
         [author],
         1,
     ),
+    (
+        "man1/flux-jobtap-dws",
+        "flux-jobtap-dws",
+        "flux-coral2 commands",
+        [author],
+        1,
+    ),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -159,3 +159,6 @@ mv
 nnf
 stdin
 stdout
+DataOut
+PostRun
+prolog

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -742,6 +742,48 @@ test_expect_success 'job submission with preset lustre storage beyond max fails'
 	flux job wait-event -t 1 ${jobid} exception | grep "max is 100 GiB per node"
 '
 
+test_expect_success 'launch service with teardown_after' '
+	flux cancel $DWS_JOBID &&
+	echo "
+[rabbit]
+teardown_after = 0.0001
+"   | flux config load &&
+	DWS_JOBID=$(flux submit \
+		--setattr=system.alloc-bypass.R="$R" \
+		-o per-resource.type=node --output=dws7.out --error=dws7.err \
+		${LAUNCH_DWS} -vvv) &&
+	flux job wait-event -vt 15 -m "note=dws watchers setup" ${DWS_JOBID} exception &&
+	${RPC} "dws.create"
+'
+
+test_expect_success 'job submission with valid DW string works with teardown_after' '
+	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
+		-N1 -n1 hostname) &&
+	flux job wait-event -vt 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -t 10 -m description=${CREATE_DEP_NAME} \
+		${jobid} dependency-remove &&
+	flux job wait-event -t 10 -m rabbit_workflow=fluxjob-$(flux job id ${jobid}) \
+		${jobid} memo &&
+	flux job wait-event -t 5 ${jobid} jobspec-update &&
+	flux job wait-event -vt 15 ${jobid} depend &&
+	flux job wait-event -vt 15 ${jobid} priority &&
+	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 25 -m description=${PROLOG_NAME} \
+		${jobid} prolog-finish &&
+	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
+	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event.json &&
+	jq -e .context.variables env-event.json &&
+	jq -e ".context.copy_offload == false" env-event.json &&
+	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
+	flux job wait-event -vt 15 ${jobid} clean &&
+	flux job wait-event -vt 1 -m "note=skipping rabbit data movement" ${jobid} exception
+'
+
 test_expect_success 'cleanup: unload fluxion' '
 	# all jobs must be canceled before unloading fluxion or a hang will occur during
 	# shutdown, unless another scheduler is loaded afterwards


### PR DESCRIPTION
Problem: PR https://github.com/flux-framework/flux-coral2/pull/336 added an epilog timeout for moving a workflow to
teardown, as well as removing the epilog and potentially draining
nodes and disabling rabbits. However, before taking that drastic step
it makes sense to move a workflow to Teardown to give it a chance
to clean up. In theory, this could make it so the epilog timeout
never hits or at least reduce the number of rabbits disabled when
the timeout hits.

Add a timer-watcher that moves a workflow to Teardown.