### PR TITLE
dws: stop prerun timer once state completes

### DIFF
--- a/etc/01-rabbit-rc
+++ b/etc/01-rabbit-rc
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-if [ $(flux getattr rank) -eq 0 && -n "$FLUX_ENCLOSING_ID" ]; then
+if [ $(flux getattr rank) -eq 0 ] && [ -n "$FLUX_ENCLOSING_ID" ]; then
     HOSTLIST=$(flux --parent job eventlog -fjson $FLUX_ENCLOSING_ID | \
                jq -r 'select(.name == "exception"
                      and .context.type == "dws-node-failure")

--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -191,7 +191,7 @@ def main():
         formatter_class=flux.util.help_formatter(),
         description=(
             "Print JGF representation of Rabbit nodes. Reads R from stdin"
-            "or a config file passed with the --from-config option."
+            " or a config file passed with the --from-config option."
         ),
     )
     parser.add_argument(

--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -781,6 +781,8 @@ def _workflow_state_change_cb_inner(
                 "variables": variables,
             },
         ).then(log_rpc_response, jobid)
+        if winfo.state_timer is not None:
+            winfo.state_timer.stop()
         save_elapsed_time_to_kvs(handle, jobid, workflow)
     elif state_complete(workflow, WorkflowState.POSTRUN):
         # move workflow to next stage, DataOut

--- a/t/t1002-dws-workflow-obj.t
+++ b/t/t1002-dws-workflow-obj.t
@@ -646,19 +646,6 @@ prerun_timeout = 0.0001
 	start_dws_script
 '
 
-test_expect_success 'job submission with valid DW string times out in prerun' '
-	jobid=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
-		-N1 -n1 hostname) &&
-	flux job wait-event -t 15 ${jobid} depend &&
-	flux job wait-event -vt 25 ${jobid} jobspec-update &&
-	flux job wait-event -t 15 ${jobid} priority &&
-	flux job wait-event -vt 15 -m description=${PROLOG_NAME} \
-		${jobid} prolog-start &&
-	job_epilog_start_finish_clean $jobid &&
-	flux job wait-event -vt 1 -m "note=timed out waiting for mounts" \
-		${jobid} exception
-'
-
 test_expect_success 'job submission with DW and dw_failure_tolerance works with prerun_timeout' '
 	jobid=$(flux batch --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs name=project1" \
 		-S dw_failure_tolerance=1 -N1 -n1 --wrap --output=kvs \
@@ -666,8 +653,6 @@ test_expect_success 'job submission with DW and dw_failure_tolerance works with 
 	walk_job_through_prolog $jobid &&
 	flux job wait-event -vt 15 -m status=0 ${jobid} finish &&
 	job_epilog_start_finish_clean $jobid &&
-	flux job wait-event -vt 1 -m "type=dws-node-failure" \
-		${jobid} exception &&
 	flux job attach ${jobid}
 '
 


### PR DESCRIPTION
Problem: the timer for the `PreRun` state cancels a job if it gets stuck in that state for too long. However, the timer is not cleared when the state completes successfully, so jobs can be canceled improperly if they run for any considerable length of time.

Stop the timer when `PreRun` state completes.