### PR TITLE
Rabbit frobnicator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,9 @@ AC_SUBST(fluxrc3dir)
 AS_VAR_SET(fluxk8spydir, $pyexecdir/flux_k8s)
 AC_SUBST(fluxk8spydir)
 
+AS_VAR_SET(fluxfrobnpluginspydir, $pyexecdir/flux/job/frobnicator/plugins)
+AC_SUBST(fluxfrobnpluginspydir)
+
 # Target of PYTHONPATH set by flux(1) cmddriver, so flux(1)
 # doesn't inadvertently insert system python paths (or any
 # other python path for that matter) first in PYTHONPATH.
@@ -222,6 +225,7 @@ AC_CONFIG_FILES([Makefile
   src/modules/Makefile
   src/python/Makefile
   src/python/flux_k8s/Makefile
+  src/python/flux/job/frobnicator/plugins/Makefile
   doc/Makefile
   doc/test/Makefile
   etc/Makefile

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,5 +1,7 @@
 .NOTPARALLEL:
 
-SUBDIRS = flux_k8s
+SUBDIRS = \
+	flux_k8s \
+	flux/job/frobnicator/plugins
 
 check-local: all

--- a/src/python/flux/job/frobnicator/plugins/Makefile.am
+++ b/src/python/flux/job/frobnicator/plugins/Makefile.am
@@ -1,0 +1,6 @@
+nobase_fluxfrobnpluginspy_PYTHON = \
+	rabbit.py
+
+clean-local:
+	-rm -f *.pyc *.pyo
+	-rm -rf __pycache__

--- a/src/python/flux/job/frobnicator/plugins/rabbit.py
+++ b/src/python/flux/job/frobnicator/plugins/rabbit.py
@@ -1,0 +1,54 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""Add rabbit property constraint to jobspec with DW directives.
+
+For jobs with both a 'dw' attribute and 'allow_rabbits' set to true,
+this plugin adds a top-level OR constraint that combines any existing
+constraints with the 'rabbit' property. This allows jobs to match
+either their existing constraints or nodes with the 'rabbit' property.
+
+This plugin is meant for systems where rabbit nodes have the `rabbit`
+property and are not configured for any queue.
+"""
+
+from flux.job.frobnicator import FrobnicatorPlugin
+
+
+class Frobnicator(FrobnicatorPlugin):
+    """Frobnicator plugin to add rabbit property constraints for DW jobs"""
+
+    def frob(self, jobspec, *_args, **_kwargs):
+        """Add OR constraint with rabbit property if job uses DW and allows rabbits
+
+        Args:
+            jobspec: The jobspec to modify
+
+        """
+        # Check if job has DW directive and if allow_rabbits is set
+        if "dw" not in jobspec.attributes.get(
+            "system", {}
+        ) or not jobspec.attributes.get("system", {}).get("allow_rabbits", False):
+            return
+        # both conditions are met, add OR constraint to existing constraints (if any)
+        try:
+            existing_constraint = jobspec.attributes["system"]["constraints"]
+        except KeyError as key_err:
+            # No existing constraints - this shouldn't happen because the constraints
+            # frobnicator should have added the queue property
+            raise RuntimeError(
+                "Misconfiguration: job must have constraints set. "
+                "Is the constraints frobnicator plugin loaded?"
+            ) from key_err
+        # create a new OR combining existing and rabbit constraints
+        jobspec.setattr(
+            "system.constraints",
+            {"or": [existing_constraint, {"properties": ["rabbit"]}]},
+        )

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -38,7 +38,8 @@ TESTSCRIPTS = \
 	python/t0001-directive-breakdown.py \
 	python/t0002-storage.py \
 	python/t0003-coral2-dws.py \
-	python/t0004-crd.py
+	python/t0004-crd.py \
+	python/t0005-rabbit-frobnicator.py
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/python/t0005-rabbit-frobnicator.py
+++ b/t/python/t0005-rabbit-frobnicator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+from flux.job import JobspecV1
+from pycotap import TAPTestRunner
+
+# Dynamically load rabbit.py and inject it into flux.job.frobnicator.plugins
+rabbit_path = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "python"
+    / "flux"
+    / "job"
+    / "frobnicator"
+    / "plugins"
+    / "rabbit.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "flux.job.frobnicator.plugins.rabbit", rabbit_path
+)
+rabbit_module = importlib.util.module_from_spec(spec)
+sys.modules["flux.job.frobnicator.plugins.rabbit"] = rabbit_module
+spec.loader.exec_module(rabbit_module)
+
+from flux.job.frobnicator.plugins.rabbit import Frobnicator  # noqa: E402
+
+
+class TestRabbitsFrobnicator(unittest.TestCase):
+    """Test the rabbits frobnicator plugin"""
+
+    def setUp(self):
+        """Create a frobnicator instance for each test"""
+        self.frob = Frobnicator(parser=None)
+        self.frob.configure(None, {})
+
+    def test_no_dw_no_change(self):
+        """Test that jobspec without DW is not modified"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.allow_rabbits", True)
+        original_constraints = jobspec.attributes.get("system", {}).get("constraints")
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should not have added constraints
+        new_constraints = jobspec.attributes.get("system", {}).get("constraints")
+        self.assertEqual(original_constraints, new_constraints)
+
+    def test_no_allow_rabbits_no_change(self):
+        """Test that jobspec with DW but no allow_rabbits is not modified"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should not have added constraints
+        constraints = jobspec.attributes.get("system", {}).get("constraints")
+        self.assertIsNone(constraints)
+
+    def test_allow_rabbits_false_no_change(self):
+        """Test that jobspec with DW but allow_rabbits=False is not modified"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+        jobspec.setattr("system.allow_rabbits", False)
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should not have added constraints
+        constraints = jobspec.attributes.get("system", {}).get("constraints")
+        self.assertIsNone(constraints)
+
+    def test_dw_and_allow_rabbits_no_change(self):
+        """Test that DW + allow_rabbits adds rabbit property constraint"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+        jobspec.setattr("system.allow_rabbits", True)
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"Misconfiguration:.*constraints frobnicator"
+        ):
+            self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+    def test_adds_or_constraint_with_existing_constraints(self):
+        """Test that existing constraints are combined with OR"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+        jobspec.setattr("system.allow_rabbits", True)
+        jobspec.setattr("system.constraints", {"properties": ["foo"]})
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should have created OR of existing and rabbit constraints
+        constraints = jobspec.attributes["system"]["constraints"]
+        self.assertIn("or", constraints)
+        self.assertEqual(len(constraints["or"]), 2)
+        self.assertIn({"properties": ["foo"]}, constraints["or"])
+        self.assertIn({"properties": ["rabbit"]}, constraints["or"])
+
+    def test_wraps_existing_or_constraint(self):
+        """Test that rabbit constraint wraps existing OR in another OR"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+        jobspec.setattr("system.allow_rabbits", True)
+        jobspec.setattr(
+            "system.constraints",
+            {"or": [{"properties": ["foo"]}, {"properties": ["bar"]}]},
+        )
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should have wrapped existing OR with rabbit in a new OR
+        constraints = jobspec.attributes["system"]["constraints"]
+        self.assertIn("or", constraints)
+        self.assertEqual(len(constraints["or"]), 2)
+        self.assertIn(
+            {"or": [{"properties": ["foo"]}, {"properties": ["bar"]}]},
+            constraints["or"],
+        )
+        self.assertIn({"properties": ["rabbit"]}, constraints["or"])
+
+    def test_works_with_and_constraint(self):
+        """Test that AND constraints are properly wrapped in OR"""
+        jobspec = JobspecV1.from_command(["hostname"])
+        jobspec.setattr("system.dw", "jobdw capacity=1GiB type=scratch")
+        jobspec.setattr("system.allow_rabbits", True)
+        jobspec.setattr(
+            "system.constraints",
+            {"and": [{"properties": ["foo"]}, {"properties": ["bar"]}]},
+        )
+
+        self.frob.frob(jobspec, user=1000, urgency=16, flags=0)
+
+        # Should have created OR with existing AND and rabbit
+        constraints = jobspec.attributes["system"]["constraints"]
+        self.assertIn("or", constraints)
+        self.assertEqual(len(constraints["or"]), 2)
+        self.assertIn(
+            {"and": [{"properties": ["foo"]}, {"properties": ["bar"]}]},
+            constraints["or"],
+        )
+        self.assertIn({"properties": ["rabbit"]}, constraints["or"])
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Problem: Jobs with DW directives need to be able to run on rabbit
nodes that have the 'rabbit' property but are not configured for any
queue.

Add a frobnicator plugin that extends jobspecs with DW directives and
'allow_rabbits=true' attribute to include an OR constraint combining
existing constraints with the 'rabbit' property. This allows jobs to
match either their queue's compute nodes or any rabbit node.

The plugin creates a top-level OR constraint that wraps any existing
constraints from the constraints frobnicator with a rabbit property
constraint, enabling flexible scheduling across both resource types.