### PR TITLE
t: fix broken test in t1003 with explicit config

### DIFF
--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -240,7 +240,10 @@ test_expect_success 'configure flux with queues' '
 '
 
 test_expect_success 'exec Storage watching script with --drain-queues' '
-    flux config reload &&
+    echo "
+[rabbit]
+drain_compute_nodes = true
+    " | flux config load &&
     jobid=$(flux submit \
             --setattr=system.alloc-bypass.R="$(flux R encode -r0)" --output=dws4.out --error=dws4.err \
             -o per-resource.type=node flux python ${DWS_MODULE_PATH} -vvv --drain-queues debug) &&


### PR DESCRIPTION
Problem: a test in t1003 relies on a config value being reset to its default value of `true` after running `flux config reload`. However, at some point that began failing.

Update the test to manually specify the desired config value.