### PR TITLE
cmd: fix help messages

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -200,8 +200,8 @@ def main():
         help="Do not throw an error if nodes are found in DWS but not in R",
     )
     parser.add_argument(
-        "--chunks-per-nnf",
         "-c",
+        "--chunks-per-nnf",
         help=(
             "The number of ways to split a rabbit/nnf for Flux scheduling. "
             "Higher numbers allow finer-grained scheduling at the possible cost "

--- a/src/cmd/flux-getrabbit.py
+++ b/src/cmd/flux-getrabbit.py
@@ -18,16 +18,16 @@ def read_args():
         description=("Map compute nodes to rabbits and vice versa."),
     )
     parser.add_argument(
-        "--computes",
         "-c",
+        "--computes",
         nargs="+",
         metavar="HOSTS",
         type=Hostlist,
         help="hostlists of compute nodes, to map to rabbits",
     )
     parser.add_argument(
-        "--jobids",
         "-j",
+        "--jobids",
         nargs="+",
         metavar="JOBID",
         help="jobids, to map to rabbits",

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -23,15 +23,15 @@ def main():
         description=("Create a mapping between compute nodes and rabbit nodes"),
     )
     parser.add_argument(
-        "--kubeconfig",
         "-k",
+        "--kubeconfig",
         default=None,
         metavar="FILE",
         help="Path to kubeconfig file to use",
     )
     parser.add_argument(
-        "--indent",
         "-i",
+        "--indent",
         default=None,
         type=int,
         metavar="N",


### PR DESCRIPTION
Problem: due to the ordering of arguments, the help message for `flux getrabbit` and other commands displays text like "--computes, -c=HOSTS" which looks strange.

Change the order to make it print text like "-c, --computes=HOSTS".