### PR TITLE
dws: status rpc

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -454,6 +454,17 @@ def abort_cb(handle, _t, msg, k8s_api):
         )
 
 
+def status_cb(handle, _arg, msg, _k8s_api):
+    """dws.status RPC callback. Returns some status info."""
+    try:
+        workflows = list(WorkflowInfo.known_workflows())
+    except Exception as exc:
+        handle.respond(msg, {"success": False, "errstr": repr(exc)})
+        LOGGER.exception("Error in responding to dws.status RPC:")
+    else:
+        handle.respond(msg, {"success": True, "workflows": workflows})
+
+
 def get_clientmounts_not_in_state(k8s_api, workflow_name, desired_state):
     """Return all nodes in a job with mounts that don't match a specified state.
 
@@ -876,6 +887,7 @@ def register_services(handle, k8s_api):
         ("post_run", post_run_cb),
         ("teardown", teardown_cb),
         ("abort", abort_cb),
+        ("status", status_cb),
     ):
         yield handle.msg_watcher_create(
             cb,

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -595,7 +595,7 @@ def workflow_state_change_cb(event, handle, k8s_api, disable_fluxion, secrets_ap
         LOGGER.warning("unrecognized workflow '%s' in event stream", workflow_name)
         return
     winfo = WorkflowInfo.get(jobid)
-    if event.get("TYPE") == "DELETED":
+    if event.get("TYPE") == "DELETED" or event.get("type") == "DELETED":
         # the workflow has been deleted, we can forget about it
         WorkflowInfo.remove(jobid)
         return

--- a/t/util/rpc.c
+++ b/t/util/rpc.c
@@ -33,6 +33,7 @@ int main (int argc, char *argv[])
     flux_t *h;
     flux_future_t *f;
     const char *topic;
+    const char *result;
     int expected_errno = -1;
     int ch;
     bool raw = false;
@@ -60,7 +61,7 @@ int main (int argc, char *argv[])
         fprintf (stderr, "flux_rpc %s\n", topic);
         exit (1);
     }
-    if (flux_rpc_get (f, NULL) < 0) {
+    if (flux_rpc_get (f, &result) < 0) {
         if (expected_errno > 0) {
             if (errno != expected_errno) {
                 fprintf (stderr,
@@ -82,6 +83,7 @@ int main (int argc, char *argv[])
                      expected_errno);
             exit (1);
         }
+        fprintf (stdout, "%s\n", result);
     }
     flux_future_destroy (f);
     flux_close (h);


### PR DESCRIPTION
Problem: sometimes the coral2-dws service becomes unresponsive. It
would be helpful if there were a RPC that could check the status of
the service.

Add a dws.status message handler.