### PR TITLE
testsuite: don't load deprecated barrier module

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -38,7 +38,6 @@ modload 0 job-manager
 modload all job-ingest
 modload all job-info
 modload 0 job-list
-modload all barrier
 modload 0 heartbeat
 
 if test $RANK -eq 0; then

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -20,7 +20,6 @@ modrm all resource
 modrm 0 job-list
 modrm all job-info
 modrm 0 job-manager
-modrm all barrier
 modrm all kvs-watch
 modrm all job-ingest
 


### PR DESCRIPTION
Problem: the flux-core barrier module is deprecated, but is loaded in test.

Don't load it.  It is unused by flux-coral2.