### PR TITLE
dws: upgrade to dws api v1alpha6

### DIFF
--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -5,11 +5,11 @@ from collections import namedtuple
 CRD = namedtuple("CRD", ["group", "version", "namespace", "plural"])
 
 DWS_GROUP = "dataworkflowservices.github.io"
-DWS_API_VERSION = "v1alpha5"
+DWS_API_VERSION = "v1alpha6"
 DEFAULT_NAMESPACE = "default"
 
 NNF_GROUP = "nnf.cray.hpe.com"
-NNF_API_VERSION = "v1alpha7"
+NNF_API_VERSION = "v1alpha8"
 
 
 WORKFLOW_CRD = CRD(

--- a/src/python/flux_k8s/directivebreakdown.py
+++ b/src/python/flux_k8s/directivebreakdown.py
@@ -155,11 +155,8 @@ def build_allocation_sets(breakdown_alloc_sets, nodes_per_nnf, hlist, min_alloc_
 def apply_breakdowns(k8s_api, workflow, old_resources, min_size):
     """Apply all of the directive breakdown information to a jobspec's `resources`.
 
-    Return the resources and a boolean indicating whether copy offload has been
-    requested.
-
-    If it appears that the information has already been applied, return
-    (None, None).
+    Return the modified resources, or, if it appears that the modification has already
+    been applied, return None.
     """
     limits = ResourceLimits()
     resources = copy.deepcopy(old_resources)


### PR DESCRIPTION
Problem: there is a new dataworkflowservices.github.io API version, `v1alpha6`.

Use the new version.

Keeping this as WIP until some substantial number of LC clusters are actually serving `v1alpha6`, which might be a while.