### PR TITLE
dws: start epilog on finish event

### DIFF
--- a/src/cmd/flux-dws2jgf.py
+++ b/src/cmd/flux-dws2jgf.py
@@ -124,7 +124,7 @@ class Coral2Graph(FluxionResourceGraphV1):
                     self._rank_to_properties.get(index, {}),
                 )
         # if the rabbit itself is in R, add it to the chassis as well,
-        # with type 'rabbit'
+        # with type 'storage_node'
         try:
             index = self._r_hostlist.index(rabbit_name)[0]
         except FileNotFoundError:

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -444,16 +444,90 @@ cleanup:
     return;
 }
 
-static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+/* Helper function to start DWS epilog for a job.
+ * Called by both finish_cb (for jobs that ran) and cleanup_cb (for jobs that
+ * failed before starting). The dws_run_started parameter indicates whether the
+ * job actually started (1) or not (0), which is passed to the coral2_dws service.
+ */
+static int start_dws_epilog_for_job (flux_plugin_t *p, flux_jobid_t id, int dws_run_started)
 {
-    flux_jobid_t id;
-    json_t *dw = NULL;
     flux_future_t *post_run_fut;
     flux_t *h = flux_jobtap_get_flux (p);
     flux_reactor_t *r = flux_get_reactor (h);
     flux_watcher_t *watcher = NULL;
-    int dws_run_started = 0;
     struct create_arg_t *create_args = NULL;
+
+    if (!r) {
+        flux_log_error (h, "Failed to fetch reactor from handle for %s", idf58 (id));
+        current_job_exception (p, "Failed to fetch reactor from handle");
+        return -1;
+    }
+    if (!(create_args = calloc (1, sizeof (struct create_arg_t)))
+        || flux_jobtap_job_aux_set (p, FLUX_JOBTAP_CURRENT_JOB, NULL, create_args, free) < 0) {
+        free (create_args);
+        flux_log_error (h, "error allocating arg struct for %s: %s", idf58 (id), __FUNCTION__);
+        current_job_exception (p, "error allocating arg struct");
+        return -1;
+    }
+    create_args->p = p;
+    create_args->id = id;
+
+    if (flux_jobtap_job_aux_set (p, id, "dws_epilog_active", (void *)1, NULL) < 0
+        || flux_jobtap_epilog_start (p, DWS_EPILOG_NAME) < 0) {
+        flux_log_error (h, "Failed to start jobtap epilog for %s", idf58 (id));
+        current_job_exception (p, "Failed to start jobtap epilog");
+        return -1;
+    }
+    if (epilog_timeout > 0.0) {
+        if (!(watcher = flux_timer_watcher_create (r,
+                                                   epilog_timeout,
+                                                   0.0,
+                                                   epilog_timeout_cb,
+                                                   create_args))
+            || flux_jobtap_job_aux_set (p,
+                                        FLUX_JOBTAP_CURRENT_JOB,
+                                        NULL,
+                                        watcher,
+                                        (flux_free_f)flux_watcher_destroy)
+                   < 0) {
+            dws_epilog_finish (h, p, id, 0, "Failed to init " DWS_EPILOG_NAME " timeout");
+            flux_log_error (h, "Failed to init " DWS_EPILOG_NAME " timeout for %s", idf58 (id));
+            flux_watcher_destroy (watcher);
+            return -1;
+        }
+        flux_watcher_start (watcher);
+    }
+    if (!(post_run_fut = flux_rpc_pack (h,
+                                        "dws.post_run",
+                                        FLUX_NODEID_ANY,
+                                        0,
+                                        "{s:I, s:b}",
+                                        "jobid",
+                                        id,
+                                        "run_started",
+                                        dws_run_started))
+        || flux_future_then (post_run_fut, -1., post_run_rpc_callback, create_args) < 0
+        || flux_jobtap_job_aux_set (p,
+                                    FLUX_JOBTAP_CURRENT_JOB,
+                                    NULL,
+                                    post_run_fut,
+                                    (flux_free_f)flux_future_destroy)
+               < 0) {
+        flux_future_destroy (post_run_fut);
+        dws_epilog_finish (h, p, id, 0, "Failed to send dws.post_run RPC");
+        flux_log_error (h, "Failed to send dws.post_run RPC for %s", idf58 (id));
+        return -1;
+    }
+    return 0;
+}
+
+/* Callback for CLEAN state.
+ * Starts the epilog if the job had no 'start' event.
+ */
+static int cleanup_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+{
+    flux_jobid_t id;
+    json_t *dw = NULL;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -471,70 +545,40 @@ static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     }
     // check that the job has a DW attr section
     if (dw) {
-        if (!r) {
-            flux_log_error (h, "Failed to fetch reactor from handle for %s", idf58 (id));
-            current_job_exception (p, "Failed to fetch reactor from handle");
-            return -1;
+        if (!flux_jobtap_job_event_posted (p, FLUX_JOBTAP_CURRENT_JOB, "start")) {
+            // no 'start' event, therefore no 'finish' event, so we need to start the epilog here
+            return start_dws_epilog_for_job (p, id, 0);
         }
-        if (!(create_args = calloc (1, sizeof (struct create_arg_t)))
-            || flux_jobtap_job_aux_set (p, FLUX_JOBTAP_CURRENT_JOB, NULL, create_args, free) < 0) {
-            free (create_args);
-            flux_log_error (h, "error allocating arg struct for %s: %s", idf58 (id), __FUNCTION__);
-            current_job_exception (p, "error allocating arg struct");
-            return -1;
-        }
-        create_args->p = p;
-        create_args->id = id;
+    }
+    return 0;
+}
 
