### PR TITLE
build: just warn if kubernetes is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 AM_CHECK_PYMOD(kubernetes,
                   [Version(kubernetes.__version__) >= Version('11.0.0')],
                   ,
-                  [AC_MSG_ERROR([could not find python module kubernetes, version 11.0.0+ required])]
+                  [AC_MSG_WARN([could not find python module kubernetes, version 11.0.0+ required])]
                 )
 
 AS_IF([test "x$enable_docs" != "xno"], [


### PR DESCRIPTION
Problem: the kubernetes python module on TOSS 4 systems is too old to work with flux-coral2, which makes it a bit annoying to develop other aspects of flux-coral2 on TOSS.

Change the error to a warning so flux-coral2 can be configured on TOSS 4.

p.s. I'm not really sure if this is a good idea.  I defer to @jameshcorbett if there is a better way to deal with this.  I just keep adding this commit in my local development branches, which is a bit annoying to have to keep remembering.