### PR TITLE
flux_k8s: compare `storage` resourceVersions

### DIFF
--- a/src/python/flux_k8s/storage.py
+++ b/src/python/flux_k8s/storage.py
@@ -267,7 +267,12 @@ def init_rabbits(k8s_api, handle, watchers, drain_queues):
     manager = RabbitManager(handle, allowlist)
     resource_version = 0
     for rabbit in api_response["items"]:
-        resource_version = rabbit["metadata"]["resourceVersion"]
+        try:  # resourceVersion should be an integer we can compare; if not, ignore
+            resource_version = max(
+                resource_version, int(rabbit["metadata"]["resourceVersion"])
+            )
+        except (TypeError, ValueError):
+            pass
         manager.rabbit_state_change_cb(
             {"object": rabbit},
         )

--- a/t/t1003-dws-nnf-watch.t
+++ b/t/t1003-dws-nnf-watch.t
@@ -24,7 +24,10 @@ fi
 
 test_expect_success 'smoke test to ensure storages are live' '
     kubectl get storages kind-worker2 -ojson | jq -e ".spec.mode == \"Live\"" &&
-    kubectl get storages kind-worker3 -ojson | jq -e ".spec.mode == \"Live\""
+    kubectl get storages kind-worker2 -ojson | jq -e ".status.status == \"Ready\"" &&
+    kubectl get storages kind-worker3 -ojson | jq -e ".spec.mode == \"Live\"" &&
+    kubectl get storages kind-worker3 -ojson | jq -e ".status.status == \"Ready\"" &&
+    kubectl get storages kind-worker2 -ojson | jq -e ".status.access.computes[0].status == \"Ready\""
 '
 
 test_expect_success 'job-manager: load alloc-bypass plugin' '


### PR DESCRIPTION
Problem: the `flux_k8s.storage` module starts watching `storage` resources from the last `resourceVersion` seen in the watch. However, this often leads to undesirable behavior when testing locally, because the last `resourceVersion` seen is often old, and since that version, the `storage` resource may have been modified such that a rabbit-to-compute-node PCIe link is marked as down. This can happen if, for example, the tests (specifically t1003) are run in quick succession. Since nodes drained on account of PCIe links being down are not undrained if the link comes back up, the fact that the watch will eventually show the link as up does not reverse the state. So in addition to causing unnecessary churn of RPCs, the current logic can cause incorrect behavior.

PR #470 noted that kubernetes `resourceVersion` fields can be cast to an integer and compared. After fetching all `storage` resources, start the watch from the largest `resourceVersion`.