### PR TITLE
dws: rename `rack` vertices to `chassis`

### DIFF
--- a/src/python/flux_k8s/storage.py
+++ b/src/python/flux_k8s/storage.py
@@ -184,7 +184,7 @@ class RabbitManager:
 class FluxionRabbitManager(RabbitManager):
     """Class for interfacing with k8s Storage resources.
 
-    Assumes Fluxion has been augmented to use a resource graph with `rack` and
+    Assumes Fluxion has been augmented to use a resource graph with `chassis` and
     `ssd` vertices as produced by `flux dws2jgf`.
 
     Offers methods for setting the `badrabbit` property on compute nodes, and for
@@ -192,7 +192,7 @@ class FluxionRabbitManager(RabbitManager):
     """
 
     def __init__(self, handle, allowlist):
-        self._rabbit_rpaths = {}  # maps rabbit hostnames to Fluxion rack paths
+        self._rabbit_rpaths = {}  # maps rabbit hostnames to Fluxion chassis paths
         super().__init__(handle, allowlist)
 
     def _get_rpaths(self):
@@ -207,7 +207,10 @@ class FluxionRabbitManager(RabbitManager):
             ) from exc
         for vertex in nodes:
             metadata = vertex["metadata"]
-            if metadata["type"] == "rack" and "rabbit" in metadata["properties"]:
+            if (
+                metadata["type"] in ("chassis", "rack")
+                and "rabbit" in metadata["properties"]
+            ):
                 self._rabbit_rpaths[metadata["properties"]["rabbit"]] = (
                     metadata["paths"]["containment"],
                     int(metadata["properties"].get("ssdcount", 36)),

--- a/t/data/dws2jgf/expected-compute-01-04.jgf
+++ b/t/data/dws2jgf/expected-compute-01-04.jgf
@@ -32,14 +32,14 @@
         {
           "id": "1",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 0,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan/rack0"
+              "containment": "/ElCapitan/chassis0"
             }
           }
         },
@@ -50,7 +50,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd0"
+              "containment": "/ElCapitan/chassis0/ssd0"
             },
             "status": 1
           }
@@ -62,7 +62,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd1"
+              "containment": "/ElCapitan/chassis0/ssd1"
             },
             "status": 1
           }
@@ -74,7 +74,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd2"
+              "containment": "/ElCapitan/chassis0/ssd2"
             },
             "status": 1
           }
@@ -86,7 +86,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd3"
+              "containment": "/ElCapitan/chassis0/ssd3"
             },
             "status": 1
           }
@@ -98,7 +98,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd4"
+              "containment": "/ElCapitan/chassis0/ssd4"
             },
             "status": 1
           }
@@ -110,7 +110,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd5"
+              "containment": "/ElCapitan/chassis0/ssd5"
             },
             "status": 1
           }
@@ -122,7 +122,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd6"
+              "containment": "/ElCapitan/chassis0/ssd6"
             },
             "status": 1
           }
@@ -134,7 +134,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd7"
+              "containment": "/ElCapitan/chassis0/ssd7"
             },
             "status": 1
           }
@@ -146,7 +146,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd8"
+              "containment": "/ElCapitan/chassis0/ssd8"
             },
             "status": 1
           }
@@ -158,7 +158,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd9"
+              "containment": "/ElCapitan/chassis0/ssd9"
             },
             "status": 1
           }
@@ -170,7 +170,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd10"
+              "containment": "/ElCapitan/chassis0/ssd10"
             },
             "status": 1
           }
@@ -182,7 +182,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd11"
+              "containment": "/ElCapitan/chassis0/ssd11"
             },
             "status": 1
           }
@@ -194,7 +194,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd12"
+              "containment": "/ElCapitan/chassis0/ssd12"
             },
             "status": 1
           }
@@ -206,7 +206,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd13"
+              "containment": "/ElCapitan/chassis0/ssd13"
             },
             "status": 1
           }
@@ -218,7 +218,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd14"
+              "containment": "/ElCapitan/chassis0/ssd14"
             },
             "status": 1
           }
@@ -230,7 +230,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd15"
+              "containment": "/ElCapitan/chassis0/ssd15"
             },
             "status": 1
           }
@@ -242,7 +242,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd16"
+              "containment": "/ElCapitan/chassis0/ssd16"
             },
             "status": 1
           }
@@ -254,7 +254,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd17"
+              "containment": "/ElCapitan/chassis0/ssd17"
             },
             "status": 1
           }
@@ -266,7 +266,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd18"
+              "containment": "/ElCapitan/chassis0/ssd18"
             },
             "status": 1
           }
@@ -278,7 +278,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd19"
+              "containment": "/ElCapitan/chassis0/ssd19"
             },
             "status": 1
           }
@@ -290,7 +290,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd20"
+              "containment": "/ElCapitan/chassis0/ssd20"
             },
             "status": 1
           }
@@ -302,7 +302,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd21"
+              "containment": "/ElCapitan/chassis0/ssd21"
             },
             "status": 1
           }
@@ -314,7 +314,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd22"
+              "containment": "/ElCapitan/chassis0/ssd22"
             },
             "status": 1
           }
@@ -326,7 +326,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd23"
+              "containment": "/ElCapitan/chassis0/ssd23"
             },
             "status": 1
           }
@@ -338,7 +338,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd24"
+              "containment": "/ElCapitan/chassis0/ssd24"
             },
             "status": 1
           }
@@ -350,7 +350,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd25"
+              "containment": "/ElCapitan/chassis0/ssd25"
             },
             "status": 1
           }
@@ -362,7 +362,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd26"
+              "containment": "/ElCapitan/chassis0/ssd26"
             },
             "status": 1
           }
@@ -374,7 +374,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd27"
+              "containment": "/ElCapitan/chassis0/ssd27"
             },
             "status": 1
           }
@@ -386,7 +386,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd28"
+              "containment": "/ElCapitan/chassis0/ssd28"
             },
             "status": 1
           }
@@ -398,7 +398,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd29"
+              "containment": "/ElCapitan/chassis0/ssd29"
             },
             "status": 1
           }
@@ -410,7 +410,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd30"
+              "containment": "/ElCapitan/chassis0/ssd30"
             },
             "status": 1
           }
@@ -422,7 +422,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd31"
+              "containment": "/ElCapitan/chassis0/ssd31"
             },
             "status": 1
           }
@@ -434,7 +434,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd32"
+              "containment": "/ElCapitan/chassis0/ssd32"
             },
             "status": 1
           }
@@ -446,7 +446,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd33"
+              "containment": "/ElCapitan/chassis0/ssd33"
             },
             "status": 1
           }
@@ -458,7 +458,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd34"
+              "containment": "/ElCapitan/chassis0/ssd34"
             },
             "status": 1
           }
@@ -470,7 +470,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd35"
+              "containment": "/ElCapitan/chassis0/ssd35"
             },
             "status": 1
           }
@@ -482,7 +482,7 @@
             "name": "compute-01",
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01"
+              "containment": "/ElCapitan/chassis0/compute-01"
             }
           }
         },
@@ -493,7 +493,7 @@
             "id": 0,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core0"
+              "containment": "/ElCapitan/chassis0/compute-01/core0"
             }
           }
         },
@@ -504,7 +504,7 @@
             "id": 1,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core1"
+              "containment": "/ElCapitan/chassis0/compute-01/core1"
             }
           }
         },
@@ -515,7 +515,7 @@
             "id": 2,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core2"
+              "containment": "/ElCapitan/chassis0/compute-01/core2"
             }
           }
         },
@@ -526,7 +526,7 @@
             "id": 3,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core3"
+              "containment": "/ElCapitan/chassis0/compute-01/core3"
             }
           }
         },
@@ -537,7 +537,7 @@
             "id": 4,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core4"
+              "containment": "/ElCapitan/chassis0/compute-01/core4"
             }
           }
         },
@@ -548,7 +548,7 @@
             "name": "compute-02",
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02"
+              "containment": "/ElCapitan/chassis0/compute-02"
             }
           }
         },
@@ -559,7 +559,7 @@
             "id": 0,
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02/core0"
+              "containment": "/ElCapitan/chassis0/compute-02/core0"
             }
           }
         },
@@ -570,7 +570,7 @@
             "id": 1,
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02/core1"
+              "containment": "/ElCapitan/chassis0/compute-02/core1"
             }
           }
         },
