### PR TITLE
NEWS.md: add release notes for v0.37.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+flux-coral2 0.37.0 - 2026-09-04
+-------------------------------
+
+### Fixes
+ * rabbitmapping: do not double-count allocations (#497)
+ * rabbitmapping: capacity check (#501)
+ * flux_k8s: compare `storage` resourceVersions (#500)
+
+### Build/Testsuite/Documentation
+ * docs: document the `--coral2-rabbit-cores` option (#498)
+
+### Cleanup
+ * dws: remove `--disable-fluxion` logic (#494)
+
+
 flux-coral2 0.36.0 - 2026-07-07
 -------------------------------
 


### PR DESCRIPTION
Problem: there are no release notes for v0.37.0.

Add them.

TBD: whether #502 is included in this release. It would be great to include, but that PR depends on a Flux-sched PR (https://github.com/flux-framework/flux-sched/pull/1467)