### PR TITLE
coral2_dws: add missing return statement

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -276,6 +276,7 @@ def prerun_timeout_cb(handle, k8s_api, winfo, rabbit_manager):
     """
     if winfo.failure_tolerance <= 0:
         handle.job_raise(winfo.jobid, "dws-timeout", 0, "timed out waiting for mounts")
+        return
     not_mounted = get_clientmounts_not_in_state(k8s_api, winfo.name, "mounted")
     rabbit_manager.set_property(not_mounted, f"{winfo.jobid} timed out in PreRun")
     try:


### PR DESCRIPTION
Problem: a conditional raises a fatal exception on a job, and should then return from the function because additional processing is not necessary. However, there is no return statement.

Add the missing `return`.