@@ -581,7 +581,7 @@
             "id": 2,
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02/core2"
+              "containment": "/ElCapitan/chassis0/compute-02/core2"
             }
           }
         },
@@ -592,7 +592,7 @@
             "id": 3,
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02/core3"
+              "containment": "/ElCapitan/chassis0/compute-02/core3"
             }
           }
         },
@@ -603,7 +603,7 @@
             "id": 4,
             "rank": 1,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-02/core4"
+              "containment": "/ElCapitan/chassis0/compute-02/core4"
             }
           }
         },
@@ -614,7 +614,7 @@
             "name": "compute-03",
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03"
+              "containment": "/ElCapitan/chassis0/compute-03"
             }
           }
         },
@@ -625,7 +625,7 @@
             "id": 0,
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03/core0"
+              "containment": "/ElCapitan/chassis0/compute-03/core0"
             }
           }
         },
@@ -636,7 +636,7 @@
             "id": 1,
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03/core1"
+              "containment": "/ElCapitan/chassis0/compute-03/core1"
             }
           }
         },
@@ -647,7 +647,7 @@
             "id": 2,
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03/core2"
+              "containment": "/ElCapitan/chassis0/compute-03/core2"
             }
           }
         },
@@ -658,7 +658,7 @@
             "id": 3,
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03/core3"
+              "containment": "/ElCapitan/chassis0/compute-03/core3"
             }
           }
         },
@@ -669,21 +669,21 @@
             "id": 4,
             "rank": 2,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-03/core4"
+              "containment": "/ElCapitan/chassis0/compute-03/core4"
             }
           }
         },
         {
           "id": "56",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan/rack1"
+              "containment": "/ElCapitan/chassis1"
             }
           }
         },
@@ -694,7 +694,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd0"
+              "containment": "/ElCapitan/chassis1/ssd0"
             },
             "status": 1
           }
@@ -706,7 +706,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd1"
+              "containment": "/ElCapitan/chassis1/ssd1"
             },
             "status": 1
           }
@@ -718,7 +718,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd2"
+              "containment": "/ElCapitan/chassis1/ssd2"
             },
             "status": 1
           }
@@ -730,7 +730,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd3"
+              "containment": "/ElCapitan/chassis1/ssd3"
             },
             "status": 1
           }
@@ -742,7 +742,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd4"
+              "containment": "/ElCapitan/chassis1/ssd4"
             },
             "status": 1
           }
@@ -754,7 +754,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd5"
+              "containment": "/ElCapitan/chassis1/ssd5"
             },
             "status": 1
           }
@@ -766,7 +766,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd6"
+              "containment": "/ElCapitan/chassis1/ssd6"
             },
             "status": 1
           }
@@ -778,7 +778,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd7"
+              "containment": "/ElCapitan/chassis1/ssd7"
             },
             "status": 1
           }
@@ -790,7 +790,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd8"
+              "containment": "/ElCapitan/chassis1/ssd8"
             },
             "status": 1
           }
@@ -802,7 +802,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd9"
+              "containment": "/ElCapitan/chassis1/ssd9"
             },
             "status": 1
           }
@@ -814,7 +814,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd10"
+              "containment": "/ElCapitan/chassis1/ssd10"
             },
             "status": 1
           }
@@ -826,7 +826,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd11"
+              "containment": "/ElCapitan/chassis1/ssd11"
             },
             "status": 1
           }
@@ -838,7 +838,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd12"
+              "containment": "/ElCapitan/chassis1/ssd12"
             },
             "status": 1
           }
@@ -850,7 +850,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd13"
+              "containment": "/ElCapitan/chassis1/ssd13"
             },
             "status": 1
           }
@@ -862,7 +862,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd14"
+              "containment": "/ElCapitan/chassis1/ssd14"
             },
             "status": 1
           }
@@ -874,7 +874,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd15"
+              "containment": "/ElCapitan/chassis1/ssd15"
             },
             "status": 1
           }
@@ -886,7 +886,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd16"
+              "containment": "/ElCapitan/chassis1/ssd16"
             },
             "status": 1
           }
@@ -898,7 +898,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd17"
+              "containment": "/ElCapitan/chassis1/ssd17"
             },
             "status": 1
           }
@@ -910,7 +910,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd18"
+              "containment": "/ElCapitan/chassis1/ssd18"
             },
             "status": 1
           }
@@ -922,7 +922,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd19"
+              "containment": "/ElCapitan/chassis1/ssd19"
             },
             "status": 1
           }
@@ -934,7 +934,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd20"
+              "containment": "/ElCapitan/chassis1/ssd20"
             },
             "status": 1
           }
@@ -946,7 +946,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd21"
+              "containment": "/ElCapitan/chassis1/ssd21"
             },
             "status": 1
           }
@@ -958,7 +958,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd22"
+              "containment": "/ElCapitan/chassis1/ssd22"
             },
             "status": 1
           }
@@ -970,7 +970,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd23"
+              "containment": "/ElCapitan/chassis1/ssd23"
             },
             "status": 1
           }
@@ -982,7 +982,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd24"
+              "containment": "/ElCapitan/chassis1/ssd24"
             },
             "status": 1
           }
@@ -994,7 +994,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd25"
+              "containment": "/ElCapitan/chassis1/ssd25"
             },
             "status": 1
           }
@@ -1006,7 +1006,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd26"
+              "containment": "/ElCapitan/chassis1/ssd26"
             },
             "status": 1
           }
@@ -1018,7 +1018,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd27"
+              "containment": "/ElCapitan/chassis1/ssd27"
             },
             "status": 1
           }
@@ -1030,7 +1030,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd28"
+              "containment": "/ElCapitan/chassis1/ssd28"
             },
             "status": 1
           }
@@ -1042,7 +1042,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd29"
+              "containment": "/ElCapitan/chassis1/ssd29"
             },
             "status": 1
           }
@@ -1054,7 +1054,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd30"
+              "containment": "/ElCapitan/chassis1/ssd30"
             },
             "status": 1
           }
@@ -1066,7 +1066,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd31"
+              "containment": "/ElCapitan/chassis1/ssd31"
             },
             "status": 1
           }
@@ -1078,7 +1078,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd32"
+              "containment": "/ElCapitan/chassis1/ssd32"
             },
             "status": 1
           }
@@ -1090,7 +1090,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd33"
+              "containment": "/ElCapitan/chassis1/ssd33"
             },
             "status": 1
           }
@@ -1102,7 +1102,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd34"
+              "containment": "/ElCapitan/chassis1/ssd34"
             },
             "status": 1
           }
@@ -1114,7 +1114,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd35"
+              "containment": "/ElCapitan/chassis1/ssd35"
             },
             "status": 1
           }
@@ -1126,7 +1126,7 @@
             "name": "compute-04",
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04"
+              "containment": "/ElCapitan/chassis1/compute-04"
             }
           }
         },
@@ -1137,7 +1137,7 @@
             "id": 0,
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04/core0"
+              "containment": "/ElCapitan/chassis1/compute-04/core0"
             }
           }
         },
@@ -1148,7 +1148,7 @@
             "id": 1,
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04/core1"
+              "containment": "/ElCapitan/chassis1/compute-04/core1"
             }
           }
         },
@@ -1159,7 +1159,7 @@
             "id": 2,
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04/core2"
+              "containment": "/ElCapitan/chassis1/compute-04/core2"
             }
           }
         },
@@ -1170,7 +1170,7 @@
             "id": 3,
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04/core3"
+              "containment": "/ElCapitan/chassis1/compute-04/core3"
             }
           }
         },
@@ -1181,7 +1181,7 @@
             "id": 4,
             "rank": 3,
             "paths": {
-              "containment": "/ElCapitan/rack1/compute-04/core4"
+              "containment": "/ElCapitan/chassis1/compute-04/core4"
             }
           }
         }

--- a/t/data/dws2jgf/expected-compute-01-nodws.jgf
+++ b/t/data/dws2jgf/expected-compute-01-nodws.jgf
@@ -32,14 +32,14 @@
         {
           "id": "1",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 0,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack0"
+              "containment": "/compute/chassis0"
             }
           }
         },
@@ -50,7 +50,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd0"
+              "containment": "/compute/chassis0/ssd0"
             },
             "status": 1
           }
