### PR TITLE
dws: fix typo in systemd unit file

### DIFF
--- a/etc/flux-coral2-dws.service.in
+++ b/etc/flux-coral2-dws.service.in
@@ -11,7 +11,7 @@ SyslogIdentifier=flux-coral2-dws
 Restart=always
 RestartSec=10s
 RestartPreventExitStatus=2 3
-WatchDogSec=60s
+WatchdogSec=60s
 
 User=flux
 Group=flux


### PR DESCRIPTION
Problem: the systemd watchdog introduced in PR #374 has a typo.

Fix it.

See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#WatchdogSec=