### PR TITLE
dws: add rc1 script to drain nodes with rabbit failures

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,8 @@ check-prep: all
 
 
 dist_fluxrc1_SCRIPTS = \
-	etc/01-coral2-rc
+	etc/01-coral2-rc \
+	etc/01-rabbit-rc
 
 export DEB_BUILD_OPTIONS ?= nocheck terse
 deb: debian scripts/debbuild.sh

--- a/doc/guide/rabbit.rst
+++ b/doc/guide/rabbit.rst
@@ -164,6 +164,10 @@ tolerate the failed creation of file systems. If any rabbits fail to create thei
 Lustre targets, the whole job will fail. However, ephemeral Lustre rabbit jobs can
 still tolerate failed mounts.
 
+If this attribute is set, and a job proceeds through some rabbit failures, the nodes
+that are missing file systems will be drained when the allocation is granted. The
+nodes may still be undrained and used at the user's discretion.
+
 
 Fetching Rabbit Information
 ---------------------------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -227,3 +227,4 @@ RPC
 vnis
 vnicount
 eventlogs
+undrained

--- a/etc/01-rabbit-rc
+++ b/etc/01-rabbit-rc
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+if [[ $(flux getattr rank) -eq 0 && -n "$FLUX_ENCLOSING_ID" ]]; then
+    HOSTLIST=$(flux --parent job eventlog -fjson $FLUX_ENCLOSING_ID | \
+               jq -r 'select(.name == "exception"
+                     and .context.type == "dws-node-failure")
+                     | .context.note' | flux hostlist)
+    if [[ -n "$HOSTLIST" ]]; then
+        echo draining $HOSTLIST
+        flux resource drain $HOSTLIST "missing rabbit file systems"
+    fi
+fi

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -660,13 +660,15 @@ test_expect_success 'job submission with valid DW string times out in prerun' '
 '
 
 test_expect_success 'job submission with DW and dw_failure_tolerance works with prerun_timeout' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
-		-S dw_failure_tolerance=1 -N1 -n1 hostname) &&
+	jobid=$(flux batch --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
+		-S dw_failure_tolerance=1 -N1 -n1 --wrap --output=kvs \
+		"$FLUX_SOURCE_DIR/etc/01-rabbit-rc && flux resource drain") &&
 	walk_job_through_prolog $jobid &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	job_epilog_start_finish_clean $jobid &&
 	flux job wait-event -vt 1 -m "type=dws-node-failure" \
-		${jobid} exception
+		${jobid} exception &&
+	flux job attach ${jobid}
 '
 
 test_expect_success 'exec dws service with setup_timeout' '
@@ -694,13 +696,15 @@ test_expect_success 'job submission with valid DW string times out in setup' '
 '
 
 test_expect_success 'job submission with DW and dw_failure_tolerance works with setup_timeout' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
-		-S dw_failure_tolerance=1 -N1 -n1 hostname) &&
+	jobid=$(flux batch --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
+		-S dw_failure_tolerance=1 -N1 -n1 --wrap --output=kvs \
+		"$FLUX_SOURCE_DIR/etc/01-rabbit-rc && flux resource drain") &&
 	walk_job_through_prolog $jobid &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	job_epilog_start_finish_clean $jobid &&
 	flux job wait-event -vt 1 -m "type=dws-node-failure" \
-		${jobid} exception
+		${jobid} exception &&
+	flux job attach ${jobid} | grep $(hostname)
 '
 
 


### PR DESCRIPTION
PR #385 added all the infrastructure to identify nodes with rabbit failures and nevertheless allow jobs to proceed through them. However, there still needs to be some action taken on the nodes with failures. This PR adds a rc1 script that drains nodes. In the future, it might be better to move the nodes to a separate queue, so that they are still available for use. However, that will be left for a later release.

Related to #364.