### PR TITLE
dws: drop copy offload

### DIFF
--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -166,7 +166,7 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
                     "jobspec resources has top level 'slot' entry with "
                     f"{subresource['type']} below it"
                 )
-        return (None, None)
+        return None
     if len(resources) > 1 or resources[0]["type"] != "node":
         raise ValueError(
             "jobspec resources must have a single top-level 'node' entry, "
@@ -188,11 +188,8 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
         }
     ]
     allocation_applied = False
-    copy_offload = False
     # update ssd_resources to the right number
     for breakdown in breakdown_list:
-        if "copy-offload" in breakdown["status"].get("requires", []):
-            copy_offload = True
         if breakdown["kind"] != "DirectiveBreakdown":
             raise ValueError(f"unsupported breakdown kind {breakdown['kind']!r}")
         if not breakdown["status"]["ready"]:
@@ -205,8 +202,8 @@ def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
                 allocation_applied = True
     limits.validate(nodecount)
     if not allocation_applied:
-        return (old_resources, copy_offload)
-    return (new_resources, copy_offload)
+        return old_resources
+    return new_resources
 
 
 def fetch_breakdowns(k8s_api, workflow):

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -32,7 +32,6 @@ def create_cb(fh, t, msg, arg):
         payload={
             "id": msg.payload["jobid"],
             "resources": msg.payload["resources"],
-            "copy-offload": False,
             "exclude": args.exclude,
         },
     )

--- a/t/python/t0001-directive-breakdown.py
+++ b/t/python/t0001-directive-breakdown.py
@@ -97,10 +97,9 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "lustre10tb.yaml")
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources, copy_offload = directivebreakdown.apply_breakdowns(
+            new_resources = directivebreakdown.apply_breakdowns(
                 None, None, resources, 1
             )
-            self.assertFalse(copy_offload)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
             slot = new_resources[0]
@@ -120,10 +119,9 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         )
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources, copy_offload = directivebreakdown.apply_breakdowns(
+            new_resources = directivebreakdown.apply_breakdowns(
                 None, None, resources, 1
             )
-            self.assertTrue(copy_offload)
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
             slot = new_resources[0]
@@ -141,11 +139,10 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         patched_fetch.return_value = read_yaml_breakdown(YAMLDIR / "xfs10gb.yaml")
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources, copy_offload = directivebreakdown.apply_breakdowns(
+            new_resources = directivebreakdown.apply_breakdowns(
                 None, None, resources, 1
             )
             patched_fetch.assert_called_with(None, None)
-            self.assertFalse(copy_offload)
             self.assertEqual(len(new_resources), 1)
             slot = new_resources[0]
             self.assertEqual(slot["type"], "slot")
@@ -164,12 +161,11 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         )
         for nodecount in (4, 6, 8):
             resources = [{"type": "node", "count": nodecount}]
-            new_resources, copy_offload = directivebreakdown.apply_breakdowns(
+            new_resources = directivebreakdown.apply_breakdowns(
                 None, None, resources, 1
             )
             patched_fetch.assert_called_with(None, None)
             self.assertEqual(len(new_resources), 1)
-            self.assertFalse(copy_offload)
             slot = new_resources[0]
             self.assertEqual(slot["type"], "slot")
             self.assertEqual(slot["count"], nodecount)
@@ -186,10 +182,7 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             YAMLDIR / "xfs10gb.yaml", YAMLDIR / "lustre10tb.yaml"
         )
         resources = [{"type": "node", "count": 1, "with": [{"type": "slot"}]}]
-        new_resources, copy_offload = directivebreakdown.apply_breakdowns(
-            None, None, resources, 1
-        )
-        self.assertFalse(copy_offload)
+        new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
         patched_fetch.assert_called_with(None, None)
         self.assertEqual(len(new_resources), 1)
         slot = new_resources[0]
@@ -208,10 +201,7 @@ class TestDirectiveBreakdowns(unittest.TestCase):
             YAMLDIR / "xfs10gb.yaml", YAMLDIR / "lustre10tb_daemon.yaml"
         )
         resources = [{"type": "node", "count": 1, "with": [{"type": "slot"}]}]
-        new_resources, copy_offload = directivebreakdown.apply_breakdowns(
-            None, None, resources, 1
-        )
-        self.assertTrue(copy_offload)
+        new_resources = directivebreakdown.apply_breakdowns(None, None, resources, 1)
         patched_fetch.assert_called_with(None, None)
         self.assertEqual(len(new_resources), 1)
         slot = new_resources[0]
@@ -255,10 +245,9 @@ class TestDirectiveBreakdowns(unittest.TestCase):
         for nodecount in (4, 6, 8):
             for min_size in (11, 15, 170):
                 resources = [{"type": "node", "count": nodecount}]
-                new_resources, copy_offload = directivebreakdown.apply_breakdowns(
+                new_resources = directivebreakdown.apply_breakdowns(
                     None, None, resources, min_size
                 )
-                self.assertFalse(copy_offload)
                 patched_fetch.assert_called_with(None, None)
                 self.assertEqual(len(new_resources), 1)
                 slot = new_resources[0]

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -251,7 +251,6 @@ test_expect_success 'job submission with valid DW string works' '
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event.json &&
 	jq -e .context.variables env-event.json &&
-	jq -e ".context.copy_offload == false" env-event.json &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \
@@ -297,7 +296,6 @@ test_expect_success 'job requesting copy-offload in DW string works' '
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event2.json &&
 	jq -e .context.variables env-event2.json &&
-	jq -e ".context.copy_offload == true" env-event2.json &&
 	jq -e .context.variables.DW_WORKFLOW_TOKEN env-event2.json &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
@@ -782,7 +780,6 @@ test_expect_success 'job submission with valid DW string works with teardown_aft
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	flux job wait-event -t1 -fjson ${jobid} dws_environment > env-event.json &&
 	jq -e .context.variables env-event.json &&
-	jq -e ".context.copy_offload == false" env-event.json &&
 	flux job wait-event -vt 15 -m description=${EPILOG_NAME} \
 		${jobid} epilog-start &&
 	flux job wait-event -vt 30 -m description=${EPILOG_NAME} \


### PR DESCRIPTION
Problem: as mentioned in https://github.com/flux-framework/flux-coral2/issues/257, the copy-offload daemon no longer
needs to be supported, and is already removed from TOSS 4.8-11.
Prolog and epilog scripts will no longer check for the copy_offload
context in dws_environment events.

Remove all related logic.

Fixes #257 .