@@ -62,7 +62,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd1"
+              "containment": "/compute/chassis0/ssd1"
             },
             "status": 1
           }
@@ -74,7 +74,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd2"
+              "containment": "/compute/chassis0/ssd2"
             },
             "status": 1
           }
@@ -86,7 +86,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd3"
+              "containment": "/compute/chassis0/ssd3"
             },
             "status": 1
           }
@@ -98,7 +98,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd4"
+              "containment": "/compute/chassis0/ssd4"
             },
             "status": 1
           }
@@ -110,7 +110,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd5"
+              "containment": "/compute/chassis0/ssd5"
             },
             "status": 1
           }
@@ -122,7 +122,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd6"
+              "containment": "/compute/chassis0/ssd6"
             },
             "status": 1
           }
@@ -134,7 +134,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd7"
+              "containment": "/compute/chassis0/ssd7"
             },
             "status": 1
           }
@@ -146,7 +146,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd8"
+              "containment": "/compute/chassis0/ssd8"
             },
             "status": 1
           }
@@ -158,7 +158,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd9"
+              "containment": "/compute/chassis0/ssd9"
             },
             "status": 1
           }
@@ -170,7 +170,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd10"
+              "containment": "/compute/chassis0/ssd10"
             },
             "status": 1
           }
@@ -182,7 +182,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd11"
+              "containment": "/compute/chassis0/ssd11"
             },
             "status": 1
           }
@@ -194,7 +194,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd12"
+              "containment": "/compute/chassis0/ssd12"
             },
             "status": 1
           }
@@ -206,7 +206,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd13"
+              "containment": "/compute/chassis0/ssd13"
             },
             "status": 1
           }
@@ -218,7 +218,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd14"
+              "containment": "/compute/chassis0/ssd14"
             },
             "status": 1
           }
@@ -230,7 +230,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd15"
+              "containment": "/compute/chassis0/ssd15"
             },
             "status": 1
           }
@@ -242,7 +242,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd16"
+              "containment": "/compute/chassis0/ssd16"
             },
             "status": 1
           }
@@ -254,7 +254,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd17"
+              "containment": "/compute/chassis0/ssd17"
             },
             "status": 1
           }
@@ -266,7 +266,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd18"
+              "containment": "/compute/chassis0/ssd18"
             },
             "status": 1
           }
@@ -278,7 +278,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd19"
+              "containment": "/compute/chassis0/ssd19"
             },
             "status": 1
           }
@@ -290,7 +290,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd20"
+              "containment": "/compute/chassis0/ssd20"
             },
             "status": 1
           }
@@ -302,7 +302,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd21"
+              "containment": "/compute/chassis0/ssd21"
             },
             "status": 1
           }
@@ -314,7 +314,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd22"
+              "containment": "/compute/chassis0/ssd22"
             },
             "status": 1
           }
@@ -326,7 +326,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd23"
+              "containment": "/compute/chassis0/ssd23"
             },
             "status": 1
           }
@@ -338,7 +338,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd24"
+              "containment": "/compute/chassis0/ssd24"
             },
             "status": 1
           }
@@ -350,7 +350,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd25"
+              "containment": "/compute/chassis0/ssd25"
             },
             "status": 1
           }
@@ -362,7 +362,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd26"
+              "containment": "/compute/chassis0/ssd26"
             },
             "status": 1
           }
@@ -374,7 +374,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd27"
+              "containment": "/compute/chassis0/ssd27"
             },
             "status": 1
           }
@@ -386,7 +386,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd28"
+              "containment": "/compute/chassis0/ssd28"
             },
             "status": 1
           }
@@ -398,7 +398,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd29"
+              "containment": "/compute/chassis0/ssd29"
             },
             "status": 1
           }
@@ -410,7 +410,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd30"
+              "containment": "/compute/chassis0/ssd30"
             },
             "status": 1
           }
@@ -422,7 +422,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd31"
+              "containment": "/compute/chassis0/ssd31"
             },
             "status": 1
           }
@@ -434,7 +434,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd32"
+              "containment": "/compute/chassis0/ssd32"
             },
             "status": 1
           }
@@ -446,7 +446,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd33"
+              "containment": "/compute/chassis0/ssd33"
             },
             "status": 1
           }
@@ -458,7 +458,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd34"
+              "containment": "/compute/chassis0/ssd34"
             },
             "status": 1
           }
@@ -470,7 +470,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd35"
+              "containment": "/compute/chassis0/ssd35"
             },
             "status": 1
           }
@@ -482,7 +482,7 @@
             "name": "compute-01",
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01"
+              "containment": "/compute/chassis0/compute-01"
             }
           }
         },
@@ -493,7 +493,7 @@
             "id": 0,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core0"
+              "containment": "/compute/chassis0/compute-01/core0"
             }
           }
         },
@@ -504,7 +504,7 @@
             "id": 1,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core1"
+              "containment": "/compute/chassis0/compute-01/core1"
             }
           }
         },
@@ -515,7 +515,7 @@
             "id": 2,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core2"
+              "containment": "/compute/chassis0/compute-01/core2"
             }
           }
         },
@@ -526,7 +526,7 @@
             "id": 3,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core3"
+              "containment": "/compute/chassis0/compute-01/core3"
             }
           }
         },
@@ -537,7 +537,7 @@
             "id": 4,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core4"
+              "containment": "/compute/chassis0/compute-01/core4"
             }
           }
         },
@@ -548,7 +548,7 @@
             "name": "compute-02",
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02"
+              "containment": "/compute/chassis0/compute-02"
             }
           }
         },
@@ -559,7 +559,7 @@
             "id": 0,
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02/core0"
+              "containment": "/compute/chassis0/compute-02/core0"
             }
           }
         },
@@ -570,7 +570,7 @@
             "id": 1,
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02/core1"
+              "containment": "/compute/chassis0/compute-02/core1"
             }
           }
         },
@@ -581,7 +581,7 @@
             "id": 2,
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02/core2"
+              "containment": "/compute/chassis0/compute-02/core2"
             }
           }
         },
@@ -592,7 +592,7 @@
             "id": 3,
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02/core3"
+              "containment": "/compute/chassis0/compute-02/core3"
             }
           }
         },
@@ -603,7 +603,7 @@
             "id": 4,
             "rank": 1,
             "paths": {
-              "containment": "/compute/rack0/compute-02/core4"
+              "containment": "/compute/chassis0/compute-02/core4"
             }
           }
         },
@@ -614,7 +614,7 @@
             "name": "compute-03",
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03"
+              "containment": "/compute/chassis0/compute-03"
             }
           }
         },
@@ -625,7 +625,7 @@
             "id": 0,
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03/core0"
+              "containment": "/compute/chassis0/compute-03/core0"
             }
           }
         },
@@ -636,7 +636,7 @@
             "id": 1,
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03/core1"
+              "containment": "/compute/chassis0/compute-03/core1"
             }
           }
         },
@@ -647,7 +647,7 @@
             "id": 2,
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03/core2"
+              "containment": "/compute/chassis0/compute-03/core2"
             }
           }
         },
@@ -658,7 +658,7 @@
             "id": 3,
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03/core3"
+              "containment": "/compute/chassis0/compute-03/core3"
             }
           }
         },
@@ -669,21 +669,21 @@
             "id": 4,
             "rank": 2,
             "paths": {
-              "containment": "/compute/rack0/compute-03/core4"
+              "containment": "/compute/chassis0/compute-03/core4"
             }
           }
         },
         {
           "id": "56",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack1"
+              "containment": "/compute/chassis1"
             }
           }
         },
@@ -694,7 +694,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd0"
+              "containment": "/compute/chassis1/ssd0"
             },
             "status": 1
           }
@@ -706,7 +706,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd1"
+              "containment": "/compute/chassis1/ssd1"
             },
             "status": 1
           }
@@ -718,7 +718,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd2"
+              "containment": "/compute/chassis1/ssd2"
             },
             "status": 1
           }
@@ -730,7 +730,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd3"
+              "containment": "/compute/chassis1/ssd3"
             },
             "status": 1
           }
@@ -742,7 +742,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd4"
+              "containment": "/compute/chassis1/ssd4"
             },
             "status": 1
           }
@@ -754,7 +754,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd5"
+              "containment": "/compute/chassis1/ssd5"
             },
             "status": 1
           }
