### PR TITLE
dws: jobtap event resubscribe

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -356,6 +356,14 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
         return -1;
     }
     if (dw) {
+        // re-subscribe to exception events, just in case the plugin was reloaded
+        if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0) {
+            current_job_exception (p, "dws-jobtap: error initializing exception-monitoring");
+            flux_log_error (h,
+                            "dws-jobtap: error initializing exception-monitoring for %s",
+                            idf58 (id));
+            return -1;
+        }
         // set a boolean aux indicating whether jobtap prolog is active, so it can
         // be finished if an exception occurs
         if (!(prolog_active = malloc (sizeof (int)))


### PR DESCRIPTION
Problem: when the dws-jobtap plugin is reloaded, as e.g. happens on
restart, the plugin will no longer receive exception event
notifications for jobs that existed before the reload, because the
only call to `flux_jobtap_job_subscribe` happens in the `DEPEND`
state callback. This means jobs can get stuck in prologs and epilogs.

Add a call to `flux_jobtap_job_subscribe` in the RUN callback as well.

Fixes #379.