-        if (flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::dws_run_started")) {
-            dws_run_started = 1;
-        }
-        if (flux_jobtap_job_aux_set (p, id, "dws_epilog_active", (void *)1, NULL) < 0
-            || flux_jobtap_epilog_start (p, DWS_EPILOG_NAME) < 0) {
-            flux_log_error (h, "Failed to start jobtap epilog for %s", idf58 (id));
-            current_job_exception (p, "Failed to start jobtap epilog");
-            return -1;
-        }
-        if (epilog_timeout > 0.0) {
-            if (!(watcher = flux_timer_watcher_create (r,
-                                                       epilog_timeout,
-                                                       0.0,
-                                                       epilog_timeout_cb,
-                                                       create_args))
-                || flux_jobtap_job_aux_set (p,
-                                            FLUX_JOBTAP_CURRENT_JOB,
-                                            NULL,
-                                            watcher,
-                                            (flux_free_f)flux_watcher_destroy)
-                       < 0) {
-                dws_epilog_finish (h, p, id, 0, "Failed to init " DWS_EPILOG_NAME " timeout");
-                flux_log_error (h, "Failed to init " DWS_EPILOG_NAME " timeout for %s", idf58 (id));
-                flux_watcher_destroy (watcher);
-                return -1;
-            }
-            flux_watcher_start (watcher);
-        }
-        if (!(post_run_fut = flux_rpc_pack (h,
-                                            "dws.post_run",
-                                            FLUX_NODEID_ANY,
-                                            0,
-                                            "{s:I, s:b}",
-                                            "jobid",
-                                            id,
-                                            "run_started",
-                                            dws_run_started))
-            || flux_future_then (post_run_fut, -1., post_run_rpc_callback, create_args) < 0
-            || flux_jobtap_job_aux_set (p,
-                                        FLUX_JOBTAP_CURRENT_JOB,
-                                        NULL,
-                                        post_run_fut,
-                                        (flux_free_f)flux_future_destroy)
-                   < 0) {
-            flux_future_destroy (post_run_fut);
-            dws_epilog_finish (h, p, id, 0, "Failed to send dws.post_run RPC");
-            flux_log_error (h, "Failed to send dws.post_run RPC for %s", idf58 (id));
-            return -1;
-        }
+/* Callback for finish event.
+ * Starts the epilog.
+ */
+static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+{
+    flux_jobid_t id;
+    json_t *dw = NULL;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:{s:{s?o}}}}",
+                                "id",
+                                &id,
+                                "jobspec",
+                                "attributes",
+                                "system",
+                                "dw",
+                                &dw)
+        < 0) {
+        current_job_exception (p, "Failed to unpack args");
+        return -1;
+    }
+    // check that the job has a DW attr section
+    if (dw) {
+        // since we know the 'finish' event was posted, the job must have started.
+        return start_dws_epilog_for_job (p, id, 1);
     }
     return 0;
 }
@@ -857,6 +901,7 @@ error:
 static const struct flux_plugin_handler tab[] = {
     {"job.state.depend", depend_cb, NULL},
     {"job.state.run", run_cb, NULL},
+    {"job.state.cleanup", cleanup_cb, NULL},
     {"job.event.finish", finish_cb, NULL},
     {"job.event.exception", exception_cb, NULL},
     {0},

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -555,6 +555,10 @@ static int cleanup_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *a
 
 /* Callback for finish event.
  * Starts the epilog.
+ *
+ * Note: Because flux_jobtap_job_subscribe() can be called multiple times
+ * this callback may be invoked multiple times for the same job. We use an aux to ensure
+ * the epilog is only started once.
  */
 static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
@@ -577,6 +581,11 @@ static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     }
     // check that the job has a DW attr section
     if (dw) {
+        // Check if we've already processed the finish event for this job and started the epilog.
+        // This can happen because the plugin subscribes to job events in multiple places.
+        if (flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "dws_epilog_active")) {
+            return 0;
+        }
         // since we know the 'finish' event was posted, the job must have started.
         return start_dws_epilog_for_job (p, id, 1);
     }

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -831,8 +831,7 @@ static void prolog_remove_msg_cb (flux_t *h,
         prolog_active = &junk_prolog_active;  // at least it's a valid address
         flux_log_error (h, "failed to fetch 'dws_prolog_active' aux for %s", idf58 (jobid));
     }