@@ -766,7 +766,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd6"
+              "containment": "/compute/chassis1/ssd6"
             },
             "status": 1
           }
@@ -778,7 +778,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd7"
+              "containment": "/compute/chassis1/ssd7"
             },
             "status": 1
           }
@@ -790,7 +790,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd8"
+              "containment": "/compute/chassis1/ssd8"
             },
             "status": 1
           }
@@ -802,7 +802,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd9"
+              "containment": "/compute/chassis1/ssd9"
             },
             "status": 1
           }
@@ -814,7 +814,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd10"
+              "containment": "/compute/chassis1/ssd10"
             },
             "status": 1
           }
@@ -826,7 +826,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd11"
+              "containment": "/compute/chassis1/ssd11"
             },
             "status": 1
           }
@@ -838,7 +838,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd12"
+              "containment": "/compute/chassis1/ssd12"
             },
             "status": 1
           }
@@ -850,7 +850,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd13"
+              "containment": "/compute/chassis1/ssd13"
             },
             "status": 1
           }
@@ -862,7 +862,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd14"
+              "containment": "/compute/chassis1/ssd14"
             },
             "status": 1
           }
@@ -874,7 +874,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd15"
+              "containment": "/compute/chassis1/ssd15"
             },
             "status": 1
           }
@@ -886,7 +886,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd16"
+              "containment": "/compute/chassis1/ssd16"
             },
             "status": 1
           }
@@ -898,7 +898,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd17"
+              "containment": "/compute/chassis1/ssd17"
             },
             "status": 1
           }
@@ -910,7 +910,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd18"
+              "containment": "/compute/chassis1/ssd18"
             },
             "status": 1
           }
@@ -922,7 +922,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd19"
+              "containment": "/compute/chassis1/ssd19"
             },
             "status": 1
           }
@@ -934,7 +934,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd20"
+              "containment": "/compute/chassis1/ssd20"
             },
             "status": 1
           }
@@ -946,7 +946,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd21"
+              "containment": "/compute/chassis1/ssd21"
             },
             "status": 1
           }
@@ -958,7 +958,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd22"
+              "containment": "/compute/chassis1/ssd22"
             },
             "status": 1
           }
@@ -970,7 +970,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd23"
+              "containment": "/compute/chassis1/ssd23"
             },
             "status": 1
           }
@@ -982,7 +982,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd24"
+              "containment": "/compute/chassis1/ssd24"
             },
             "status": 1
           }
@@ -994,7 +994,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd25"
+              "containment": "/compute/chassis1/ssd25"
             },
             "status": 1
           }
@@ -1006,7 +1006,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd26"
+              "containment": "/compute/chassis1/ssd26"
             },
             "status": 1
           }
@@ -1018,7 +1018,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd27"
+              "containment": "/compute/chassis1/ssd27"
             },
             "status": 1
           }
@@ -1030,7 +1030,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd28"
+              "containment": "/compute/chassis1/ssd28"
             },
             "status": 1
           }
@@ -1042,7 +1042,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd29"
+              "containment": "/compute/chassis1/ssd29"
             },
             "status": 1
           }
@@ -1054,7 +1054,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd30"
+              "containment": "/compute/chassis1/ssd30"
             },
             "status": 1
           }
@@ -1066,7 +1066,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd31"
+              "containment": "/compute/chassis1/ssd31"
             },
             "status": 1
           }
@@ -1078,7 +1078,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd32"
+              "containment": "/compute/chassis1/ssd32"
             },
             "status": 1
           }
@@ -1090,7 +1090,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd33"
+              "containment": "/compute/chassis1/ssd33"
             },
             "status": 1
           }
@@ -1102,7 +1102,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd34"
+              "containment": "/compute/chassis1/ssd34"
             },
             "status": 1
           }
@@ -1114,7 +1114,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd35"
+              "containment": "/compute/chassis1/ssd35"
             },
             "status": 1
           }
@@ -1126,7 +1126,7 @@
             "name": "compute-04",
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04"
+              "containment": "/compute/chassis1/compute-04"
             }
           }
         },
@@ -1137,7 +1137,7 @@
             "id": 0,
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04/core0"
+              "containment": "/compute/chassis1/compute-04/core0"
             }
           }
         },
@@ -1148,7 +1148,7 @@
             "id": 1,
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04/core1"
+              "containment": "/compute/chassis1/compute-04/core1"
             }
           }
         },
@@ -1159,7 +1159,7 @@
             "id": 2,
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04/core2"
+              "containment": "/compute/chassis1/compute-04/core2"
             }
           }
         },
@@ -1170,7 +1170,7 @@
             "id": 3,
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04/core3"
+              "containment": "/compute/chassis1/compute-04/core3"
             }
           }
         },
@@ -1181,7 +1181,7 @@
             "id": 4,
             "rank": 3,
             "paths": {
-              "containment": "/compute/rack1/compute-04/core4"
+              "containment": "/compute/chassis1/compute-04/core4"
             }
           }
         },

--- a/t/data/dws2jgf/expected-compute-01.jgf
+++ b/t/data/dws2jgf/expected-compute-01.jgf
@@ -32,14 +32,14 @@
         {
           "id": "1",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 0,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan/rack0"
+              "containment": "/ElCapitan/chassis0"
             }
           }
         },
@@ -50,7 +50,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd0"
+              "containment": "/ElCapitan/chassis0/ssd0"
             },
             "status": 1
           }
@@ -62,7 +62,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd1"
+              "containment": "/ElCapitan/chassis0/ssd1"
             },
             "status": 1
           }
@@ -74,7 +74,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd2"
+              "containment": "/ElCapitan/chassis0/ssd2"
             },
             "status": 1
           }
@@ -86,7 +86,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd3"
+              "containment": "/ElCapitan/chassis0/ssd3"
             },
             "status": 1
           }
@@ -98,7 +98,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd4"
+              "containment": "/ElCapitan/chassis0/ssd4"
             },
             "status": 1
           }
@@ -110,7 +110,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd5"
+              "containment": "/ElCapitan/chassis0/ssd5"
             },
             "status": 1
           }
@@ -122,7 +122,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd6"
+              "containment": "/ElCapitan/chassis0/ssd6"
             },
             "status": 1
           }
@@ -134,7 +134,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd7"
+              "containment": "/ElCapitan/chassis0/ssd7"
             },
             "status": 1
           }
@@ -146,7 +146,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd8"
+              "containment": "/ElCapitan/chassis0/ssd8"
             },
             "status": 1
           }
@@ -158,7 +158,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd9"
+              "containment": "/ElCapitan/chassis0/ssd9"
             },
             "status": 1
           }
@@ -170,7 +170,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd10"
+              "containment": "/ElCapitan/chassis0/ssd10"
             },
             "status": 1
           }
@@ -182,7 +182,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd11"
+              "containment": "/ElCapitan/chassis0/ssd11"
             },
             "status": 1
           }
@@ -194,7 +194,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd12"
+              "containment": "/ElCapitan/chassis0/ssd12"
             },
             "status": 1
           }
@@ -206,7 +206,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd13"
+              "containment": "/ElCapitan/chassis0/ssd13"
             },
             "status": 1
           }
@@ -218,7 +218,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd14"
+              "containment": "/ElCapitan/chassis0/ssd14"
             },
             "status": 1
           }
@@ -230,7 +230,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd15"
+              "containment": "/ElCapitan/chassis0/ssd15"
             },
             "status": 1
           }
@@ -242,7 +242,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd16"
+              "containment": "/ElCapitan/chassis0/ssd16"
             },
             "status": 1
           }
@@ -254,7 +254,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd17"
+              "containment": "/ElCapitan/chassis0/ssd17"
             },
             "status": 1
           }
@@ -266,7 +266,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd18"
+              "containment": "/ElCapitan/chassis0/ssd18"
             },
             "status": 1
           }
@@ -278,7 +278,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd19"
+              "containment": "/ElCapitan/chassis0/ssd19"
             },
             "status": 1
           }
@@ -290,7 +290,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd20"
+              "containment": "/ElCapitan/chassis0/ssd20"
             },
             "status": 1
           }
@@ -302,7 +302,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd21"
+              "containment": "/ElCapitan/chassis0/ssd21"
             },
             "status": 1
           }
