### PR TITLE
ci: add libcxi to one of the docker builds

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -12,3 +12,4 @@ extend-exclude = [
 # commonly used names/variables that aren't typos
 BA = "BA"
 HPE = "HPE"
+SHS = "SHS"

--- a/scripts/build-libcxi.sh
+++ b/scripts/build-libcxi.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+# Last tested with libcxi main branch, at:
+#  Thu Sep 4 17:33:35 2025 -0500
+#  1eab4498d397c91de4f3652b9dfec1f9045fa4c8
+# and contemporaeous cxi-driver.
+
+git clone \
+    --recursive --depth=1 https://github.com/HewlettPackard/shs-cassini-headers
+mkdir -p cassini-headers
+ln -s ../shs-cassini-headers cassini-headers/install
+
+git clone -b ${SHS_CXI_DRIVER_BRANCH:-main} \
+    --recursive --depth=1 https://github.com/HewlettPackard/shs-cxi-driver
+
+git clone -b ${SHS_LIBCXI_BRANCH:-main} \
+    --recursive --depth=1 https://github.com/HewlettPackard/shs-libcxi
+
+BUILD_CPPFLAGS="-I$(pwd)/shs-cassini-headers/include -I$(pwd)/shs-cxi-driver/include"
+BUILD_CFLAGS="-Wno-unused-but-set-variable"
+
+cd shs-libcxi
+./autogen.sh
+CFLAGS="$BUILD_CPPFLAGS $BUILD_CFLAGS" ./configure --prefix=/usr
+make

--- a/scripts/install-libcxi-deps-deb.sh
+++ b/scripts/install-libcxi-deps-deb.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+apt -qq install -y \
+  libconfig-dev \
+  libuv1-dev \
+  libfuse-dev \
+  libyaml-dev \
+  libnl-3-dev \
+  libsensors-dev

--- a/scripts/install-libcxi.sh
+++ b/scripts/install-libcxi.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+cd shs-cassini-headers/include
+install -m 0644 cassini_cntr_defs.h /usr/include
+install -m 0644 cxi_prov_hw.h /usr/include
+install -m 0644 cassini_user_defs.h /usr/include
+cd ../..
+
+cd shs-cxi-driver/include/uapi
+install -m 0755 -d /usr/include/uapi/misc
+install -m 0644 misc/cxi.h /usr/include/uapi/misc
+if test -f ethernet/cxi-abi.h; then
+    install -m 0755 -d /usr/include/uapi/ethernet
+    install -m 0644 ethernet/cxi-abi.h /usr/include/uapi/ethernet
+fi
+cd ../../..
+
+cd shs-libcxi
+make install

--- a/src/cmd/flux-slingshot.c
+++ b/src/cmd/flux-slingshot.c
@@ -583,13 +583,19 @@ static int cmd_prolog (optparse_t *p, int argc, char **argv)
     if (json_array_size (vnis) == 0)
         goto done;
     ncores = ncores_from_R (f_R);
+    int count = 0;
 #if HAVE_CXI
-    allocate_cxi_service (p, uid, vnis, ncores);
-#else
-    char *s = json_dumps (vnis, JSON_COMPACT);
-    warn ("no CXI support uid=%u ncores=%d vnis=%s", uid, ncores, s ? s : "");
-    free (s);
+    count = allocate_cxi_service (p, uid, vnis, ncores);
 #endif
+    /* N.B. tests expect to find ncore and vnis in output, so if it
+     * wasn't emitted during service creation (no CXI support or no devices),
+     * do it here.
+     */
+    if (count == 0) {
+        char *s = json_dumps (vnis, JSON_COMPACT);
+        warn ("no CXI devices uid=%u ncores=%d vnis=%s", uid, ncores, s ? s : "");
+        free (s);
+    }
     json_decref (res);
 done:
     flux_future_destroy (f_eventlog);

--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -3,6 +3,11 @@ FROM fluxrm/flux-sched:noble
 ARG USER=fluxuser
 ARG UID=1000
 ARG KUBECTL_VERSION=latest
+ARG SHS_CXI_DRIVER_BRANCH=release/shs-13.0
+ARG SHS_LIBCXI_BRANCH=release/shs-13.0
+
+ENV SHS_CXI_DRIVER_BRANCH=${SHS_CXI_DRIVER_BRANCH}
+ENV SHS_LIBCXI_BRANCH=${SHS_LIBCXI_BRANCH}
 
 # Copy scripts into image
 COPY scripts/ /scripts
@@ -22,6 +27,19 @@ RUN sudo /scripts/kubectl.sh \
   && echo "source /scripts/sync-kube-config.sh" | sudo tee -a /etc/bash.bashrc \
   && sudo chmod 755 /etc/bash.bashrc
 
+# Install libcxi prereqs
+RUN sudo /scripts/install-libcxi-deps-deb.sh \
+  && sudo apt clean \
+  && sudo rm -rf /var/lib/apt/lists*
+
+# Build/install libcxi
+RUN cd /tmp \
+  && /scripts/build-libcxi.sh \
+  && sudo /scripts/install-libcxi.sh \
+  && rm -rf shs-libcxi \
+  && rm -rf shs-cxi-driver \
+  && rm -rf shs-cassini-headers \
+  && rm -rf cassini-headers
 
 USER $USER
 WORKDIR /home/$USER


### PR DESCRIPTION
Problem: conditionally compiled slingshot support isn't even compile-tested in CI.

Build the open source libcxi and install it in the `noble` Docker image so we can do a compile test on at least one platform.  Our software won't find any slingshot devices but at least we can find compilation issues.

The docker image uses the `release/shs-13.0` branch to hopefully maintain stability moving forward (there are no tags in that repo).  Some scripts are also added that can install the main development branch on a test system if desired.