### PR TITLE
flux-slingshot clean: fall back to default pool config

### DIFF
--- a/src/job-manager/plugins/cray-slingshot.c
+++ b/src/job-manager/plugins/cray-slingshot.c
@@ -63,7 +63,7 @@ struct cray_slingshot {
     bool vni_reserve_fatal;
 };
 
-static const char *vni_pool_default = "1024-65535";
+static const char *vni_pool_default = VNIPOOL_DEFAULT;
 static const int vnis_per_job_default = 1;
 static const bool vni_reserve_fatal_default = true;
 

--- a/src/job-manager/plugins/vnipool.h
+++ b/src/job-manager/plugins/vnipool.h
@@ -16,6 +16,8 @@
 #include <jansson.h>
 #include <flux/core.h>
 
+#define VNIPOOL_DEFAULT "1024-65535"
+
 struct vnipool *vnipool_create (void);
 void vnipool_destroy (struct vnipool *vp);
 

--- a/t/t3002-slingshot-cmd.t
+++ b/t/t3002-slingshot-cmd.t
@@ -74,7 +74,22 @@ test_expect_success 'flux-slingshot epilog --retry-busy=badfsd fails' '
 	    --jobid=$(flux job last) --retry-busy=badfsd
 '
 test_expect_success 'flux-slingshot clean --dry-run works' '
-	$SLINGSHOT_CMD clean --dry-run
+	$SLINGSHOT_CMD clean --dry-run 2>clean.err
+'
+test_expect_success 'the default vnipool was logged' '
+	grep "vnipool = 1024-65535" clean.err
+'
+test_expect_success 'reconfigure the vnipool' '
+	flux config load <<-EOT
+	[cray-slingshot]
+	vni-pool = "1000-1001"
+	EOT
+'
+test_expect_success 'flux-slingshot clean --dry-run works' '
+	$SLINGSHOT_CMD clean --dry-run 2>clean2.err
+'
+test_expect_success 'the new vnipool was logged' '
+	grep "vnipool = 1000-1001" clean2.err
 '
 
 test_done


### PR DESCRIPTION
Problem: `flux slingshot clean` doesn't know that there is now a default vni pool config.

Fix that.

Note that this isn't even used yet because it's a little scary.  At this point the housekeeping script just runs `flux slingshot epilog` with a longer `--retry-busy` duration than the epilog script.  IOW it only removes CXI services for the job that triggered housekeeping.  `clean` would remove _all_ CXI services matching Flux's VNI pool on the assumption that the node is exclusively scheduled and none should be active at that point.