@@ -314,7 +314,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd22"
+              "containment": "/ElCapitan/chassis0/ssd22"
             },
             "status": 1
           }
@@ -326,7 +326,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd23"
+              "containment": "/ElCapitan/chassis0/ssd23"
             },
             "status": 1
           }
@@ -338,7 +338,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd24"
+              "containment": "/ElCapitan/chassis0/ssd24"
             },
             "status": 1
           }
@@ -350,7 +350,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd25"
+              "containment": "/ElCapitan/chassis0/ssd25"
             },
             "status": 1
           }
@@ -362,7 +362,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd26"
+              "containment": "/ElCapitan/chassis0/ssd26"
             },
             "status": 1
           }
@@ -374,7 +374,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd27"
+              "containment": "/ElCapitan/chassis0/ssd27"
             },
             "status": 1
           }
@@ -386,7 +386,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd28"
+              "containment": "/ElCapitan/chassis0/ssd28"
             },
             "status": 1
           }
@@ -398,7 +398,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd29"
+              "containment": "/ElCapitan/chassis0/ssd29"
             },
             "status": 1
           }
@@ -410,7 +410,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd30"
+              "containment": "/ElCapitan/chassis0/ssd30"
             },
             "status": 1
           }
@@ -422,7 +422,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd31"
+              "containment": "/ElCapitan/chassis0/ssd31"
             },
             "status": 1
           }
@@ -434,7 +434,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd32"
+              "containment": "/ElCapitan/chassis0/ssd32"
             },
             "status": 1
           }
@@ -446,7 +446,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd33"
+              "containment": "/ElCapitan/chassis0/ssd33"
             },
             "status": 1
           }
@@ -458,7 +458,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd34"
+              "containment": "/ElCapitan/chassis0/ssd34"
             },
             "status": 1
           }
@@ -470,7 +470,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack0/ssd35"
+              "containment": "/ElCapitan/chassis0/ssd35"
             },
             "status": 1
           }
@@ -482,7 +482,7 @@
             "name": "compute-01",
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01"
+              "containment": "/ElCapitan/chassis0/compute-01"
             }
           }
         },
@@ -493,21 +493,21 @@
             "id": 0,
             "rank": 0,
             "paths": {
-              "containment": "/ElCapitan/rack0/compute-01/core0"
+              "containment": "/ElCapitan/chassis0/compute-01/core0"
             }
           }
         },
         {
           "id": "40",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/ElCapitan/rack1"
+              "containment": "/ElCapitan/chassis1"
             }
           }
         },
@@ -518,7 +518,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd0"
+              "containment": "/ElCapitan/chassis1/ssd0"
             },
             "status": 1
           }
@@ -530,7 +530,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd1"
+              "containment": "/ElCapitan/chassis1/ssd1"
             },
             "status": 1
           }
@@ -542,7 +542,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd2"
+              "containment": "/ElCapitan/chassis1/ssd2"
             },
             "status": 1
           }
@@ -554,7 +554,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd3"
+              "containment": "/ElCapitan/chassis1/ssd3"
             },
             "status": 1
           }
@@ -566,7 +566,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd4"
+              "containment": "/ElCapitan/chassis1/ssd4"
             },
             "status": 1
           }
@@ -578,7 +578,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd5"
+              "containment": "/ElCapitan/chassis1/ssd5"
             },
             "status": 1
           }
@@ -590,7 +590,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd6"
+              "containment": "/ElCapitan/chassis1/ssd6"
             },
             "status": 1
           }
@@ -602,7 +602,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd7"
+              "containment": "/ElCapitan/chassis1/ssd7"
             },
             "status": 1
           }
@@ -614,7 +614,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd8"
+              "containment": "/ElCapitan/chassis1/ssd8"
             },
             "status": 1
           }
@@ -626,7 +626,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd9"
+              "containment": "/ElCapitan/chassis1/ssd9"
             },
             "status": 1
           }
@@ -638,7 +638,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd10"
+              "containment": "/ElCapitan/chassis1/ssd10"
             },
             "status": 1
           }
@@ -650,7 +650,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd11"
+              "containment": "/ElCapitan/chassis1/ssd11"
             },
             "status": 1
           }
@@ -662,7 +662,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd12"
+              "containment": "/ElCapitan/chassis1/ssd12"
             },
             "status": 1
           }
@@ -674,7 +674,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd13"
+              "containment": "/ElCapitan/chassis1/ssd13"
             },
             "status": 1
           }
@@ -686,7 +686,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd14"
+              "containment": "/ElCapitan/chassis1/ssd14"
             },
             "status": 1
           }
@@ -698,7 +698,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd15"
+              "containment": "/ElCapitan/chassis1/ssd15"
             },
             "status": 1
           }
@@ -710,7 +710,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd16"
+              "containment": "/ElCapitan/chassis1/ssd16"
             },
             "status": 1
           }
@@ -722,7 +722,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd17"
+              "containment": "/ElCapitan/chassis1/ssd17"
             },
             "status": 1
           }
@@ -734,7 +734,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd18"
+              "containment": "/ElCapitan/chassis1/ssd18"
             },
             "status": 1
           }
@@ -746,7 +746,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd19"
+              "containment": "/ElCapitan/chassis1/ssd19"
             },
             "status": 1
           }
@@ -758,7 +758,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd20"
+              "containment": "/ElCapitan/chassis1/ssd20"
             },
             "status": 1
           }
@@ -770,7 +770,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd21"
+              "containment": "/ElCapitan/chassis1/ssd21"
             },
             "status": 1
           }
@@ -782,7 +782,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd22"
+              "containment": "/ElCapitan/chassis1/ssd22"
             },
             "status": 1
           }
@@ -794,7 +794,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd23"
+              "containment": "/ElCapitan/chassis1/ssd23"
             },
             "status": 1
           }
@@ -806,7 +806,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd24"
+              "containment": "/ElCapitan/chassis1/ssd24"
             },
             "status": 1
           }
@@ -818,7 +818,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd25"
+              "containment": "/ElCapitan/chassis1/ssd25"
             },
             "status": 1
           }
@@ -830,7 +830,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd26"
+              "containment": "/ElCapitan/chassis1/ssd26"
             },
             "status": 1
           }
@@ -842,7 +842,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd27"
+              "containment": "/ElCapitan/chassis1/ssd27"
             },
             "status": 1
           }
@@ -854,7 +854,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd28"
+              "containment": "/ElCapitan/chassis1/ssd28"
             },
             "status": 1
           }
@@ -866,7 +866,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd29"
+              "containment": "/ElCapitan/chassis1/ssd29"
             },
             "status": 1
           }
@@ -878,7 +878,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd30"
+              "containment": "/ElCapitan/chassis1/ssd30"
             },
             "status": 1
           }
@@ -890,7 +890,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd31"
+              "containment": "/ElCapitan/chassis1/ssd31"
             },
             "status": 1
           }
@@ -902,7 +902,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd32"
+              "containment": "/ElCapitan/chassis1/ssd32"
             },
             "status": 1
           }
@@ -914,7 +914,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd33"
+              "containment": "/ElCapitan/chassis1/ssd33"
             },
             "status": 1
           }
@@ -926,7 +926,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd34"
+              "containment": "/ElCapitan/chassis1/ssd34"
             },
             "status": 1
           }
@@ -938,7 +938,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/ElCapitan/rack1/ssd35"
+              "containment": "/ElCapitan/chassis1/ssd35"
             },
             "status": 1
           }

--- a/t/data/dws2jgf/expected-configfile.jgf
+++ b/t/data/dws2jgf/expected-configfile.jgf
@@ -32,14 +32,14 @@
         {
           "id": "1",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 0,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack0"
+              "containment": "/compute/chassis0"
             }
           }
         },
@@ -50,7 +50,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd0"
+              "containment": "/compute/chassis0/ssd0"
             },
             "status": 1
           }
@@ -62,7 +62,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd1"
+              "containment": "/compute/chassis0/ssd1"
             },
             "status": 1
           }
@@ -74,7 +74,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd2"
+              "containment": "/compute/chassis0/ssd2"
             },
             "status": 1
           }
@@ -86,7 +86,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd3"
+              "containment": "/compute/chassis0/ssd3"
             },
             "status": 1
           }
