### PR TITLE
dws: update dws and nnf crd versions

### DIFF
--- a/src/python/flux_k8s/crd.py
+++ b/src/python/flux_k8s/crd.py
@@ -5,11 +5,11 @@ from collections import namedtuple
 CRD = namedtuple("CRD", ["group", "version", "namespace", "plural"])
 
 DWS_GROUP = "dataworkflowservices.github.io"
-DWS_API_VERSION = "v1alpha6"
+DWS_API_VERSION = "v1alpha7"
 DEFAULT_NAMESPACE = "default"
 
 NNF_GROUP = "nnf.cray.hpe.com"
-NNF_API_VERSION = "v1alpha8"
+NNF_API_VERSION = "v1alpha9"
 
 
 WORKFLOW_CRD = CRD(


### PR DESCRIPTION
Problem: the latest API versions for DWS and NNF are a release above what is used in the code base.

Increment the version strings, so that they are at the latest.

WIP until the versions referenced in the PR are deployed across LC.