### PR TITLE
dws: enable faulthandler module

### DIFF
--- a/src/modules/coral2_dws.py
+++ b/src/modules/coral2_dws.py
@@ -23,6 +23,7 @@ import base64
 import cProfile
 import pstats
 import io
+import faulthandler
 
 import kubernetes
 import kubernetes.client
@@ -1143,6 +1144,7 @@ def main():
     """Init script, begin processing of services."""
     profiler = cProfile.Profile()
     profiler.enable()
+    faulthandler.enable()
     args = setup_parsing().parse_args()
     _MIN_ALLOCATION_SIZE = args.min_allocation_size
     config_logging(args)


### PR DESCRIPTION
Problem: when the `coral2_dws` module is killed by systemd due to a watchdog timeout, it would be good to see a stack trace.

Enable the faulthandler module to print a stack trace on SIGABRT.