### PR TITLE
doc: add man page for flux run --coral2-chassis

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -13,7 +13,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-rabbitmapping.1 \
 	man1/flux-getrabbit.1 \
 	man1/flux-dws2jgf.1 \
-	man1/flux-jobtap-dws.1
+	man1/flux-jobtap-dws.1 \
+	man1/flux-coral2-chassis.1
 
 MAN5_FILES = $(MAN5_FILES_PRIMARY)
 

--- a/doc/guide/rabbit.rst
+++ b/doc/guide/rabbit.rst
@@ -263,3 +263,10 @@ of Flux's KVS, the complete logs cannot be stored.
 .. code-block:: bash
 
 	flux job info ${jobid} rabbit_container_log | less
+
+Node Distribution
+~~~~~~~~~~~~~~~~~
+
+Rabbit systems have one rabbit per chassis. The :man1:`flux-coral2-chassis` flag
+may therefore be useful in controlling the allocation of rabbits, especially
+for node-local file systems like XFS.

--- a/doc/man1/flux-coral2-chassis.rst
+++ b/doc/man1/flux-coral2-chassis.rst
@@ -1,0 +1,43 @@
+======================
+flux-coral2-chassis(1)
+======================
+
+
+SYNOPSIS
+========
+
+**flux** **run** **--nodes=N** *--coral2-chassis=COUNT*
+
+
+DESCRIPTION
+===========
+
+:program:`--coral2-chassis` is an optional flag added to
+:core:man1:`flux-submit`, :core:man1:`flux-run`, :core:man1:`flux-alloc`,
+and :core:man1:`flux-batch`. The flag takes a positive integer, representing
+the number of chassis desired; the number of nodes specified via ``-N, --nodes``
+will then be split evenly across that number of chassis.
+
+Use of the ``--coral2-chassis`` flag requires that ``-N, --nodes`` be specified.
+Also, current limitations require that the number of chassis evenly divide the
+number of nodes. For example, five total nodes across three chassis *is not*
+supported, but fifteen total nodes across three chassis is supported.
+
+When not specified, the number of chassis chosen is up to the scheduler.
+
+
+EXAMPLES
+========
+
+Request 15 nodes, all on a single chassis:
+
+::
+
+  flux alloc -N15 --coral2-chassis=1 -q myqueue /bin/true
+
+Request 200 nodes split evenly across 20 chassis:
+
+::
+
+  flux alloc -N200 --coral2-chassis=20 -q myqueue /bin/true
+

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -72,6 +72,13 @@ man_pages = [
         1,
     ),
     (
+        "man1/flux-coral2-chassis",
+        "flux-coral2-chassis",
+        "Optional chassis flag for flux job submission",
+        [author],
+        1,
+    ),
+    (
         "man5/flux-config-slingshot",
         "flux-config-slingshot",
         "Flux Slingshot Configuration",


### PR DESCRIPTION
Problem: there is no documentation for the `--coral2-chassis` flag.

Add documentation.