### PR TITLE
set SLINGSHOT_TCS in job environment

### DIFF
--- a/doc/guide/slingshot.rst
+++ b/doc/guide/slingshot.rst
@@ -203,7 +203,10 @@ This is reflected in the job environment:
 
 .. envvar:: SLINGSHOT_TCS
 
-   Hex bitmask of allowed traffic classes.
+   Bitmask of allowed traffic classes. The bit encoding is
+   :const:`DEDICATED ACCESS` (1), :const:`LOW_LATENCY` (2),
+   :const:`BULK_DATA` (4), :const:`BEST_EFFORT` (8).  This environment
+   variable is interpreted by Cray MPICH.
 
 Example::
 

--- a/t/t3001-slingshot-shell.t
+++ b/t/t3001-slingshot-shell.t
@@ -73,6 +73,7 @@ test_expect_success 'run a job with broker SLINGSHOT_ environment' '
 	    --env=SLINGSHOT_VNIS=999 \
 	    --env=SLINGSHOT_DEVICES=cxi0,cxi1 \
 	    --env=SLINGSHOT_SVC_IDS=42,43 \
+	    --env=SLINGSHOT_TCS=0x0a \
 	    sh -c "flux setattr conf.shell_initrc testrc.lua &&
 	    flux run -o verbose=2 printenv >inherit.out 2>inherit.err"
 '
@@ -82,7 +83,8 @@ test_expect_success 'job is running in inherited mode' '
 test_expect_success 'the slingshot environment is inherited' '
 	grep SLINGSHOT_VNIS=999 inherit.out &&
 	grep SLINGSHOT_DEVICES=cxi0,cxi1 inherit.out &&
-	grep SLINGSHOT_SVC_IDS=42,43 inherit.out
+	grep SLINGSHOT_SVC_IDS=42,43 inherit.out &&
+	grep SLINGSHOT_TCS=0x0a inherit.out
 '
 
 ##
@@ -101,6 +103,9 @@ test_expect_success 'job is running in reservation mode' '
 # CI: SLINGSHOST_VNIS will be set even if there are no devices present
 test_expect_success 'SLINGSHOT_VNIS=1024' '
 	grep SLINGSHOT_VNIS=1024 rez.out
+'
+test_expect_success 'SLINGSHOT_TCS=0xf' '
+	grep SLINGSHOT_TCS=0xf rez.out
 '
 test_expect_success 'run a job that requests two vnis' '
 	flux run -o verbose=2 -o cray-slingshot.vnicount=2 \
@@ -121,6 +126,9 @@ test_expect_success 'job is running in reservation mode' '
 '
 test_expect_success 'SLINGSHOT_VNIS is not set' '
 	test_must_fail grep SLINGSHOT_VNIS rez0.out
+'
+test_expect_success 'SLINGSHOT_TCS=0xf' '
+	grep SLINGSHOT_TCS=0xf rez0.out
 '
 
 test_done


### PR DESCRIPTION
Problem: the cray-slingshot shell plugin does not set SLINGSHOT_TCS in the job environment, but Cray MPICH does use it if set.

Set it as discussed in #412 