### PR TITLE
docs: document the `--coral2-rabbit-cores` option

### DIFF
--- a/doc/guide/rabbit.rst
+++ b/doc/guide/rabbit.rst
@@ -274,3 +274,19 @@ allocation of rabbits, especially for node-local file systems like XFS.
 
 The flag is only available on systems with the ``flux-coral2`` package installed.
 On any such system, run ``flux alloc --help=coral2-chassis`` for documentation.
+
+Rabbit Cores
+~~~~~~~~~~~~
+
+The ``--coral2-rabbit-cores`` flag to :core:man1:`flux-batch`, :core:man1:`flux-alloc`,
+:core:man1:`flux-run`, and :core:man1:`flux-submit` is an **experimental** option
+for allocating compute cores on the rabbits themselves, in addition to the compute
+nodes. It takes a positive integer, the number of cores to allocate on each rabbit
+associated with the job.
+
+Because rabbits are allocated per chassis, ``--coral2-rabbit-cores`` requires that
+the ``--coral2-chassis`` flag also be set; the requested cores are reserved on the
+rabbit in each allocated chassis.
+
+The flag is only available on systems with the ``flux-coral2`` package installed.
+On any such system, run ``flux alloc --help=coral2-rabbit-cores`` for documentation.

--- a/etc/cli/plugins/chassis.py
+++ b/etc/cli/plugins/chassis.py
@@ -37,6 +37,13 @@ class Coral2ChassisPlugin(CLIPlugin):
     be initialized with information about chassis layout. Otherwise an exception
     will be raised with a message about "chassis" not being a known resource type.
 
+    This plugin also provides an EXPERIMENTAL ``--coral2-rabbit-cores`` flag, which
+    takes a positive integer and allocates that many compute cores on each rabbit
+    associated with the job, in addition to the compute nodes. Because rabbits are
+    allocated per chassis, ``--coral2-rabbit-cores`` requires that
+    ``--coral2-chassis`` also be set; the requested cores are reserved on the rabbit
+    in each allocated chassis.
+
     EXAMPLES
     --------
 
@@ -47,6 +54,10 @@ class Coral2ChassisPlugin(CLIPlugin):
     Request 200 nodes split evenly across 20 chassis:
 
     ``flux alloc -N200 --coral2-chassis=20 -q myqueue /bin/true``
+
+    Request 32 nodes across 2 chassis, with 4 cores on each chassis's rabbit:
+
+    ``flux alloc -N32 --coral2-chassis=2 --coral2-rabbit-cores=4 -q myqueue /bin/true``
     """
 
     def __init__(self, prog, prefix="coral2"):


### PR DESCRIPTION
Problem: the experimental --coral2-rabbit-cores option is undocumented
in the rabbit guide.

Add a "Rabbit Cores" section to the Node Distribution part of the rabbit
guide describing the flag and its dependency on --coral2-chassis.