### PR TITLE
dws: postrun timeout

### DIFF
--- a/doc/guide/rabbit_config.rst
+++ b/doc/guide/rabbit_config.rst
@@ -78,6 +78,12 @@ Flux's interactions with the rabbits.
   ``epilog-timeout``, to give the NNF software time to clean up before the
   ``epilog-timeout`` takes effect.
 
+**postrun_timeout** (float)
+  (optional) Maximum time for a workflow to be in the `PostRun` state
+  before it is moved to Teardown. If unset or negative, do not set a timer.
+  If both ``postrun_timeout`` and ``teardown_after`` are set, ``postrun_timeout``
+  should be set to a smaller number.
+
 **drain_compute_nodes** (boolean)
   (optional) Whether to automatically drain compute nodes that lose PCIe connection
   with their rabbit. Defaults to ``true``.

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -948,7 +948,7 @@ def main():
     )
     cleanup.setup_cleanup_thread(handle.conf_get("rabbit.kubeconfig"))
     storage.populate_rabbits_dict(k8s_api)
-    systemstatus.start_watch(k8s_api, handle)
+    systemstatus.SystemStatusManager(handle, k8s_api).start()
     # start watching k8s workflow resources and operate on them when updates occur
     # or new RPCs are received
     with Watchers(handle, watch_interval=args.watch_interval) as watchers:

--- a/src/python/flux_k8s/systemstatus.py
+++ b/src/python/flux_k8s/systemstatus.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from kubernetes.client.rest import ApiException
+
 import flux
 from flux.idset import IDset
 from flux.hostlist import Hostlist
@@ -10,33 +12,65 @@ from flux_k8s import crd
 LOGGER = logging.getLogger(__name__)
 
 
-def _update_resource(rpc, hlist, k8s_api):
-    """Update k8s `systemstatus` resource based on online brokers."""
-    online = IDset(rpc.get()["members"])
-    offline = IDset(f"0-{len(hlist) - 1}") - online
-    disabled_dict = {node_name: "Disabled" for node_name in hlist[offline]}
-    k8s_api.patch_namespaced_custom_object(
-        *crd.SYSTEMSTATUS_CRD, "default", {"data": {"nodes": disabled_dict}}
-    )
+class SystemStatusManager:
+    """Class for updating the k8s systemstatus resource.
 
+    A node may be marked as Disabled in the systemstatus resource for one of two
+    reasons: either the node has an offline broker, or the node failed to unmount
+    in a timely manner and is drained while the mount is removed.
 
-def _rpc_callback(rpc, hlist, k8s_api):
-    """Wrap _update_resource in try/finally."""
-    try:
-        _update_resource(rpc, hlist, k8s_api)
-    except Exception:
-        LOGGER.exception("Exception in systemstatus watch:")
-        raise
-    finally:
-        rpc.reset()
+    Nodes are no longer marked as Disabled once the broker comes online, or once
+    the node is undrained.
+    """
 
+    def __init__(self, handle, k8s_api):
+        self.handle = handle
+        self.k8s_api = k8s_api
+        self._hlist = Hostlist(handle.attr_get("hostlist"))  # instance hostlist
+        self._idset = IDset(f"0-{len(self._hlist) - 1}")  # instance IDset
+        self._last_online = IDset("")  # nodes most recently listed as online
 
-def start_watch(k8s_api, handle):
-    """Start watching for node status updates on `handle` and update k8s."""
-    hlist = Hostlist(handle.attr_get("hostlist"))
-    handle.rpc(
-        "groups.get",
-        {"name": "broker.online"},
-        nodeid=0,
-        flags=flux.constants.FLUX_RPC_STREAMING,
-    ).then(_rpc_callback, hlist, k8s_api)
+    def start(self):
+        """Begin updating the systemstatus resource."""
+        self.handle.rpc(
+            "groups.get",
+            {"name": "broker.online"},
+            nodeid=0,
+            flags=flux.constants.FLUX_RPC_STREAMING,
+        ).then(self._rpc_callback)
+        return self
+
+    def _rpc_callback(self, rpc):
+        """Wrap _update_offline in try/finally."""
+        try:
+            self._update_offline(rpc)
+        except Exception:
+            LOGGER.exception("Exception in systemstatus watch:")
+        finally:
+            rpc.reset()
+
+    def _update_offline(self, rpc):
+        """Update the set of known offline brokers."""
+        online = IDset(rpc.get()["members"])
+        newly_online = online - self._last_online
+        offline = self._idset - online
+        self._last_online = online
+        self._patch_resource(self._hlist[newly_online], self._hlist[offline])
+
+    def _patch_resource(self, newly_online=(), newly_offline=()):
+        """Patch the systemstatus kubernetes object with the latest disabled nodes.
+
+        A disabled node is one that either has an offline broker or a failed unmount.
+        """
+        nodes = {node_name: "Enabled" for node_name in newly_online}
+        for node_name in newly_offline:
+            nodes[node_name] = "Disabled"
+        try:
+            self.k8s_api.patch_namespaced_custom_object(
+                *crd.SYSTEMSTATUS_CRD, "default", {"data": {"nodes": nodes}}
+            )
+        except ApiException as api_err:
+            if api_err.status == 404:
+                LOGGER.debug("could not find systemstatus resource")
+            else:
+                LOGGER.exception("Failed to patch systemstatus resource")

--- a/src/python/flux_k8s/workflow.py
+++ b/src/python/flux_k8s/workflow.py
@@ -81,6 +81,7 @@ class WorkflowInfo:
         self.toredown = False  # True if workflows has been moved to teardown
         self.deleted = False  # True if delete request has been sent to k8s
         self.epilog_removed = False  # True if jobtap epilog was already removed
+        self.postrun_watcher = None  # Flux timer-watcher for the PostRun state
 
     def move_to_teardown(self, handle, k8s_api, workflow=None):
         """Move a workflow to the 'Teardown' desiredState."""

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -397,10 +397,10 @@ test_expect_success 'revert the changes to the Storage' '
 '
 
 test_expect_success 'systemstatus watch and update works' '
-    kubectl get systemstatus default -ojson | test_must_fail jq -e .data.nodes.\"$(hostname)\"
+    kubectl get systemstatus default -ojson | jq -e ".data.nodes.\"$(hostname)\" == \"Enabled\"" &&
     kill $(flux exec -r1 flux getattr broker.pid) &&
     sleep 2 &&
-    kubectl get systemstatus default -ojson | jq -e .data.nodes.\"$(hostname)\"
+    kubectl get systemstatus default -ojson | jq -e ".data.nodes.\"$(hostname)\" == \"Disabled\""
 '
 
 test_expect_success 'unload fluxion and revert systemstatus' '


### PR DESCRIPTION
There have recently been several issues on elcap clusters where rabbit workflows were stuck in the `PostRun` state waiting for nodes to unmount file systems. Some of them had a hung mount point. Flux needs a way to abandon mounts and drain nodes when this happens, and this PR implements that.