### PR TITLE
dws: external rabbit allocations in `flux rabbitmapping`

### DIFF
--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -116,6 +116,11 @@ def main():
         action="store_false",
         help="Do not sort keys in output JSON document",
     )
+    parser.add_argument(
+        "--ignore-external-allocations",
+        action="store_true",
+        help="Ignore external (non-Flux) allocations from Servers objects",
+    )
     args = parser.parse_args()
     k8s_api = cleanup.get_k8s_api(args.kubeconfig)
     crd.determine_api_versions(flux.Flux(), k8s_api)
@@ -134,7 +139,8 @@ def main():
         if rabbit_mapping["rabbits"][nnf_name].get("capacity") is None:
             rabbit_mapping["rabbits"][nnf_name]["capacity"] = max_capacity
     # reduce capacity by external allocations from Servers objects
-    reduce_capacity_by_servers(k8s_api, rabbit_mapping)
+    if not args.ignore_external_allocations:
+        reduce_capacity_by_servers(k8s_api, rabbit_mapping)
     json.dump(rabbit_mapping, sys.stdout, indent=args.indent, sort_keys=args.nosort)
 
 

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -11,6 +11,45 @@ from flux.hostlist import Hostlist
 from flux_k8s import crd, cleanup
 
 
+def initialize_from_systemconfig(sysconfig):
+    """Initialize the rabbitmapping dict with locality information.
+
+    Populate as much data as possible using the SystemConfiguration, since
+    it is complete and static, while the Storage resources can come and go.
+    """
+    rabbit_mapping = {"computes": {}, "rabbits": {}}
+    for nnf in sysconfig["spec"]["storageNodes"]:
+        hlist = Hostlist()
+        nnf_name = nnf["name"]
+        for compute in nnf.get("computesAccess", []):
+            hlist.append(compute["name"])
+            rabbit_mapping["computes"][compute["name"]] = nnf_name
+        rabbit_mapping["rabbits"][nnf_name] = {}
+        rabbit_mapping["rabbits"][nnf_name]["hostlist"] = hlist.uniq().encode()
+    return rabbit_mapping
+
+
+def populate_from_storages(storages, rabbit_mapping):
+    """Populate the rabbit_mapping dict using data from Storage resources."""
+    max_capacity = 0
+    for nnf in storages["items"]:
+        nnf_name = nnf["metadata"]["name"]
+        for compute in nnf["status"]["access"].get("computes", []):
+            compute_name = compute["name"]
+            if rabbit_mapping["computes"].get(compute_name) != nnf_name:
+                raise RuntimeError(
+                    f"Mismatch: rabbit {nnf_name} claims to be "
+                    f"connected to {compute_name} but systemconfiguration gives "
+                    f"{rabbit_mapping['computes'].get(compute_name)}"
+                )
+            capacity = nnf.get("status", {}).get("capacity", 0)
+            max_capacity = max(capacity, max_capacity)
+            if capacity == 0:
+                capacity = max_capacity
+            rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
+    return max_capacity
+
+
 def main():
     """Create a JSON file mapping compute nodes <-> rabbits.
 
@@ -43,42 +82,17 @@ def main():
         help="Do not sort keys in output JSON document",
     )
     args = parser.parse_args()
-    rabbit_mapping = {"computes": {}, "rabbits": {}}
     k8s_api = cleanup.get_k8s_api(args.kubeconfig)
     crd.determine_api_versions(flux.Flux(), k8s_api)
-    # populate as much data as possible using the SystemConfiguration, since
-    # it is complete and static, while the Storage resources can come and go
     sysconfig = k8s_api.get_namespaced_custom_object(
         *crd.SYSTEMCONFIGURATION_CRD, "default"
     )
-    for nnf in sysconfig["spec"]["storageNodes"]:
-        hlist = Hostlist()
-        nnf_name = nnf["name"]
-        for compute in nnf.get("computesAccess", []):
-            hlist.append(compute["name"])
-            rabbit_mapping["computes"][compute["name"]] = nnf_name
-        rabbit_mapping["rabbits"][nnf_name] = {}
-        rabbit_mapping["rabbits"][nnf_name]["hostlist"] = hlist.uniq().encode()
+    rabbit_mapping = initialize_from_systemconfig(sysconfig)
     # fetch storages to fill in capacity field
     storages = k8s_api.list_cluster_custom_object(
         crd.RABBIT_CRD.group, crd.RABBIT_CRD.version, crd.RABBIT_CRD.plural
     )
-    max_capacity = 0
-    for nnf in storages["items"]:
-        nnf_name = nnf["metadata"]["name"]
-        for compute in nnf["status"]["access"].get("computes", []):
-            compute_name = compute["name"]
-            if rabbit_mapping["computes"].get(compute_name) != nnf_name:
-                raise RuntimeError(
-                    f"Mismatch: rabbit {nnf_name} claims to be "
-                    f"connected to {compute_name} but systemconfiguration gives "
-                    f"{rabbit_mapping['computes'].get(compute_name)}"
-                )
-            capacity = nnf.get("status", {}).get("capacity", 0)
-            max_capacity = max(capacity, max_capacity)
-            if capacity == 0:
-                capacity = max_capacity
-            rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
+    max_capacity = populate_from_storages(storages, rabbit_mapping)
     # go back through sysconfig, make sure capacity is there for all resources
     for nnf in sysconfig["spec"]["storageNodes"]:
         nnf_name = nnf["name"]

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -8,7 +8,7 @@ import json
 
 import flux
 from flux.hostlist import Hostlist
-from flux_k8s import crd, cleanup
+from flux_k8s import crd, cleanup, workflow
 
 
 def initialize_from_systemconfig(sysconfig):
@@ -48,6 +48,41 @@ def populate_from_storages(storages, rabbit_mapping):
                 capacity = max_capacity
             rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
     return max_capacity
+
+
+def reduce_capacity_by_servers(k8s_api, rabbit_mapping):
+    """Reduce rabbit capacity by allocations in Servers custom objects.
+
+    Fetches all Servers objects across all namespaces and sums up the
+    allocated capacity per rabbit, then reduces each rabbit's capacity
+    accordingly. Skips Servers resources managed by Flux.
+    """
+    servers = k8s_api.list_cluster_custom_object(
+        crd.SERVER_CRD.group, crd.SERVER_CRD.version, crd.SERVER_CRD.plural
+    )
+
+    # Track allocated capacity per rabbit
+    allocated = {}
+    for server in servers["items"]:
+        server_name = server["metadata"]["name"]
+        # Skip Servers resources managed by Flux
+        if workflow.WorkflowInfo.is_recognized(server_name):
+            continue
+        for alloc_set in server.get("spec", {}).get("allocationSets", []):
+            allocation_size = alloc_set.get("allocationSize", 0)
+            for storage in alloc_set.get("storage", []):
+                rabbit_name = storage["name"]
+                alloc_count = storage.get("allocationCount", 1)
+                total_alloc = allocation_size * alloc_count
+                allocated[rabbit_name] = allocated.get(rabbit_name, 0) + total_alloc
+
+    # Reduce each rabbit's capacity by its allocated amount
+    for rabbit_name, alloc_amount in allocated.items():
+        if rabbit_name in rabbit_mapping["rabbits"]:
+            current_capacity = rabbit_mapping["rabbits"][rabbit_name].get("capacity", 0)
+            rabbit_mapping["rabbits"][rabbit_name]["capacity"] = max(
+                0, current_capacity - alloc_amount
+            )
 
 
 def main():
@@ -98,6 +133,8 @@ def main():
         nnf_name = nnf["name"]
         if rabbit_mapping["rabbits"][nnf_name].get("capacity") is None:
             rabbit_mapping["rabbits"][nnf_name]["capacity"] = max_capacity
+    # reduce capacity by external allocations from Servers objects
+    reduce_capacity_by_servers(k8s_api, rabbit_mapping)
     json.dump(rabbit_mapping, sys.stdout, indent=args.indent, sort_keys=args.nosort)
 
 

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -45,6 +45,7 @@ def main():
     args = parser.parse_args()
     rabbit_mapping = {"computes": {}, "rabbits": {}}
     k8s_api = cleanup.get_k8s_api(args.kubeconfig)
+    crd.determine_api_versions(flux.Flux(), k8s_api)
     # populate as much data as possible using the SystemConfiguration, since
     # it is complete and static, while the Storage resources can come and go
     sysconfig = k8s_api.get_namespaced_custom_object(

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -31,6 +31,7 @@ TESTSCRIPTS = \
 	t2000-dws2jgf.t \
 	t2001-getrabbit.t \
 	t2002-dws2jgf2.t \
+	t2003-rabbitmapping.t \
 	t3000-slingshot-jobtap.t \
 	t3001-slingshot-shell.t \
 	t3002-slingshot-cmd.t \

--- a/t/data/rabbitmapping/rabbits-basic.json
+++ b/t/data/rabbitmapping/rabbits-basic.json
@@ -1,0 +1,18 @@
+{
+  "computes": {
+    "compute-01": "kind-worker2",
+    "compute-02": "kind-worker2",
+    "compute-03": "kind-worker2",
+    "compute-04": "kind-worker3"
+  },
+  "rabbits": {
+    "kind-worker2": {
+      "capacity": 39582418599936,
+      "hostlist": "compute-[01-03]"
+    },
+    "kind-worker3": {
+      "capacity": 39582418599936,
+      "hostlist": "compute-04"
+    }
+  }
+}

--- a/t/t2003-rabbitmapping.t
+++ b/t/t2003-rabbitmapping.t
@@ -1,0 +1,167 @@
+#!/bin/sh
+
+test_description='Test rabbitmapping command'
+
+. $(dirname $0)/sharness.sh
+
+FLUX_SIZE=1
+
+test_under_flux ${FLUX_SIZE} job -Slog-stderr-level=1
+
+CMD=${FLUX_SOURCE_DIR}/src/cmd/flux-rabbitmapping.py
+DATADIR=${SHARNESS_TEST_SRCDIR}/data/rabbitmapping
+
+export FLUX_PYCLI_LOGLEVEL=10
+# Have to set so kubernetes can automatically detect the ~/.kube/config
+export KUBECONFIG=${REAL_HOME}/.kube/config
+
+if test_have_prereq NO_DWS_K8S; then
+    skip_all='skipping rabbitmapping tests due to no DWS K8s'
+    test_done
+fi
+
+test_expect_success 'smoke test to ensure the storage resources are expected' '
+	test $(kubectl get storages | wc -l) -eq 3 &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes | length == 3" &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[0].name == \"compute-01\"" &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[1].name == \"compute-02\"" &&
+	kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[2].name == \"compute-03\"" &&
+	kubectl get storages kind-worker3 -ojson | jq -e ".status.access.computes | length == 1" &&
+	kubectl get storages kind-worker3 -ojson | jq -e ".status.access.computes[0].name == \"compute-04\""
+'
+
+test_expect_success 'flux-rabbitmapping outputs expected mapping' '
+	flux python ${CMD} -i2 > rabbits-basic.json &&
+	# add a newline to make the files the same
+	echo >> rabbits-basic.json &&
+	test_cmp ${DATADIR}/rabbits-basic.json rabbits-basic.json
+'
+
+test_expect_success 'flux-rabbitmapping works with compact output' '
+	flux python ${CMD} > rabbits-compact.json &&
+	test $(jq ".computes | length" rabbits-compact.json) -eq 4 &&
+	test $(jq ".rabbits | length" rabbits-compact.json) -eq 2 &&
+	test $(jq -r ".computes[\"compute-01\"]" rabbits-compact.json) = "kind-worker2" &&
+	test $(jq -r ".computes[\"compute-04\"]" rabbits-compact.json) = "kind-worker3"
+'
+
+test_expect_success 'flux-rabbitmapping generates capacity field' '
+	flux python ${CMD} -i2 > rabbits-capacity.json &&
+	jq -e ".rabbits[\"kind-worker2\"].capacity" rabbits-capacity.json &&
+	jq -e ".rabbits[\"kind-worker3\"].capacity" rabbits-capacity.json
+'
+
+test_expect_success 'flux-rabbitmapping generates hostlist field' '
+	flux python ${CMD} -i2 > rabbits-hostlist.json &&
+	test $(jq -r ".rabbits[\"kind-worker2\"].hostlist" rabbits-hostlist.json) = "compute-[01-03]" &&
+	test $(jq -r ".rabbits[\"kind-worker3\"].hostlist" rabbits-hostlist.json) = "compute-04"
+'
+
+test_expect_success 'flux-rabbitmapping respects --nosort flag' '
+	flux python ${CMD} --nosort > rabbits-nosort.json &&
+	jq -e ".computes" rabbits-nosort.json &&
+	jq -e ".rabbits" rabbits-nosort.json
+'
+
+test_expect_success 'create external Servers allocation for testing' '
+	cat > systemstorage.yaml <<-EOF &&
+apiVersion: nnf.cray.hpe.com/v1alpha11
+kind: NnfSystemStorage
+metadata:
+  name: example
+  namespace: default
+spec:
+  excludeDisabledRabbits: true
+  type: "xfs"
+  capacity: 5000000000
+  computesTarget: "all"
+  makeClientMounts: false
+  ignoreOfflineComputes: true
+  shared: false
+  storageProfile:
+    name: default
+    namespace: nnf-system
+    kind: NnfStorageProfile
+EOF
+	kubectl apply -f systemstorage.yaml
+'
+
+test_expect_success 'flux-rabbitmapping reduces capacity by external allocations' '
+	flux python ${CMD} -i2 > rabbits-reduced.json &&
+	orig_capacity=$(jq ".rabbits[\"kind-worker2\"].capacity" ${DATADIR}/rabbits-basic.json) &&
+	new_capacity=$(jq ".rabbits[\"kind-worker2\"].capacity" rabbits-reduced.json) &&
+	test $new_capacity -lt $orig_capacity
+'
+
+test_expect_success 'flux-rabbitmapping --ignore-external-allocations shows full capacity' '
+	flux python ${CMD} --ignore-external-allocations -i2 > rabbits-ignored.json &&
+	# add a newline to make the files the same
+	echo >> rabbits-ignored.json &&
+	test_cmp ${DATADIR}/rabbits-basic.json rabbits-ignored.json
+'
+
+test_expect_success 'delete example systemstorage' '
+	kubectl delete nnfsystemstorage example
+'
+
+test_expect_success 'flux-rabbitmapping ignores Flux-managed Servers' '
+	cat > systemstorage_namedflux.yaml <<-EOF &&
+apiVersion: nnf.cray.hpe.com/v1alpha11
+kind: NnfSystemStorage
+metadata:
+  name: fluxjob-example
+  namespace: default
+spec:
+  excludeDisabledRabbits: true
+  type: "xfs"
+  capacity: 5000000000
+  computesTarget: "all"
+  makeClientMounts: false
+  ignoreOfflineComputes: true
+  shared: false
+  storageProfile:
+    name: default
+    namespace: nnf-system
+    kind: NnfStorageProfile
+EOF
+	kubectl apply -f systemstorage_namedflux.yaml &&
+	flux python ${CMD} -i2 > rabbits-flux-managed.json &&
+	echo >> rabbits-flux-managed.json &&
+	test_cmp ${DATADIR}/rabbits-basic.json rabbits-flux-managed.json
+'
+
+test_expect_success 'delete example fluxjob systemstorage' '
+	kubectl delete nnfsystemstorage fluxjob-example
+'
+
+test_expect_success 'flux-rabbitmapping capacity never goes negative' '
+	cat > huge_systemstorage.yaml <<-EOF &&
+apiVersion: nnf.cray.hpe.com/v1alpha11
+kind: NnfSystemStorage
+metadata:
+  name: example
+  namespace: default
+spec:
+  excludeDisabledRabbits: true
+  type: "xfs"
+  capacity: 50000000000000
+  computesTarget: "all"
+  makeClientMounts: false
+  ignoreOfflineComputes: true
+  shared: false
+  storageProfile:
+    name: default
+    namespace: nnf-system
+    kind: NnfStorageProfile
+EOF
+	kubectl apply -f huge_systemstorage.yaml &&
+	flux python ${CMD} -i2 > rabbits-huge-alloc.json &&
+	capacity=$(jq ".rabbits[\"kind-worker2\"].capacity" rabbits-huge-alloc.json) &&
+	test $capacity -eq 0
+'
+
+test_expect_success 'cleanup external Servers allocations' '
+	kubectl delete nnfsystemstorage example
+'
+
+test_done


### PR DESCRIPTION
Mitigates #473 by reducing rabbits' capacity in config. This is not the full solution however, because ideally it would be more dynamic, and Fluxion would be able to update capacity as new allocations are made on a live system.