-    if (flux_jobtap_event_post_pack (p, jobid, "dws_environment", "{s:O}", "variables", env) < 0
-        || flux_jobtap_job_aux_set (p, jobid, "flux::dws_run_started", (void *)1, NULL) < 0) {
+    if (flux_jobtap_event_post_pack (p, jobid, "dws_environment", "{s:O}", "variables", env) < 0) {
         errmsg = "failed to post dws_environment event";
         dws_prolog_finish (h, p, jobid, 0, errmsg, prolog_active);
         goto error;

--- a/src/job-manager/plugins/dws-jobtap.c
+++ b/src/job-manager/plugins/dws-jobtap.c
@@ -444,7 +444,7 @@ cleanup:
     return;
 }
 
-static int cleanup_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+static int finish_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_jobid_t id;
     json_t *dw = NULL;
@@ -857,7 +857,7 @@ error:
 static const struct flux_plugin_handler tab[] = {
     {"job.state.depend", depend_cb, NULL},
     {"job.state.run", run_cb, NULL},
-    {"job.state.cleanup", cleanup_cb, NULL},
+    {"job.event.finish", finish_cb, NULL},
     {"job.event.exception", exception_cb, NULL},
     {0},
 };

--- a/t/t1000-dws-dependencies.t
+++ b/t/t1000-dws-dependencies.t
@@ -75,6 +75,12 @@ test_expect_success 'job-manager: dws jobtap plugin works when setup RPC fails' 
 	flux job wait-event -vt 5 -m description=${PROLOG_NAME} -m status=1 \
 		${jobid} prolog-finish &&
 	flux job wait-event -vt 1 ${jobid} exception &&
+	# test that the epilog still runs even with no start event
+	test_must_fail flux job wait-event -vt 0.1 ${jobid} start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-finish &&
 	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
 '
@@ -386,6 +392,32 @@ test_expect_success 'job-manager: dws jobtap plugin raises exception after bad R
 	flux job wait-event -vt 2 ${jobid} exception | grep malformed &&
 	flux job wait-event -vt 5 ${jobid} clean &&
 	flux job wait-event -vt 5 ${create_jobid} clean
+'
+
+test_expect_success 'job-manager: epilog-start event occurs after finish event' '
+	create_jobid=$(flux submit -t 8 --output=dws18.out --error=dws18.out \
+		flux python ${DWS_SCRIPT}) &&
+	flux job wait-event -vt 15 -p guest.exec.eventlog ${create_jobid} shell.start &&
+	jobid=$(flux submit --setattr=system.dw="foo" sleep 10) &&
+	flux job wait-event -vt 5 -m description=${DEPENDENCY_NAME} \
+		${jobid} dependency-add &&
+	flux job wait-event -t 5 -m description=${DEPENDENCY_NAME} \
+		${jobid} dependency-remove &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-start &&
+	flux job wait-event -vt 5 -m description=${PROLOG_NAME} \
+		${jobid} prolog-finish &&
+	flux cancel ${jobid} &&
+	flux job wait-event -vt 5 ${jobid} finish &&
+	flux job wait-event -vt 5 -m description=${EPILOG_NAME} \
+		${jobid} epilog-start &&
+	flux job wait-event -vt 5 ${jobid} clean &&
+	flux job wait-event -vt 5 ${create_jobid} clean &&
+	flux job eventlog ${jobid} > eventlog.txt &&
+	line1=$(grep -n "finish status=" eventlog.txt | head -1 | cut -d: -f1) &&
+	line2=$(grep -n "epilog-start" eventlog.txt | head -1 | cut -d: -f1) &&
+	echo $line1 && echo $line2 &&
+	[ -n "$line1" ] && [ -n "$line2" ] && [ "$line1" -lt "$line2" ]
 '
 
 test_done


### PR DESCRIPTION
@grondo asked in #472 

> Why is the dws epilog action started on entry to CLEANUP state instead of on the finish event?
> 
> As noted above, the job-manager.epilog doesn't start until the finish event. Would it make sense to start the dws epilog at the same time (along with the timer)? Before the finish event is posted, there are still IMP, job shell, and maybe user processes on one or more nodes of the job, so it may not make sense to do whatever occurs in the DWS epilog action.
> 
> A case to handle here though is when a prolog fails there will be no start event and thus no finish event. In the perilog plugin the job-manager.epilog is started immediately when the job-manager.prolog fails. The dws jobtap plugin could handle this case by starting its epilog action on entry to the CLEANUP state when there was no start event (using flux_jobtap_job_event_posted()).

He made a good point. 

Fixes #472.