### PR TITLE
dws: improve malformed RPC error message

### DIFF
--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -691,6 +691,13 @@ static void resource_update_msg_cb (flux_t *h,
                          &constraint_to_add)
         < 0) {
         errmsg = "received malformed dws.resource-update RPC";
+        if (flux_msg_unpack (msg, "{s:I}", "id", &jobid) == 0) {
+            raise_job_exception (p, jobid, "exception", errmsg);
+        }
+        flux_log_error (h,
+                        "%s, coral2_dws module and dws_jobtap plugin versions"
+                        " may be out of sync, Flux may need to be restarted",
+                        errmsg);
         goto error;
     }
     if (errmsg) {
@@ -764,6 +771,13 @@ static void prolog_remove_msg_cb (flux_t *h,
 
     if (flux_msg_unpack (msg, "{s:I, s:o}", "id", &jobid, "variables", &env) < 0) {
         errmsg = "received malformed dws.prolog-remove RPC";
+        if (flux_msg_unpack (msg, "{s:I}", "id", &jobid) == 0) {
+            raise_job_exception (p, jobid, "exception", errmsg);
+        }
+        flux_log_error (h,
+                        "%s, coral2_dws module and dws_jobtap plugin versions"
+                        " may be out of sync, Flux may need to be restarted",
+                        errmsg);
         goto error;
     }
     if (!(prolog_active = flux_jobtap_job_aux_get (p, (flux_jobid_t)jobid, "dws_prolog_active"))) {
@@ -811,6 +825,10 @@ static void epilog_remove_msg_cb (flux_t *h,
 
     if (flux_msg_unpack (msg, "{s:I}", "id", &jobid) < 0) {
         errmsg = "received malformed dws.epilog-remove RPC";
+        flux_log_error (h,
+                        "%s, coral2_dws module and dws_jobtap plugin versions"
+                        " may be out of sync, Flux may need to be restarted",
+                        errmsg);
         goto error;
     }
     if (!(job = flux_jobtap_job_lookup (p, jobid))

--- a/t/dws-dependencies/coral2_dws.py
+++ b/t/dws-dependencies/coral2_dws.py
@@ -13,6 +13,7 @@ parser.add_argument("--setup-hang", action="store_true")
 parser.add_argument("--post-run-fail", action="store_true")
 parser.add_argument("--teardown-hang", action="store_true")
 parser.add_argument("--exclude", default="")
+parser.add_argument("--bad-rpc", action="store_true")
 
 args = parser.parse_args()
 
@@ -31,14 +32,20 @@ def create_cb(fh, t, msg, arg):
     print(f"Responded to create request with {payload}")
     if not payload["success"]:
         return
-    fh.rpc(
-        "job-manager.dws.resource-update",
-        payload={
-            "id": msg.payload["jobid"],
-            "resources": msg.payload["resources"],
-            "exclude": {"not": [{"properties": [args.exclude]}]},
-        },
-    )
+    if args.bad_rpc:
+        fh.rpc(
+            "job-manager.dws.resource-update",
+            payload={"id": msg.payload["jobid"]},
+        )
+    else:
+        fh.rpc(
+            "job-manager.dws.resource-update",
+            payload={
+                "id": msg.payload["jobid"],
+                "resources": msg.payload["resources"],
+                "exclude": {"not": [{"properties": [args.exclude]}]},
+            },
+        )
 
 
 def setup_cb(fh, t, msg, arg):

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -376,4 +376,16 @@ test_expect_success 'job-manager: dws jobtap plugin adds or-rabbit constraint' '
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
 
+test_expect_success 'job-manager: dws jobtap plugin raises exception after bad RPC' '
+	create_jobid=$(flux submit -t 8 --output=dws17.out --error=dws17.out \
+		flux python ${DWS_SCRIPT} --bad-rpc) &&
+	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
+	jobid=$(flux submit -S dw="foo" hostname) &&
+	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -vt 2 ${jobid} exception | grep malformed &&
+	flux job wait-event -vt 5 ${jobid} clean &&
+	flux job wait-event -vt 5 ${create_jobid} clean
+'
+
 test_done


### PR DESCRIPTION
Problem: when RPC protocol changes between flux-coral2 versions, and flux-coral2 is updated on a live system, the `dws-jobtap` plugin may be left at an older version that is incompatible with the `coral2_dws` module.

Add a more descriptive error message and suggest restarting Flux to reload both the `coral2_dws` module and the `dws-jobtap` plugin.