### PR TITLE
rc: avoid unportable bashism

### DIFF
--- a/etc/01-rabbit-rc
+++ b/etc/01-rabbit-rc
@@ -1,11 +1,11 @@
 #!/bin/sh -e
 
-if [[ $(flux getattr rank) -eq 0 && -n "$FLUX_ENCLOSING_ID" ]]; then
+if [ $(flux getattr rank) -eq 0 && -n "$FLUX_ENCLOSING_ID" ]; then
     HOSTLIST=$(flux --parent job eventlog -fjson $FLUX_ENCLOSING_ID | \
                jq -r 'select(.name == "exception"
                      and .context.type == "dws-node-failure")
                      | .context.note' | flux hostlist)
-    if [[ -n "$HOSTLIST" ]]; then
+    if [ -n "$HOSTLIST" ]; then
         echo draining $HOSTLIST
         flux resource drain $HOSTLIST "missing rabbit file systems"
     fi


### PR DESCRIPTION
Problem: 01-rabbit-rc uses a bash [[ ]] test but its shebang invokes sh, which is not portable.

On debian, where sh -> dash, this fails with

broker.err[0]: rc1.0: /etc/flux/rc1.d/01-rabbit-rc: 3: [[: not found

Admittedly this is a coral2 specific package, but it is helpful to be able to install it on debian test systems.