@@ -98,7 +98,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd4"
+              "containment": "/compute/chassis0/ssd4"
             },
             "status": 1
           }
@@ -110,7 +110,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd5"
+              "containment": "/compute/chassis0/ssd5"
             },
             "status": 1
           }
@@ -122,7 +122,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd6"
+              "containment": "/compute/chassis0/ssd6"
             },
             "status": 1
           }
@@ -134,7 +134,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd7"
+              "containment": "/compute/chassis0/ssd7"
             },
             "status": 1
           }
@@ -146,7 +146,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd8"
+              "containment": "/compute/chassis0/ssd8"
             },
             "status": 1
           }
@@ -158,7 +158,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd9"
+              "containment": "/compute/chassis0/ssd9"
             },
             "status": 1
           }
@@ -170,7 +170,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd10"
+              "containment": "/compute/chassis0/ssd10"
             },
             "status": 1
           }
@@ -182,7 +182,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd11"
+              "containment": "/compute/chassis0/ssd11"
             },
             "status": 1
           }
@@ -194,7 +194,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd12"
+              "containment": "/compute/chassis0/ssd12"
             },
             "status": 1
           }
@@ -206,7 +206,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd13"
+              "containment": "/compute/chassis0/ssd13"
             },
             "status": 1
           }
@@ -218,7 +218,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd14"
+              "containment": "/compute/chassis0/ssd14"
             },
             "status": 1
           }
@@ -230,7 +230,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd15"
+              "containment": "/compute/chassis0/ssd15"
             },
             "status": 1
           }
@@ -242,7 +242,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd16"
+              "containment": "/compute/chassis0/ssd16"
             },
             "status": 1
           }
@@ -254,7 +254,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd17"
+              "containment": "/compute/chassis0/ssd17"
             },
             "status": 1
           }
@@ -266,7 +266,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd18"
+              "containment": "/compute/chassis0/ssd18"
             },
             "status": 1
           }
@@ -278,7 +278,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd19"
+              "containment": "/compute/chassis0/ssd19"
             },
             "status": 1
           }
@@ -290,7 +290,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd20"
+              "containment": "/compute/chassis0/ssd20"
             },
             "status": 1
           }
@@ -302,7 +302,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd21"
+              "containment": "/compute/chassis0/ssd21"
             },
             "status": 1
           }
@@ -314,7 +314,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd22"
+              "containment": "/compute/chassis0/ssd22"
             },
             "status": 1
           }
@@ -326,7 +326,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd23"
+              "containment": "/compute/chassis0/ssd23"
             },
             "status": 1
           }
@@ -338,7 +338,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd24"
+              "containment": "/compute/chassis0/ssd24"
             },
             "status": 1
           }
@@ -350,7 +350,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd25"
+              "containment": "/compute/chassis0/ssd25"
             },
             "status": 1
           }
@@ -362,7 +362,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd26"
+              "containment": "/compute/chassis0/ssd26"
             },
             "status": 1
           }
@@ -374,7 +374,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd27"
+              "containment": "/compute/chassis0/ssd27"
             },
             "status": 1
           }
@@ -386,7 +386,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd28"
+              "containment": "/compute/chassis0/ssd28"
             },
             "status": 1
           }
@@ -398,7 +398,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd29"
+              "containment": "/compute/chassis0/ssd29"
             },
             "status": 1
           }
@@ -410,7 +410,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd30"
+              "containment": "/compute/chassis0/ssd30"
             },
             "status": 1
           }
@@ -422,7 +422,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd31"
+              "containment": "/compute/chassis0/ssd31"
             },
             "status": 1
           }
@@ -434,7 +434,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd32"
+              "containment": "/compute/chassis0/ssd32"
             },
             "status": 1
           }
@@ -446,7 +446,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd33"
+              "containment": "/compute/chassis0/ssd33"
             },
             "status": 1
           }
@@ -458,7 +458,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd34"
+              "containment": "/compute/chassis0/ssd34"
             },
             "status": 1
           }
@@ -470,7 +470,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd35"
+              "containment": "/compute/chassis0/ssd35"
             },
             "status": 1
           }
@@ -482,7 +482,7 @@
             "name": "compute-01",
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01"
+              "containment": "/compute/chassis0/compute-01"
             }
           }
         },
@@ -493,7 +493,7 @@
             "id": 0,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core0"
+              "containment": "/compute/chassis0/compute-01/core0"
             }
           }
         },
@@ -504,7 +504,7 @@
             "id": 1,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core1"
+              "containment": "/compute/chassis0/compute-01/core1"
             }
           }
         },
@@ -515,7 +515,7 @@
             "id": 2,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core2"
+              "containment": "/compute/chassis0/compute-01/core2"
             }
           }
         },
@@ -526,7 +526,7 @@
             "id": 3,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core3"
+              "containment": "/compute/chassis0/compute-01/core3"
             }
           }
         },
@@ -537,21 +537,21 @@
             "id": 4,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core4"
+              "containment": "/compute/chassis0/compute-01/core4"
             }
           }
         },
         {
           "id": "44",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack1"
+              "containment": "/compute/chassis1"
             }
           }
         },
@@ -562,7 +562,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd0"
+              "containment": "/compute/chassis1/ssd0"
             },
             "status": 1
           }
@@ -574,7 +574,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd1"
+              "containment": "/compute/chassis1/ssd1"
             },
             "status": 1
           }
@@ -586,7 +586,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd2"
+              "containment": "/compute/chassis1/ssd2"
             },
             "status": 1
           }
@@ -598,7 +598,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd3"
+              "containment": "/compute/chassis1/ssd3"
             },
             "status": 1
           }
@@ -610,7 +610,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd4"
+              "containment": "/compute/chassis1/ssd4"
             },
             "status": 1
           }
@@ -622,7 +622,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd5"
+              "containment": "/compute/chassis1/ssd5"
             },
             "status": 1
           }
@@ -634,7 +634,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd6"
+              "containment": "/compute/chassis1/ssd6"
             },
             "status": 1
           }
@@ -646,7 +646,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd7"
+              "containment": "/compute/chassis1/ssd7"
             },
             "status": 1
           }
@@ -658,7 +658,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd8"
+              "containment": "/compute/chassis1/ssd8"
             },
             "status": 1
           }
@@ -670,7 +670,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd9"
+              "containment": "/compute/chassis1/ssd9"
             },
             "status": 1
           }
@@ -682,7 +682,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd10"
+              "containment": "/compute/chassis1/ssd10"
             },
             "status": 1
           }
@@ -694,7 +694,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd11"
+              "containment": "/compute/chassis1/ssd11"
             },
             "status": 1
           }
@@ -706,7 +706,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd12"
+              "containment": "/compute/chassis1/ssd12"
             },
             "status": 1
           }
@@ -718,7 +718,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd13"
+              "containment": "/compute/chassis1/ssd13"
             },
             "status": 1
           }
@@ -730,7 +730,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd14"
+              "containment": "/compute/chassis1/ssd14"
             },
             "status": 1
           }
@@ -742,7 +742,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd15"
+              "containment": "/compute/chassis1/ssd15"
             },
             "status": 1
           }
@@ -754,7 +754,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd16"
+              "containment": "/compute/chassis1/ssd16"
             },
             "status": 1
           }
@@ -766,7 +766,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd17"
+              "containment": "/compute/chassis1/ssd17"
             },
             "status": 1
           }
@@ -778,7 +778,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd18"
+              "containment": "/compute/chassis1/ssd18"
             },
             "status": 1
           }
@@ -790,7 +790,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd19"
+              "containment": "/compute/chassis1/ssd19"
             },
             "status": 1
           }
@@ -802,7 +802,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd20"
+              "containment": "/compute/chassis1/ssd20"
             },
             "status": 1
           }
@@ -814,7 +814,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd21"
+              "containment": "/compute/chassis1/ssd21"
             },
             "status": 1
           }
@@ -826,7 +826,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd22"
+              "containment": "/compute/chassis1/ssd22"
             },
             "status": 1
           }
@@ -838,7 +838,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd23"
+              "containment": "/compute/chassis1/ssd23"
             },
             "status": 1
           }
@@ -850,7 +850,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd24"
+              "containment": "/compute/chassis1/ssd24"
             },
             "status": 1
           }
@@ -862,7 +862,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd25"
+              "containment": "/compute/chassis1/ssd25"
             },
             "status": 1
           }
