### PR TITLE
dws: exceptions raised while fetching pod logs are lost

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -898,7 +898,9 @@ def config_logging(args):
     logging.getLogger(flux_k8s.__name__).setLevel(log_level)
     try:
         from systemd.journal import JournalHandler
-    except ImportError:
+
+        os.environ["INVOCATION_ID"]  # set by systemd
+    except (ImportError, KeyError):
         pass
     else:
         # if running under systemd, use a JournalHandler

--- a/src/python/flux_k8s/cleanup.py
+++ b/src/python/flux_k8s/cleanup.py
@@ -155,7 +155,7 @@ async def teardown_workflow_coro(workflow):
             threading.current_thread().flux_handle,
         )
     except Exception:
-        LOGGER.warning("Failed to fetch pod logs for workflow %s", name)
+        LOGGER.exception("Failed to fetch pod logs for workflow %s", name)
     while True:
         try:
             crd_api.patch_namespaced_custom_object(


### PR DESCRIPTION
Problem: the `save_pod_log` function of the `flux_k8s.cleanup` module
sometimes raises exceptions, but the tracebacks are lost.

Log exceptions from the function.