### PR TITLE
`flux rabbitmapping`: do not double-count allocations

### DIFF
--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -42,7 +42,12 @@ def populate_from_storages(storages, rabbit_mapping):
                     f"connected to {compute_name} but systemconfiguration gives "
                     f"{rabbit_mapping['computes'].get(compute_name)}"
                 )
-        capacity = nnf.get("status", {}).get("capacity", 0)
+        # status.capacity is free (not total) bytes; sum the per-device
+        # capacities to get the rabbit's total raw capacity instead.
+        capacity = sum(
+            device.get("capacity", 0)
+            for device in nnf.get("status", {}).get("devices", [])
+        )
         max_capacity = max(capacity, max_capacity)
         if capacity == 0:
             capacity = max_capacity

--- a/src/cmd/flux-rabbitmapping.py
+++ b/src/cmd/flux-rabbitmapping.py
@@ -42,11 +42,11 @@ def populate_from_storages(storages, rabbit_mapping):
                     f"connected to {compute_name} but systemconfiguration gives "
                     f"{rabbit_mapping['computes'].get(compute_name)}"
                 )
-            capacity = nnf.get("status", {}).get("capacity", 0)
-            max_capacity = max(capacity, max_capacity)
-            if capacity == 0:
-                capacity = max_capacity
-            rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
+        capacity = nnf.get("status", {}).get("capacity", 0)
+        max_capacity = max(capacity, max_capacity)
+        if capacity == 0:
+            capacity = max_capacity
+        rabbit_mapping["rabbits"][nnf_name]["capacity"] = capacity
     return max_capacity
 
 


### PR DESCRIPTION
Problem: populate_from_storages set each rabbit's capacity from Storage
status.capacity, which is free (not total) bytes. Subtracting external
Servers allocations from a free-space figure double-counts them; on
tuolumne209 this reported ~21.69 TiB free instead of ~24.82 TiB.
    
Sum status.devices[].capacity to get the rabbit's total raw capacity, so
that reduce_capacity_by_servers subtracts external allocations from the
true total rather than from an already-net free figure.

Fixes #496.