@@ -874,7 +874,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd26"
+              "containment": "/compute/chassis1/ssd26"
             },
             "status": 1
           }
@@ -886,7 +886,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd27"
+              "containment": "/compute/chassis1/ssd27"
             },
             "status": 1
           }
@@ -898,7 +898,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd28"
+              "containment": "/compute/chassis1/ssd28"
             },
             "status": 1
           }
@@ -910,7 +910,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd29"
+              "containment": "/compute/chassis1/ssd29"
             },
             "status": 1
           }
@@ -922,7 +922,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd30"
+              "containment": "/compute/chassis1/ssd30"
             },
             "status": 1
           }
@@ -934,7 +934,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd31"
+              "containment": "/compute/chassis1/ssd31"
             },
             "status": 1
           }
@@ -946,7 +946,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd32"
+              "containment": "/compute/chassis1/ssd32"
             },
             "status": 1
           }
@@ -958,7 +958,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd33"
+              "containment": "/compute/chassis1/ssd33"
             },
             "status": 1
           }
@@ -970,7 +970,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd34"
+              "containment": "/compute/chassis1/ssd34"
             },
             "status": 1
           }
@@ -982,7 +982,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd35"
+              "containment": "/compute/chassis1/ssd35"
             },
             "status": 1
           }

--- a/t/data/dws2jgf/expected-properties.jgf
+++ b/t/data/dws2jgf/expected-properties.jgf
@@ -35,14 +35,14 @@
         {
           "id": "1",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 0,
             "properties": {
               "rabbit": "kind-worker2",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack0"
+              "containment": "/compute/chassis0"
             }
           }
         },
@@ -53,7 +53,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd0"
+              "containment": "/compute/chassis0/ssd0"
             },
             "status": 1
           }
@@ -65,7 +65,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd1"
+              "containment": "/compute/chassis0/ssd1"
             },
             "status": 1
           }
@@ -77,7 +77,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd2"
+              "containment": "/compute/chassis0/ssd2"
             },
             "status": 1
           }
@@ -89,7 +89,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd3"
+              "containment": "/compute/chassis0/ssd3"
             },
             "status": 1
           }
@@ -101,7 +101,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd4"
+              "containment": "/compute/chassis0/ssd4"
             },
             "status": 1
           }
@@ -113,7 +113,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd5"
+              "containment": "/compute/chassis0/ssd5"
             },
             "status": 1
           }
@@ -125,7 +125,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd6"
+              "containment": "/compute/chassis0/ssd6"
             },
             "status": 1
           }
@@ -137,7 +137,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd7"
+              "containment": "/compute/chassis0/ssd7"
             },
             "status": 1
           }
@@ -149,7 +149,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd8"
+              "containment": "/compute/chassis0/ssd8"
             },
             "status": 1
           }
@@ -161,7 +161,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd9"
+              "containment": "/compute/chassis0/ssd9"
             },
             "status": 1
           }
@@ -173,7 +173,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd10"
+              "containment": "/compute/chassis0/ssd10"
             },
             "status": 1
           }
@@ -185,7 +185,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd11"
+              "containment": "/compute/chassis0/ssd11"
             },
             "status": 1
           }
@@ -197,7 +197,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd12"
+              "containment": "/compute/chassis0/ssd12"
             },
             "status": 1
           }
@@ -209,7 +209,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd13"
+              "containment": "/compute/chassis0/ssd13"
             },
             "status": 1
           }
@@ -221,7 +221,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd14"
+              "containment": "/compute/chassis0/ssd14"
             },
             "status": 1
           }
@@ -233,7 +233,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd15"
+              "containment": "/compute/chassis0/ssd15"
             },
             "status": 1
           }
@@ -245,7 +245,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd16"
+              "containment": "/compute/chassis0/ssd16"
             },
             "status": 1
           }
@@ -257,7 +257,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd17"
+              "containment": "/compute/chassis0/ssd17"
             },
             "status": 1
           }
@@ -269,7 +269,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd18"
+              "containment": "/compute/chassis0/ssd18"
             },
             "status": 1
           }
@@ -281,7 +281,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd19"
+              "containment": "/compute/chassis0/ssd19"
             },
             "status": 1
           }
@@ -293,7 +293,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd20"
+              "containment": "/compute/chassis0/ssd20"
             },
             "status": 1
           }
@@ -305,7 +305,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd21"
+              "containment": "/compute/chassis0/ssd21"
             },
             "status": 1
           }
@@ -317,7 +317,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd22"
+              "containment": "/compute/chassis0/ssd22"
             },
             "status": 1
           }
@@ -329,7 +329,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd23"
+              "containment": "/compute/chassis0/ssd23"
             },
             "status": 1
           }
@@ -341,7 +341,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd24"
+              "containment": "/compute/chassis0/ssd24"
             },
             "status": 1
           }
@@ -353,7 +353,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd25"
+              "containment": "/compute/chassis0/ssd25"
             },
             "status": 1
           }
@@ -365,7 +365,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd26"
+              "containment": "/compute/chassis0/ssd26"
             },
             "status": 1
           }
@@ -377,7 +377,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd27"
+              "containment": "/compute/chassis0/ssd27"
             },
             "status": 1
           }
@@ -389,7 +389,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd28"
+              "containment": "/compute/chassis0/ssd28"
             },
             "status": 1
           }
@@ -401,7 +401,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd29"
+              "containment": "/compute/chassis0/ssd29"
             },
             "status": 1
           }
@@ -413,7 +413,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd30"
+              "containment": "/compute/chassis0/ssd30"
             },
             "status": 1
           }
@@ -425,7 +425,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd31"
+              "containment": "/compute/chassis0/ssd31"
             },
             "status": 1
           }
@@ -437,7 +437,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd32"
+              "containment": "/compute/chassis0/ssd32"
             },
             "status": 1
           }
@@ -449,7 +449,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd33"
+              "containment": "/compute/chassis0/ssd33"
             },
             "status": 1
           }
@@ -461,7 +461,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd34"
+              "containment": "/compute/chassis0/ssd34"
             },
             "status": 1
           }
@@ -473,7 +473,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack0/ssd35"
+              "containment": "/compute/chassis0/ssd35"
             },
             "status": 1
           }
@@ -488,7 +488,7 @@
               "pdebug": ""
             },
             "paths": {
-              "containment": "/compute/rack0/compute-01"
+              "containment": "/compute/chassis0/compute-01"
             }
           }
         },
@@ -499,7 +499,7 @@
             "id": 0,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core0"
+              "containment": "/compute/chassis0/compute-01/core0"
             }
           }
         },
@@ -510,7 +510,7 @@
             "id": 1,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core1"
+              "containment": "/compute/chassis0/compute-01/core1"
             }
           }
         },
@@ -521,7 +521,7 @@
             "id": 2,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core2"
+              "containment": "/compute/chassis0/compute-01/core2"
             }
           }
         },
@@ -532,7 +532,7 @@
             "id": 3,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core3"
+              "containment": "/compute/chassis0/compute-01/core3"
             }
           }
         },
@@ -543,7 +543,7 @@
             "id": 4,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core4"
+              "containment": "/compute/chassis0/compute-01/core4"
             }
           }
         },
@@ -554,7 +554,7 @@
             "id": 5,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core5"
+              "containment": "/compute/chassis0/compute-01/core5"
             }
           }
         },
@@ -565,7 +565,7 @@
             "id": 6,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core6"
+              "containment": "/compute/chassis0/compute-01/core6"
             }
           }
         },
@@ -576,7 +576,7 @@
             "id": 7,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core7"
+              "containment": "/compute/chassis0/compute-01/core7"
             }
           }
         },
@@ -587,7 +587,7 @@
             "id": 8,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core8"
+              "containment": "/compute/chassis0/compute-01/core8"
             }
           }
         },
@@ -598,21 +598,21 @@
             "id": 9,
             "rank": 0,
             "paths": {
-              "containment": "/compute/rack0/compute-01/core9"
+              "containment": "/compute/chassis0/compute-01/core9"
             }
           }
         },
         {
           "id": "49",
           "metadata": {
-            "type": "rack",
+            "type": "chassis",
             "id": 1,
             "properties": {
               "rabbit": "kind-worker3",
               "ssdcount": "36"
             },
             "paths": {
-              "containment": "/compute/rack1"
+              "containment": "/compute/chassis1"
             }
           }
         },
@@ -623,7 +623,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd0"
+              "containment": "/compute/chassis1/ssd0"
             },
             "status": 1
           }
@@ -635,7 +635,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd1"
+              "containment": "/compute/chassis1/ssd1"
             },
             "status": 1
           }
@@ -647,7 +647,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd2"
+              "containment": "/compute/chassis1/ssd2"
             },
             "status": 1
           }
@@ -659,7 +659,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd3"
+              "containment": "/compute/chassis1/ssd3"
             },
             "status": 1
           }
@@ -671,7 +671,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd4"
+              "containment": "/compute/chassis1/ssd4"
             },
             "status": 1
           }
@@ -683,7 +683,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd5"
+              "containment": "/compute/chassis1/ssd5"
             },
             "status": 1
           }
@@ -695,7 +695,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd6"
+              "containment": "/compute/chassis1/ssd6"
             },
             "status": 1
           }
@@ -707,7 +707,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd7"
+              "containment": "/compute/chassis1/ssd7"
             },
             "status": 1
           }
@@ -719,7 +719,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd8"
+              "containment": "/compute/chassis1/ssd8"
             },
             "status": 1
           }
@@ -731,7 +731,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd9"
+              "containment": "/compute/chassis1/ssd9"
             },
             "status": 1
           }
@@ -743,7 +743,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd10"
+              "containment": "/compute/chassis1/ssd10"
             },
             "status": 1
           }
@@ -755,7 +755,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd11"
+              "containment": "/compute/chassis1/ssd11"
             },
             "status": 1
           }
@@ -767,7 +767,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd12"
+              "containment": "/compute/chassis1/ssd12"
             },
             "status": 1
           }
@@ -779,7 +779,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd13"
+              "containment": "/compute/chassis1/ssd13"
             },
             "status": 1
           }
@@ -791,7 +791,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd14"
+              "containment": "/compute/chassis1/ssd14"
             },
             "status": 1
           }
@@ -803,7 +803,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd15"
+              "containment": "/compute/chassis1/ssd15"
             },
             "status": 1
           }
@@ -815,7 +815,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd16"
+              "containment": "/compute/chassis1/ssd16"
             },
             "status": 1
           }
@@ -827,7 +827,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd17"
+              "containment": "/compute/chassis1/ssd17"
             },
             "status": 1
           }
@@ -839,7 +839,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd18"
+              "containment": "/compute/chassis1/ssd18"
             },
             "status": 1
           }
@@ -851,7 +851,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd19"
+              "containment": "/compute/chassis1/ssd19"
             },
             "status": 1
           }
@@ -863,7 +863,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd20"
+              "containment": "/compute/chassis1/ssd20"
             },
             "status": 1
           }
@@ -875,7 +875,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd21"
+              "containment": "/compute/chassis1/ssd21"
             },
             "status": 1
           }
@@ -887,7 +887,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd22"
+              "containment": "/compute/chassis1/ssd22"
             },
             "status": 1
           }
@@ -899,7 +899,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd23"
+              "containment": "/compute/chassis1/ssd23"
             },
             "status": 1
           }
@@ -911,7 +911,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd24"
+              "containment": "/compute/chassis1/ssd24"
             },
             "status": 1
           }
@@ -923,7 +923,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd25"
+              "containment": "/compute/chassis1/ssd25"
             },
             "status": 1
           }
@@ -935,7 +935,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd26"
+              "containment": "/compute/chassis1/ssd26"
             },
             "status": 1
           }
@@ -947,7 +947,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd27"
+              "containment": "/compute/chassis1/ssd27"
             },
             "status": 1
           }
@@ -959,7 +959,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd28"
+              "containment": "/compute/chassis1/ssd28"
             },
             "status": 1
           }
@@ -971,7 +971,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd29"
+              "containment": "/compute/chassis1/ssd29"
             },
             "status": 1
           }
@@ -983,7 +983,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd30"
+              "containment": "/compute/chassis1/ssd30"
             },
             "status": 1
           }
@@ -995,7 +995,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd31"
+              "containment": "/compute/chassis1/ssd31"
             },
             "status": 1
           }
@@ -1007,7 +1007,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd32"
+              "containment": "/compute/chassis1/ssd32"
             },
             "status": 1
           }
@@ -1019,7 +1019,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd33"
+              "containment": "/compute/chassis1/ssd33"
             },
             "status": 1
           }
@@ -1031,7 +1031,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd34"
+              "containment": "/compute/chassis1/ssd34"
             },
             "status": 1
           }
@@ -1043,7 +1043,7 @@
             "unit": "GiB",
             "size": 1024,
             "paths": {
-              "containment": "/compute/rack1/ssd35"
+              "containment": "/compute/chassis1/ssd35"
             },
             "status": 1
           }

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -189,7 +189,7 @@ test_expect_success 'flux sets badrabbit property on compute node, job is not sc
     sleep 3 &&
     test_must_fail flux job wait-event -vt 1 ${jobid} finish &&
     flux resource drain | test_must_fail grep compute-01 &&
-    flux ion-resource get-property /compute/rack0/compute-01 badrabbit &&
+    flux ion-resource get-property /compute/chassis0/compute-01 badrabbit &&
     flux jobtap load ${PLUGINPATH}/dws-jobtap.so &&
     JOBID=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs \
         name=project1" -N1 -n1 hostname) &&
@@ -208,7 +208,7 @@ test_expect_success 'return the storage resource to Live mode' '
 
 test_expect_success 'flux removes badrabbit property from compute node, job is scheduled' '
     sleep 5 &&
-    test_must_fail flux ion-resource get-property /compute/rack0/compute-01 badrabbit &&
+    test_must_fail flux ion-resource get-property /compute/chassis0/compute-01 badrabbit &&
     JOBID=$(flux submit --setattr=system.dw="#DW jobdw capacity=10GiB type=xfs \
         name=project1" -N1 -n1 hostname) &&
     flux job wait-event -vt 10 ${JOBID} jobspec-update &&

--- a/t/t2000-dws2jgf.t
+++ b/t/t2000-dws2jgf.t
@@ -82,7 +82,7 @@ test_expect_success 'flux-dws2jgf.py reading from config file is same as parse-c
 	test_cmp ${DATADIR}/expected-configfile.jgf actual-configfile-parseconfig.jgf
 '
 
-test_expect_success 'fluxion rejects a rack/rabbit job when no rabbits are recognized' '
+test_expect_success 'fluxion rejects a chassis/rabbit job when no rabbits are recognized' '
 	flux module remove -f sched-fluxion-qmanager &&
 	flux module remove -f sched-fluxion-resource &&
 	flux module reload resource &&
@@ -108,14 +108,14 @@ test_expect_success 'fluxion can be loaded with output of dws2jgf' '
 	flux job wait-event -vt 2 -m status=0 ${JOBID} finish
 '
 
-test_expect_success 'fluxion does not allocate a rack/rabbit job after adding down rabbits' '
+test_expect_success 'fluxion does not allocate a chassis/rabbit job after adding down rabbits' '
 	JOBID=$(flux job submit ${DATADIR}/rabbit-jobspec.json) &&
 	test_must_fail flux job wait-event -vt 2 ${JOBID} alloc &&
 	flux cancel $JOBID
 '
 
-test_expect_success 'fluxion allocates a rack/rabbit job when rabbit is up' '
-	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan/rack0/ssd0 up &&
+test_expect_success 'fluxion allocates a chassis/rabbit job when rabbit is up' '
+	${SHARNESS_TEST_SRCDIR}/scripts/set_status.py /ElCapitan/chassis0/ssd0 up &&
 	JOBID=$(flux job submit ${DATADIR}/rabbit-jobspec.json) &&
 	flux job wait-event -vt 2 -m status=0 ${JOBID} finish &&
 	flux job attach $JOBID &&


### PR DESCRIPTION
Problem: the 'rack' vertices in JGF generated by `dws2jgf` are misnamed; the physical object they represent is actually a chassis, not a rack. This can lead to all kinds of confusion when talking about the layout of elcap systems, because it can be unclear whether one is talking about a physical rack or a rack vertex.

Rename `rack` vertices to `chassis`.

Fixes #399.